### PR TITLE
feat: Enable cleanup of cursor table

### DIFF
--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreConfiguration.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreConfiguration.java
@@ -1,9 +1,11 @@
 package com.bloxbean.cardano.yaci.store.core;
 
+import com.bloxbean.cardano.yaci.store.core.service.CursorCleanupScheduler;
 import com.bloxbean.cardano.yaci.store.core.storage.api.CursorStorage;
 import com.bloxbean.cardano.yaci.store.core.storage.api.EraStorage;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -38,5 +40,14 @@ public class StoreConfiguration {
     @ConditionalOnMissingBean
     public EraStorage eraStorage(EraRepository eraRepository, EraMapper eraMapper) {
         return new EraStorageImpl(eraRepository, eraMapper);
+    }
+
+    @Bean
+    @ConditionalOnExpression("${store.cardano.cursor-no-of-blocks-to-keep:1} > 0")
+    public CursorCleanupScheduler cursorCleanupScheduler(CursorStorage cursorStorage, StoreProperties storeProperties) {
+        log.info("<<< Enable CursorCleanupScheduler >>>");
+        log.info("CursorCleanupScheduler will run every {} sec", storeProperties.getCursorCleanupInterval());
+        log.info("CursorCleanupScheduler will keep {} blocks in cursor", storeProperties.getCursorNoOfBlocksToKeep());
+        return new CursorCleanupScheduler(cursorStorage, storeProperties);
     }
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreProperties.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreProperties.java
@@ -39,7 +39,11 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
     private String byronGenesisFile;
     private String shelleyGenesisFile;
 
-    private int blockDiffToStartSyncProtocol = 3600;
+    private int blockDiffToStartSyncProtocol = 2000;
+
+    //Cursor table cleanup properties
+    private int cursorNoOfBlocksToKeep = 2160;
+    private int cursorCleanupInterval = 3600;
 
     //derived from protocol magic. No need to set
     private boolean mainnet;

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/CursorCleanupScheduler.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/CursorCleanupScheduler.java
@@ -1,0 +1,37 @@
+package com.bloxbean.cardano.yaci.store.core.service;
+
+import com.bloxbean.cardano.yaci.store.core.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.domain.Cursor;
+import com.bloxbean.cardano.yaci.store.core.storage.api.CursorStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CursorCleanupScheduler {
+    private final CursorStorage cursorStorage;
+    private final StoreProperties storeProperties;
+
+    @Transactional
+    @Scheduled(fixedRateString = "#{storeProperties.cursorCleanupInterval * 1000}", initialDelay = 30000)
+    public void scheduleCursorCleanup() {
+        log.info("Running cursor cleanup scheduler");
+        Optional<Cursor> cursor = cursorStorage.getCurrentCursor(storeProperties.getEventPublisherId());
+        log.info("Current cursor: {}", cursor);
+
+        if (!cursor.isPresent())
+            return;
+
+        //Block no to delete from
+        long fromBlock = cursor.get().getBlock() - storeProperties.getCursorNoOfBlocksToKeep();
+        if (fromBlock < 0)
+            return;
+
+        int blocks = cursorStorage.deleteCursorBefore(storeProperties.getEventPublisherId(), fromBlock);
+        log.info("Deleted {} cursors before block {}", blocks, fromBlock);
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/api/CursorStorage.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/api/CursorStorage.java
@@ -10,4 +10,6 @@ public interface CursorStorage {
     Optional<Cursor> getPreviousCursor(long eventPublisherId, long slot);
     Optional<Cursor> findByBlockHash(long eventPublisherId, String blockHash);
     int deleteBySlotGreaterThan(long eventPublisherId, long slot);
+
+    int deleteCursorBefore(long eventPublisherId, long blockNumber);
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
@@ -5,7 +5,6 @@ import com.bloxbean.cardano.yaci.store.core.storage.impl.model.CursorId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +16,7 @@ public interface CursorRepository extends JpaRepository<CursorEntity, CursorId> 
     Optional<CursorEntity> findByIdAndBlockHash(Long id, String blockHash);
 
     int deleteByIdAndSlotGreaterThan(Long id, Long slot);
+
+    //Required for history cleanup
+    int deleteByIdAndBlockLessThan(Long id, Long block);
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorStorageImpl.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorStorageImpl.java
@@ -53,6 +53,11 @@ public class CursorStorageImpl implements CursorStorage {
         return cursorRepository.deleteByIdAndSlotGreaterThan(eventPublisherId, slot);
     }
 
+    @Override
+    public int deleteCursorBefore(long eventPublisherId, long blockNumber) {
+        return cursorRepository.deleteByIdAndBlockLessThan(eventPublisherId, blockNumber);
+    }
+
     private static Cursor cursorEntityToCursor(CursorEntity cursorEntity) {
         return Cursor.builder()
                 .slot(cursorEntity.getSlot())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.2.1-beta2.2-SNAPSHOT"
+yaci = "com.bloxbean.cardano:yaci:0.2.1"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.5.0-beta2"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.5.0-beta2"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.5.0-beta2"

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -154,6 +154,8 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setShelleyGenesisFile(properties.getCardano().getShelleyGenesisFile());
 
         storeProperties.setBlockDiffToStartSyncProtocol(properties.getCardano().getBlockDiffToStartSyncProtocol());
+        storeProperties.setCursorNoOfBlocksToKeep(properties.getCardano().getCursorNoOfBlocksToKeep());
+        storeProperties.setCursorCleanupInterval(properties.getCardano().getCursorCleanupInterval());
         return storeProperties;
     }
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -43,6 +43,9 @@ public class YaciStoreProperties {
         private String shelleyGenesisFile;
 
         private int blockDiffToStartSyncProtocol = 2000;
+
+        private int cursorNoOfBlocksToKeep = 2160;
+        private int cursorCleanupInterval = 3600;
     }
 
     @Getter


### PR DESCRIPTION
- Added scheduler to delete old cursor records in cursor_ table

**Properties:**
```
store:
  cardano:
    cursor-cleanup-interval: <Interval In Sec>
    cursor-no-of-blocks-to-keep: <No of blocks to keep>
```

 **Default Value**
```
 store:
  cardano:
    cursor-cleanup-interval: 3600
    cursor-no-of-blocks-to-keep: 2160
```

**To disable cleanup scheduler**

Set no of blocks to keep to -1

```
 store:
  cardano:
    cursor-no-of-blocks-to-keep: -1
```    
    