### PR TITLE
fix(core) : #36 Update primary key to (id, block_hash)

### DIFF
--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/CursorEntity.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/CursorEntity.java
@@ -20,11 +20,11 @@ public class CursorEntity extends BaseEntity {
     private Long id;
 
     @Id
-    @Column(name = "slot")
-    private Long slot;
-
     @Column(name = "block_hash")
     private String blockHash;
+
+    @Column(name = "slot")
+    private Long slot;
 
     @Column(name = "block_number")
     private Long block;

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/CursorId.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/CursorId.java
@@ -13,6 +13,6 @@ import java.io.Serializable;
 public class CursorId implements Serializable {
     @Column(name = "id")
     private Long id;
-    @Column(name = "slot")
-    private Long slot;
+    @Column(name = "block_hash")
+    private String blockHash;
 }

--- a/components/core/src/main/resources/db/migration/h2/V0_000_1__init.sql
+++ b/components/core/src/main/resources/db/migration/h2/V0_000_1__init.sql
@@ -2,12 +2,12 @@ drop table if exists cursor_;
 create table cursor_
 (
     id          integer not null,
+    block_hash  varchar(255),
     slot        bigint,
     block_number bigint,
-    block_hash  varchar(255),
     create_datetime  timestamp,
     update_datetime  timestamp,
-    primary key (id, slot)
+    primary key (id, block_hash)
 );
 
 CREATE INDEX idx_cursor_id

--- a/components/core/src/main/resources/db/migration/mysql/V0_000_1__init.sql
+++ b/components/core/src/main/resources/db/migration/mysql/V0_000_1__init.sql
@@ -2,12 +2,12 @@ drop table if exists cursor_;
 create table cursor_
 (
     id          int not null,
+    block_hash  varchar(255),
     slot        bigint,
     block_number bigint,
-    block_hash  varchar(255),
     create_datetime  timestamp,
     update_datetime  timestamp,
-    primary key (id, slot)
+    primary key (id, block_hash)
 );
 
 CREATE INDEX idx_cursor_id

--- a/components/core/src/main/resources/db/migration/postgresql/V0_000_1__init.sql
+++ b/components/core/src/main/resources/db/migration/postgresql/V0_000_1__init.sql
@@ -2,12 +2,12 @@ drop table if exists cursor_;
 create table cursor_
 (
     id          integer not null,
+    block_hash  varchar(255),
     slot        bigint,
     block_number bigint,
-    block_hash  varchar(255),
     create_datetime  timestamp,
     update_datetime  timestamp,
-    primary key (id, slot)
+    primary key (id, block_hash)
 );
 
 CREATE INDEX idx_cursor_id


### PR DESCRIPTION
For mainnet, byron block number which is a derived value is not set correctly in cursor_ table.

For block 1 is set as 0, block 2 is set as 1

Reason:
The primary key for the cursor_table is id (event_publisher_id), slot. In the mainnet, both block 0 and block 1 have the same slot number, which is 0. As a result, block 0 is being overwritten by block 1.

Fix:
Change the primary key to (id, block_hash)

@matiwinnetou, Re-sync is required after this PR.