### PR TITLE
chore: Upgrade to spring boot 3.2.2 and sql datatype fix for H2 & mysql

### DIFF
--- a/applications/admin/build.gradle
+++ b/applications/admin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 dependencies {

--- a/applications/aggregation-app/build.gradle
+++ b/applications/aggregation-app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 dependencies {
@@ -15,6 +15,6 @@ dependencies {
 
     implementation libs.spring.boot.admin.client
 
-    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
-    runtimeOnly 'org.postgresql:postgresql:42.5.0'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'org.postgresql:postgresql:42.7.1'
 }

--- a/applications/all/build.gradle
+++ b/applications/all/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 dependencies {
@@ -23,7 +23,8 @@ dependencies {
 
     implementation libs.spring.boot.admin.client
 
-    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
-    runtimeOnly 'org.postgresql:postgresql:42.6.0'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'org.postgresql:postgresql:42.7.1'
+
 }
 

--- a/applications/gateway/build.gradle
+++ b/applications/gateway/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 dependencies {

--- a/applications/utxo-indexer/build.gradle
+++ b/applications/utxo-indexer/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 dependencies {
@@ -15,7 +15,7 @@ dependencies {
 
     implementation libs.spring.boot.admin.client
 
-    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
-    runtimeOnly 'org.postgresql:postgresql:42.5.0'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'org.postgresql:postgresql:42.7.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'maven-publish'
     id 'signing'
-    id 'org.flywaydb.flyway' version '9.7.0'
-    id 'nu.studer.jooq' version '8.2'
+    id 'org.flywaydb.flyway' version '9.22.3'
+    id 'nu.studer.jooq' version '8.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
 
     id 'org.ajoberstar.grgit' version '5.2.0'
@@ -30,7 +30,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom("org.springframework.boot:spring-boot-dependencies:3.2.1")
+            mavenBom("org.springframework.boot:spring-boot-dependencies:3.2.2")
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.0"
         }
     }

--- a/docs/getting-started-as-library.md
+++ b/docs/getting-started-as-library.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to use Yaci Store as a library in your own a
 ## Prerequisites
 
 - Java 21
-- Spring Boot 3.2.x (Tested with Spring Boot 3.2.0, 3.2.1)
+- Spring Boot 3.2.x (Tested with Spring Boot 3.2.0, 3.2.1, 3.2.2)
 
 ## Create a Spring Boot application
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogm
 rocks-types="com.bloxbean:rocks-types:0.0.1-preview6"
 
 cbor = "co.nstant.in:cbor:0.9"
-hibernate-types = "io.hypersistence:hypersistence-utils-hibernate-63:3.7.0"
-codehaus-janino = "org.codehaus.janino:janino:3.1.8"
+hibernate-types = "io.hypersistence:hypersistence-utils-hibernate-63:3.7.1"
+codehaus-janino = "org.codehaus.janino:janino:3.1.11"
 guava = "com.google.guava:guava:33.0.0-jre"
 springdoc-openapi-starter-webmvc-ui = "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0"
 mapstruct="org.mapstruct:mapstruct:1.5.5.Final"

--- a/publish-common.gradle
+++ b/publish-common.gradle
@@ -83,6 +83,7 @@ if (jooq_modules.contains(name)) {
     }
 
     jooq {
+        version = '3.18.9'
         configurations {
             main {
                 generationTool {

--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/GovActionProposalEntity.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/GovActionProposalEntity.java
@@ -26,7 +26,7 @@ public class GovActionProposalEntity extends BlockAwareEntity {
     private String txHash;
 
     @Id
-    @Column(name = "index")
+    @Column(name = "idx")
     private long index;
 
     @Column(name = "slot")

--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/GovActionProposalId.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/GovActionProposalId.java
@@ -10,6 +10,6 @@ public class GovActionProposalId implements Serializable {
     @Column(name = "tx_hash")
     private String txHash;
 
-    @Column(name = "index")
+    @Column(name = "idx")
     private long index;
 }

--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/VotingProcedureEntity.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/storage/impl/model/VotingProcedureEntity.java
@@ -27,7 +27,7 @@ public class VotingProcedureEntity extends BlockAwareEntity {
     @Column(name = "tx_hash")
     private String txHash;
 
-    @Column(name = "index")
+    @Column(name = "idx")
     private long index;
 
     @Column(name = "slot")

--- a/stores/governance/src/main/resources/db/store/h2/V0_1100_1__init.sql
+++ b/stores/governance/src/main/resources/db/store/h2/V0_1100_1__init.sql
@@ -2,10 +2,10 @@ drop table if exists gov_action_proposal;
 create table gov_action_proposal
 (
     tx_hash         varchar(64) not null,
-    index           int         not null,
+    idx             int         not null,
     deposit         bigint,
     return_address  varchar(255),
-    anchor_url      varchar(256),
+    anchor_url      varchar,
     anchor_hash     varchar(64),
     type            varchar(50),
     details         json,
@@ -14,7 +14,7 @@ create table gov_action_proposal
     block           bigint,
     block_time      bigint,
     update_datetime timestamp,
-    primary key (tx_hash, index)
+    primary key (tx_hash, idx)
 );
 
 CREATE INDEX idx_gov_action_proposal_slot
@@ -34,7 +34,7 @@ create table voting_procedure
 (
     id                 uuid        not null,
     tx_hash            varchar(64) not null,
-    index              int         not null,
+    idx                int         not null,
     voter_type         varchar(50),
     voter_hash         varchar(56),
     gov_action_tx_hash varchar(64),
@@ -66,8 +66,8 @@ CREATE TABLE committee_registration
 (
     tx_hash         varchar(64) not null,
     cert_index      int         NOT NULL,
-    cold_key        varchar,
-    hot_key         varchar,
+    cold_key        varchar(56),
+    hot_key         varchar(56),
     cred_type       varchar(40),
     epoch           int,
     slot            bigint,
@@ -84,9 +84,9 @@ CREATE TABLE committee_deregistration
 (
     tx_hash         varchar(64) not null,
     cert_index      int         NOT NULL,
-    anchor_url      varchar(256),
+    anchor_url      varchar,
     anchor_hash     varchar(64),
-    cold_key        varchar     NOT NULL,
+    cold_key        varchar(56)     NOT NULL,
     cred_type       varchar(40),
     epoch           int,
     slot            bigint,

--- a/stores/governance/src/main/resources/db/store/mysql/V0_1100_1__init.sql
+++ b/stores/governance/src/main/resources/db/store/mysql/V0_1100_1__init.sql
@@ -2,10 +2,10 @@ drop table if exists gov_action_proposal;
 create table gov_action_proposal
 (
     tx_hash         varchar(64) not null,
-    index           int         not null,
+    idx             int         not null,
     deposit         bigint,
     return_address  varchar(255),
-    anchor_url      varchar(256),
+    anchor_url      longtext,
     anchor_hash     varchar(64),
     type            varchar(50),
     details         json,
@@ -14,7 +14,7 @@ create table gov_action_proposal
     block           bigint,
     block_time      bigint,
     update_datetime timestamp,
-    primary key (tx_hash, index)
+    primary key (tx_hash, idx)
 );
 
 CREATE INDEX idx_gov_action_proposal_slot
@@ -32,15 +32,15 @@ CREATE INDEX idx_gov_action_proposal_type
 drop table if exists voting_procedure;
 create table voting_procedure
 (
-    id                 uuid        not null,
+    id                 binary(16)  not null,
     tx_hash            varchar(64) not null,
-    index              int         not null,
+    idx                int         not null,
     voter_type         varchar(50),
     voter_hash         varchar(56),
     gov_action_tx_hash varchar(64),
     gov_action_index   int,
     vote               varchar(10),
-    anchor_url         varchar,
+    anchor_url         longtext,
     anchor_hash        varchar(64),
     epoch              int,
     slot               bigint,
@@ -66,8 +66,8 @@ CREATE TABLE committee_registration
 (
     tx_hash         varchar(64) not null,
     cert_index      int         NOT NULL,
-    cold_key        varchar,
-    hot_key         varchar,
+    cold_key        varchar(56),
+    hot_key         varchar(56),
     cred_type       varchar(40),
     epoch           int,
     slot            bigint,
@@ -84,9 +84,9 @@ CREATE TABLE committee_deregistration
 (
     tx_hash         varchar(64) not null,
     cert_index      int         NOT NULL,
-    anchor_url      varchar(256),
+    anchor_url      longtext,
     anchor_hash     varchar(64),
-    cold_key        varchar     NOT NULL,
+    cold_key        varchar(56)     NOT NULL,
     cred_type       varchar(40),
     epoch           int,
     slot            bigint,
@@ -133,7 +133,7 @@ CREATE TABLE drep_registration
     deposit         bigint NULL,
     drep_hash       varchar(56),
     drep_id         varchar(255),
-    anchor_url      varchar,
+    anchor_url      longtext,
     anchor_hash     varchar(64),
     cred_type       varchar(40),
     epoch           int,

--- a/stores/governance/src/main/resources/db/store/postgresql/V0_1100_1__init.sql
+++ b/stores/governance/src/main/resources/db/store/postgresql/V0_1100_1__init.sql
@@ -2,10 +2,10 @@ drop table if exists gov_action_proposal;
 create table gov_action_proposal
 (
     tx_hash         varchar(64) not null,
-    index           int         not null,
+    idx           int         not null,
     deposit         bigint,
     return_address  varchar(255),
-    anchor_url      varchar(256),
+    anchor_url      varchar,
     anchor_hash     varchar(64),
     type            varchar(50),
     details         jsonb,
@@ -14,7 +14,7 @@ create table gov_action_proposal
     block           bigint,
     block_time      bigint,
     update_datetime timestamp,
-    primary key (tx_hash, index)
+    primary key (tx_hash, idx)
 );
 
 CREATE INDEX idx_gov_action_proposal_slot
@@ -34,7 +34,7 @@ create table voting_procedure
 (
     id                 uuid        not null,
     tx_hash            varchar(64) not null,
-    index              int         not null,
+    idx                int         not null,
     voter_type         varchar(50),
     voter_hash         varchar(56),
     gov_action_tx_hash varchar(64),
@@ -84,7 +84,7 @@ CREATE TABLE committee_deregistration
 (
     tx_hash         varchar(64) not null,
     cert_index      int         NOT NULL,
-    anchor_url      varchar(256),
+    anchor_url      varchar,
     anchor_hash     varchar(64),
     cold_key        varchar     NOT NULL,
     cred_type       varchar(40),

--- a/stores/governance/src/test/resources/scripts/gov_action_proposal_data.sql
+++ b/stores/governance/src/test/resources/scripts/gov_action_proposal_data.sql
@@ -1,21 +1,21 @@
 TRUNCATE TABLE gov_action_proposal;
 
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('39b3cfae7ea05e4f1ceb3bb04c599fc4a3495ecdb93f880f731eef5cf7ce3b06', 0, 1000000000,
         'stake_test1urd3hs7rlxwwdzthe6hj026dmyt3y0heuulctscyydh2kgck6nkmz', 'https://bit.ly/3zCH2HL',
         '1111111111111111111111111111111111111111111111111111111111111111', 'INFO_ACTION',
         '{"type": "INFO_ACTION"}' FORMAT JSON, 220, 19092948, 926799, 1705881929, '2024-01-23 18:16:45.423');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('2e336f7b0e9c202fb0165827a1b836b31f0fdb4f3e273f8dd54058141e693853', 0, 1000000000,
         'stake_test1urd3hs7rlxwwdzthe6hj026dmyt3y0heuulctscyydh2kgck6nkmz', 'https://bit.ly/3zCH2HL',
         '1111111111111111111111111111111111111111111111111111111111111111', 'INFO_ACTION',
         '{"type": "INFO_ACTION"}' FORMAT JSON, 220, 19092937, 926798, 1705881918, '2024-01-23 18:16:45.411');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('53699ec63a77450a24c74681ad45de23efa8e671dfcc4f62d663a54bb6c02cbd', 0, 1000000000,
         'stake_test1uqvj4r4h0fh5qhvpjmwedkcnj5xysvq2plutdapw0yq69mccrcnd7', 'https://hornan7.github.io/proposal.txt',
@@ -23,21 +23,21 @@ VALUES ('53699ec63a77450a24c74681ad45de23efa8e671dfcc4f62d663a54bb6c02cbd', 0, 1
         '{"type": "TREASURY_WITHDRAWALS_ACTION", "withdrawals": {"e0192a8eb77a6f405d8196dd96db13950c48300a0ff8b6f42e7901a2ef": 64000000000000}}' FORMAT JSON,
         220, 19092418, 926776, 1705881399, '2024-01-23 18:16:45.392');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('46e91efe1091f776318351361bf28ef7d7726b5815f5e6858f05e72f6d942d56', 0, 1000000000,
         'stake_test1urd3hs7rlxwwdzthe6hj026dmyt3y0heuulctscyydh2kgck6nkmz', 'https://bit.ly/3zCH2HL',
         '1111111111111111111111111111111111111111111111111111111111111111', 'INFO_ACTION',
         '{"type": "INFO_ACTION"}' FORMAT JSON, 219, 19006693, 923169, 1705795674, '2024-01-23 18:16:41.485');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('cc6bc0963a68bd6e3f6b1a770e2d196a497b33e58ee5687fd8f574087164400a', 0, 1000000000,
         'stake_test1urd3hs7rlxwwdzthe6hj026dmyt3y0heuulctscyydh2kgck6nkmz', 'https://bit.ly/3zCH2HL',
         '1111111111111111111111111111111111111111111111111111111111111111', 'INFO_ACTION',
         '{"type": "INFO_ACTION"}' FORMAT JSON, 219, 19006688, 923168, 1705795669, '2024-01-23 18:16:41.474');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('fc921d974f6fe0fee05e6cf5147320d5b3341ddb0fa89b2507bbc43b1b6b4e92', 1, 1000000000,
         'stake_test1uqvj4r4h0fh5qhvpjmwedkcnj5xysvq2plutdapw0yq69mccrcnd7', 'https://hornan7.github.io/proposal.txt',
@@ -45,7 +45,7 @@ VALUES ('fc921d974f6fe0fee05e6cf5147320d5b3341ddb0fa89b2507bbc43b1b6b4e92', 1, 1
         '{"type": "TREASURY_WITHDRAWALS_ACTION", "withdrawals": {"e0893b50a95e7ffd6603f08cbab569f05ed73222db740ea1fb21906950": 55000000}}' FORMAT JSON,
         219, 18961390, 921187, 1705750371, '2024-01-23 18:16:39.382');
 INSERT INTO gov_action_proposal
-(tx_hash, index, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
+(tx_hash, idx, deposit, return_address, anchor_url, anchor_hash, type, details, epoch, slot, block, block_time,
  update_datetime)
 VALUES ('fc921d974f6fe0fee05e6cf5147320d5b3341ddb0fa89b2507bbc43b1b6b4e92', 0, 1000000000,
         'stake_test1uqvj4r4h0fh5qhvpjmwedkcnj5xysvq2plutdapw0yq69mccrcnd7', 'https://hornan7.github.io/proposal.txt',

--- a/stores/governance/src/test/resources/scripts/voting_procedure_data.sql
+++ b/stores/governance/src/test/resources/scripts/voting_procedure_data.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE voting_procedure;
 
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('9529230f-efef-47ac-9cbd-6a6e415f0c0c',
         '86e24fcff8e64d32ac57747ea13788cec997435940a887cb10541fe14443d6cb', 0, 'DREP_KEY_HASH',
@@ -10,7 +10,7 @@ VALUES ('9529230f-efef-47ac-9cbd-6a6e415f0c0c',
         '1111111111111111111111111111111111111111111111111111111111111111', 167, 14468003, 723258, 1701256984,
         '2024-01-23 18:12:19.183');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('0a2e7ac2-6cdf-4064-ac2f-c24dac654841',
         'be675fa7679ed5e4f1518e527554ca2a24d4a007e27a8af2561b8c4b8eaa872d', 0, 'DREP_KEY_HASH',
@@ -19,7 +19,7 @@ VALUES ('0a2e7ac2-6cdf-4064-ac2f-c24dac654841',
         '621e38dedb1d24a0459d0bcf1e8beb5e3f4a6d04fe7d1617266ce70e291e978c', 167, 14468321, 723281, 1701257302,
         '2024-01-23 18:12:19.312');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('9afb7270-297b-45f6-acd1-934594880460',
         '80898d573eadd8c34de4038bb039ce1f960b101fcc644fafa94e502d58202707', 0, 'DREP_KEY_HASH',
@@ -28,7 +28,7 @@ VALUES ('9afb7270-297b-45f6-acd1-934594880460',
         'eb5ddd426349752ce831e7f6a1dc4778046295069efa0bd3cbda5feed89e6cc6', 167, 14468394, 723282, 1701257375,
         '2024-01-23 18:12:19.332');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('307679ed-c469-4fcd-ab02-8453482310fc',
         '5f8196244286d13776cdd5d6fd9e6f19a33df2825b58f2c5a34db1f0ade50502', 0, 'DREP_KEY_HASH',
@@ -37,7 +37,7 @@ VALUES ('307679ed-c469-4fcd-ab02-8453482310fc',
         'c8fcb20a81e568dd6381b44db157c06bea808ef0abfa5d7314fda906da2156db', 167, 14468508, 723284, 1701257489,
         '2024-01-23 18:12:19.352');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('a839a44f-5ee4-48ea-a006-f0be45388973',
         'e725f304f5b57bb21c30ff6ba93c4def5f0127027e18445c82b5f73a8ddae68b', 0, 'DREP_KEY_HASH',
@@ -46,7 +46,7 @@ VALUES ('a839a44f-5ee4-48ea-a006-f0be45388973',
         '7d32382f4919d1d3595cdeabf0f567397677e800712d0ca1f57728f20938766f', 167, 14468578, 723288, 1701257559,
         '2024-01-23 18:12:19.398');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('9fba4180-d167-4622-bca0-8445075eb924',
         '26b068f8658510df7ba7fc5f4eb1d017ad60b51d9c948254e8d2084cd8fe2132', 0, 'DREP_KEY_HASH',
@@ -54,7 +54,7 @@ VALUES ('9fba4180-d167-4622-bca0-8445075eb924',
         'bd5d786d745ec7c1994f8cff341afee513c7cdad73e8883d540ff71c41763fd1', 27, 'YES', NULL, NULL, 167, 14498537,
         724785, 1701287518, '2024-01-23 18:12:21.703');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('8e05dcb4-4d59-4dda-b8cc-854ffc523f94',
         '7797671108626b91c7409b9ba9a411b97881b90a801b04793b8f671fa96add28', 0, 'DREP_KEY_HASH',
@@ -62,7 +62,7 @@ VALUES ('8e05dcb4-4d59-4dda-b8cc-854ffc523f94',
         '491eb32c9b248263868b617e669f35c2c15d0ce94d738b63de7d36b71e4486b0', 1, 'NO', NULL, NULL, 168, 14559346, 727840,
         1701348327, '2024-01-23 18:12:28.462');
 INSERT INTO voting_procedure
-(id, tx_hash, index, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
+(id, tx_hash, idx, voter_type, voter_hash, gov_action_tx_hash, gov_action_index, vote, anchor_url, anchor_hash,
  epoch, slot, block, block_time, update_datetime)
 VALUES ('2621835f-6785-4ded-8042-c875e743729a',
         'c25c6ecf8eadabc3848b0bff3e7b201aed55efffd47528bf387a84d6431fd640', 0, 'DREP_KEY_HASH',

--- a/test-scripts/query.http
+++ b/test-scripts/query.http
@@ -172,16 +172,16 @@ accept: */*
 ###
 
 # Assets tx by policy
-GET http://localhost:8080/api/v1/assets/txs/policy/e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999
+GET http://localhost:8080/api/v1/assets/policy/e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999
 
 ###  Assets tx fingerprint
-GET http://localhost:8080/api/v1/assets/txs/fingerprint/asset14p0rxzq3wc2a8tuftzkvjt5xt067rteaf8wqr3
+GET http://localhost:8080/api/v1/assets/fingerprint/asset14p0rxzq3wc2a8tuftzkvjt5xt067rteaf8wqr3
 
 ### Assets tx by unit
-GET http://localhost:8080/api/v1/assets/txs/unit/39086ef91d452d1b6ea9c8c92a2f3243467ddf93bf7c142d370e7d6443617264616e6f4275647a483253363434
+GET http://localhost:8080/api/v1/assets/unit/39086ef91d452d1b6ea9c8c92a2f3243467ddf93bf7c142d370e7d6443617264616e6f4275647a483253363434
 
 ### Unit
-GET http://localhost:8080/api/v1/assets/txs/unit/e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb33799953554d4d495441574152445344656669
+GET http://localhost:8080/api/v1/assets/unit/e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb33799953554d4d495441574152445344656669
 
 ### supply unit
 GET http://localhost:8080/api/v1/assets/supply/unit/42f0e3706d2e0a0761db8da21387aadabe609a7cf328d249ebc2eeff96f0ab7cec670d934f369bfecab402f0387983733238b93be6213e61c94ea16f


### PR DESCRIPTION
- Spring Boot 3.2.2 
- Driver version upgrade (mysql, postgres)
- Fix governance table data types for H2 and mysql
- Rename "index" column to "idx" for mysql as "index" is a reserve keyword in mysql