### PR TITLE
fix(block): Runtime db error and populate total output in block table…

### DIFF
--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/domain/Epoch.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/domain/Epoch.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.math.BigInteger;
 
 @Data
 @NoArgsConstructor
@@ -19,8 +19,8 @@ import java.util.Date;
 public class Epoch {
     private long number;
     private int blockCount;
-    private int transactionCount;
-    private long totalOutput;
+    private long transactionCount;
+    private BigInteger totalOutput;
     private long startTime;
     private long endTime;
     private long maxSlot;

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/processor/EpochProcessor.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/processor/EpochProcessor.java
@@ -1,10 +1,14 @@
 package com.bloxbean.cardano.yaci.store.blocks.processor;
 
 import com.bloxbean.cardano.yaci.store.blocks.service.EpochService;
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.TimeUnit;
 
@@ -19,5 +23,12 @@ public class EpochProcessor {
     public void scheduleEpochDataAggregation() {
         log.info("Start epoch data aggregation ....");
         epochService.aggregateData();
+    }
+
+    //TODO -- handle rollback event
+    @EventListener
+    @Transactional
+    public void handleRollbackEvent(@NotNull RollbackEvent rollbackEvent) {
+        log.info("Rollback -- {} block records. //TODO-- Need to handle for EpochProcessor");
     }
 }

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/service/EpochService.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/service/EpochService.java
@@ -7,7 +7,9 @@ import com.bloxbean.cardano.yaci.store.blocks.storage.api.BlockStorage;
 import com.bloxbean.cardano.yaci.store.blocks.storage.api.EpochStorage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,6 +27,7 @@ public class EpochService {
         return epochStorage.findEpochs(page, count);
     }
 
+    @Transactional
     public void aggregateData() {
         Optional<Block> recentBlock = blockStorage.findRecentBlock();
 
@@ -55,11 +58,14 @@ public class EpochService {
                     .endTime(blocks.get(blocks.size() - 1).getBlockTime())
                     .blockCount(blocks.size())
                     .maxSlot(blocks.get(blocks.size() - 1).getSlot())
+                    .totalOutput(BigInteger.ZERO)
                     .build();
             for (Block block : blocks) {
                 epoch.setTransactionCount(epoch.getTransactionCount() + block.getNoOfTxs());
-                epoch.setTotalOutput(epoch.getTotalOutput());
+                epoch.setTotalOutput(epoch.getTotalOutput().add(block.getTotalOutput()));
             }
+
+            epochStorage.save(epoch);
         }
     }
 }

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/EpochStorageImpl.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/EpochStorageImpl.java
@@ -32,13 +32,19 @@ public class EpochStorageImpl implements EpochStorage {
 
     @Override
     public void save(Epoch epoch) {
-        EpochEntity epochEntity = epochMapper.toEpochEntity(epoch);
-        epochRepository.save(epochEntity);
+        EpochEntity updatedEpochEntity = epochRepository.findById(epoch.getNumber())
+                .map(epochEntity -> {
+                    epochMapper.updateEntity(epoch, epochEntity);
+                    return epochEntity;
+                }).orElse(epochMapper.toEpochEntity(epoch));
+
+        epochRepository.save(updatedEpochEntity);
     }
 
     @Override
     public Optional<Epoch> findByNumber(int number) {
-        return epochRepository.findByNumber(number);
+        return epochRepository.findById((long)number)
+                .map(epochEntity -> epochMapper.toEpoch(epochEntity));
     }
 
     @Override

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/mapper/EpochMapper.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/mapper/EpochMapper.java
@@ -8,4 +8,15 @@ import org.mapstruct.Mapper;
 public abstract class EpochMapper {
     public abstract Epoch toEpoch(EpochEntity blockEntity);
     public abstract EpochEntity toEpochEntity(Epoch blockEntity);
+
+    public EpochEntity updateEntity(Epoch epoch, EpochEntity targetEntity) {
+        targetEntity.setTotalOutput(epoch.getTotalOutput());
+        targetEntity.setTransactionCount(epoch.getTransactionCount());
+        targetEntity.setBlockCount(epoch.getBlockCount());
+        targetEntity.setStartTime(epoch.getStartTime());
+        targetEntity.setEndTime(epoch.getEndTime());
+        targetEntity.setMaxSlot(epoch.getMaxSlot());
+
+        return targetEntity;
+    }
 }

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/model/EpochEntity.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/model/EpochEntity.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,10 +26,10 @@ public class EpochEntity {
     private int blockCount;
 
     @Column(name = "transaction_count")
-    private int transactionCount;
+    private long transactionCount;
 
     @Column(name = "total_output")
-    private long totalOutput;
+    private BigInteger totalOutput;
 
     @Column(name = "start_time")
     private long startTime;

--- a/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/repository/EpochRepository.java
+++ b/components/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/jpa/repository/EpochRepository.java
@@ -1,14 +1,13 @@
 package com.bloxbean.cardano.yaci.store.blocks.storage.impl.jpa.repository;
 
-import com.bloxbean.cardano.yaci.store.blocks.domain.Epoch;
 import com.bloxbean.cardano.yaci.store.blocks.storage.impl.jpa.model.EpochEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-public interface EpochRepository extends JpaRepository<EpochEntity, String> {
+@Repository
+public interface EpochRepository extends JpaRepository<EpochEntity, Long> {
 
     Optional<EpochEntity> findTopByOrderByNumberDesc();
-
-    Optional<Epoch> findByNumber(int number);
 }

--- a/components/stores/blocks/src/main/resources/db/migration/h2/V0_100_1__init.sql
+++ b/components/stores/blocks/src/main/resources/db/migration/h2/V0_100_1__init.sql
@@ -27,7 +27,7 @@ create table epoch
 (
     number bigint       not null primary key,
     block_count         int             null,
-    transaction_count   int             null,
+    transaction_count   bigint          null,
     total_output        bigint          null,
     start_time          bigint          null,
     end_time            bigint          null,

--- a/components/stores/blocks/src/main/resources/db/migration/mysql/V0_100_1__init.sql
+++ b/components/stores/blocks/src/main/resources/db/migration/mysql/V0_100_1__init.sql
@@ -27,7 +27,7 @@ create table epoch
 (
     number bigint       not null primary key,
     block_count         int             null,
-    transaction_count   int             null,
+    transaction_count   bigint          null,
     total_output        bigint          null,
     start_time          bigint          null,
     end_time            bigint          null,

--- a/components/stores/blocks/src/main/resources/db/migration/postgresql/V0_100_1__init.sql
+++ b/components/stores/blocks/src/main/resources/db/migration/postgresql/V0_100_1__init.sql
@@ -27,7 +27,7 @@ create table epoch
 (
     number bigint       not null primary key,
     block_count         int             null,
-    transaction_count   int             null,
+    transaction_count   bigint          null,
     total_output        bigint          null,
     start_time          bigint          null,
     end_time            bigint          null,


### PR DESCRIPTION
This PR fixes 
- Runtime error while persisting new epoch specific data
- Total outputs in a block
- Data type change from int to bigInt for fields like total outputs

Known issues:
- Incorrect Epch no  for preprod network
- no of blocks in an epoch
https://github.com/bloxbean/yaci-store/issues/14

The above issues will be fixed in another PR.