### PR TITLE
fix: #209 Removed NUL character (\u0000) which is not allowed in Postgres jsonb column

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/JsonUtil.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/JsonUtil.java
@@ -56,6 +56,10 @@ public class JsonUtil {
         return mapper.readTree(jsonContent);
     }
 
+    public static ObjectMapper getMapper() {
+        return mapper;
+    }
+
     static {
         mapper = (new ObjectMapper()).enable(SerializationFeature.INDENT_OUTPUT);
     }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/InvalidTransactionEntity.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/InvalidTransactionEntity.java
@@ -2,11 +2,10 @@ package com.bloxbean.cardano.yaci.store.utxo.storage.impl.model;
 
 import com.bloxbean.cardano.yaci.helper.model.Transaction;
 import com.bloxbean.cardano.yaci.store.common.model.BaseEntity;
+import com.bloxbean.cardano.yaci.store.common.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -33,4 +32,21 @@ public class InvalidTransactionEntity extends BaseEntity {
     @Type(JsonType.class)
     @Column(columnDefinition = "json")
     private Transaction transaction;
+
+    @PrePersist
+    public void prePersist() {
+        if (transaction == null) return;
+
+        var json = JsonUtil.getJson(transaction);
+        if (json.contains("\\u0000")) {
+            json = json.replace("\\u0000", "");
+
+            try {
+                var updatedTransaction = JsonUtil.getMapper().readValue(json, Transaction.class);
+                setTransaction(updatedTransaction);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Error deserializing transaction json", e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Issue #209 

- Removed NUL character (\u0000) which is not allowed in Postgres jsonb column

@Sotatek-HuyLe3a Do you know any better way to do this?

Also, should we implement this sanitization in Yaci? Currently, we need to apply this logic in 3 different places wherever the Amount field is present.
 I'm not sure if it's ok to change the original string due to PostgreSQL limitations. However, we also have the `assetNameAsBytes` field, which contains the original byte array, so it might be acceptable to make this change. 