### PR TITLE
fix: Add missing indexes on slot column to fix slow delete query duri…

### DIFF
--- a/stores/assets/src/main/resources/db/migration/h2/V0_700_2__indexes.sql
+++ b/stores/assets/src/main/resources/db/migration/h2/V0_700_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_assets_slot
+    ON assets(slot);

--- a/stores/assets/src/main/resources/db/migration/mysql/V0_700_2__indexes.sql
+++ b/stores/assets/src/main/resources/db/migration/mysql/V0_700_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_assets_slot
+    ON assets(slot);

--- a/stores/assets/src/main/resources/db/migration/postgresql/V0_700_2__indexes.sql
+++ b/stores/assets/src/main/resources/db/migration/postgresql/V0_700_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_assets_slot
+    ON assets(slot);

--- a/stores/metadata/src/main/resources/db/migration/h2/V0_600_2__indexes.sql
+++ b/stores/metadata/src/main/resources/db/migration/h2/V0_600_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_txn_metadata_slot
+    ON transaction_metadata(slot);

--- a/stores/metadata/src/main/resources/db/migration/mysql/V0_600_2__indexes.sql
+++ b/stores/metadata/src/main/resources/db/migration/mysql/V0_600_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_txn_metadata_slot
+    ON transaction_metadata(slot);

--- a/stores/metadata/src/main/resources/db/migration/postgresql/V0_600_2__indexes.sql
+++ b/stores/metadata/src/main/resources/db/migration/postgresql/V0_600_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_txn_metadata_slot
+    ON transaction_metadata(slot);

--- a/stores/script/src/main/resources/db/migration/h2/V0_400_2__indexes.sql
+++ b/stores/script/src/main/resources/db/migration/h2/V0_400_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_txn_scripts_slot
+    ON transaction_scripts (slot);

--- a/stores/script/src/main/resources/db/migration/mysql/V0_400_2__indexes.sql
+++ b/stores/script/src/main/resources/db/migration/mysql/V0_400_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_txn_scripts_slot
+    ON transaction_scripts (slot);

--- a/stores/script/src/main/resources/db/migration/postgresql/V0_400_2__indexes.sql
+++ b/stores/script/src/main/resources/db/migration/postgresql/V0_400_2__indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX if not exists idx_txn_scripts_slot
+    ON transaction_scripts (slot);


### PR DESCRIPTION
Rollback queries for few tables are very slow on mainnet due to missing index on "slot" column. This PR is adding missing indexes.
