### PR TITLE
chore: Maintain address cache and new AddressProcessor

### DIFF
--- a/aggregates/account/build.gradle
+++ b/aggregates/account/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api project(":stores:utxo")
+    implementation(libs.guava)
 }
 
 publishing {

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
@@ -31,4 +31,10 @@ public class AccountStoreProperties {
     private int balanceHistoryCleanupInterval = 300;
     @Builder.Default
     private long balanceCleanupSlotCount = 43200; //2160 blocks
+
+    @Builder.Default
+    private int addressCacheSize = 2_000_000;
+
+    @Builder.Default
+    private int addressCacheExpiryAfterAccess = 15;
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AddressProcessor.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AddressProcessor.java
@@ -1,0 +1,92 @@
+package com.bloxbean.cardano.yaci.store.account.processor;
+
+import com.bloxbean.cardano.yaci.store.account.AccountStoreProperties;
+import com.bloxbean.cardano.yaci.store.account.domain.Address;
+import com.bloxbean.cardano.yaci.store.account.storage.AddressStorage;
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.bloxbean.cardano.yaci.store.events.internal.CommitEvent;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressUtxoEvent;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AddressProcessor {
+    private final AddressStorage addressStorage;
+    private final AccountStoreProperties accountStoreProperties;
+
+    private Cache<String, String> cache;
+    private Set<Address> addresseCache = Collections.synchronizedSet(new HashSet<>());
+
+    @PostConstruct
+    public void init() {
+        log.info("-- Address Processor Initialized with address cache size: {}, expiry: {} min"
+                , accountStoreProperties.getAddressCacheSize(), accountStoreProperties.getAddressCacheExpiryAfterAccess());
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(accountStoreProperties.getAddressCacheSize())
+                .expireAfterAccess(accountStoreProperties.getAddressCacheExpiryAfterAccess(),
+                        TimeUnit.MINUTES)
+                .build();
+    }
+
+    @EventListener
+    public void handleAddress(AddressUtxoEvent addressUtxoEvent) {
+        //Get Addresses
+        var addresses = addressUtxoEvent.getTxInputOutputs()
+                .stream().flatMap(txInputOutput -> txInputOutput.getOutputs().stream())
+                .filter(addressUtxo -> cache.getIfPresent(addressUtxo.getOwnerAddr()) == null)
+                .map(addressUtxo -> Address.builder()
+                        .address(addressUtxo.getOwnerAddr())
+                        .stakeAddress(addressUtxo.getOwnerStakeAddr())
+                        .paymentCredential(addressUtxo.getOwnerPaymentCredential())
+                        .stakeCredential(addressUtxo.getOwnerStakeCredential())
+                        .build())
+                .toList();
+
+        if (addresses.isEmpty())
+            return;
+
+        addresseCache.addAll(addresses);
+    }
+
+    @EventListener
+    @Transactional
+    public void handleCommit(CommitEvent commitEvent) {
+        try {
+            if (addresseCache.size() > 0) {
+                long t1 = System.currentTimeMillis();
+                addressStorage.save(addresseCache);
+
+                if (!commitEvent.getMetadata().isSyncMode()) { //Store only for initial sync
+                    addresseCache.stream()
+                            .forEach(address -> cache.put(address.getAddress(), ""));
+                }
+
+                long t2 = System.currentTimeMillis();
+                log.info("Address save size : {}, time: {} ms", addresseCache.size(),  (t2 - t1));
+                log.info("Address Cache Size: {}", cache.size());
+            }
+        } finally {
+            addresseCache.clear();
+        }
+    }
+
+    @EventListener
+    @Transactional
+    public void handleRollback(RollbackEvent rollbackEvent) {
+        addresseCache.clear();
+        cache.invalidateAll();
+    }
+}

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AddressTxAmountProcessor.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AddressTxAmountProcessor.java
@@ -1,8 +1,6 @@
 package com.bloxbean.cardano.yaci.store.account.processor;
 
-import com.bloxbean.cardano.yaci.store.account.domain.Address;
 import com.bloxbean.cardano.yaci.store.account.domain.AddressTxAmount;
-import com.bloxbean.cardano.yaci.store.account.storage.AddressStorage;
 import com.bloxbean.cardano.yaci.store.account.storage.AddressTxAmountStorage;
 import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
@@ -34,12 +32,10 @@ public class AddressTxAmountProcessor {
     public static final int BLOCK_ADDRESS_TX_AMT_THRESHOLD = 100; //Threshold to save address_tx_amounts records for block
 
     private final AddressTxAmountStorage addressTxAmountStorage;
-    private final AddressStorage addressStorage;
     private final UtxoClient utxoClient;
 
     private List<Pair<EventMetadata, TxInputOutput>> pendingTxInputOutputListCache = Collections.synchronizedList(new ArrayList<>());
     private List<AddressTxAmount> addressTxAmountListCache = Collections.synchronizedList(new ArrayList<>());
-    private Set<Address> addresseCache = Collections.synchronizedSet(new HashSet<>());
 
     @EventListener
     @Transactional
@@ -55,17 +51,6 @@ public class AddressTxAmountProcessor {
         List<AddressTxAmount> addressTxAmountList = new ArrayList<>();
 
         for (var txInputOutput : txInputOutputList) {
-            //Get Addresses
-            var addresses = txInputOutput.getOutputs().stream()
-                    .map(addressUtxo -> Address.builder()
-                            .address(addressUtxo.getOwnerAddr())
-                            .stakeAddress(addressUtxo.getOwnerStakeAddr())
-                            .paymentCredential(addressUtxo.getOwnerPaymentCredential())
-                            .stakeCredential(addressUtxo.getOwnerStakeCredential())
-                            .build())
-                    .toList();
-            addresseCache.addAll(addresses);
-
             var txAddressTxAmountEntities = processAddressAmountForTx(addressUtxoEvent.getEventMetadata(), txInputOutput, false);
             if (txAddressTxAmountEntities == null || txAddressTxAmountEntities.isEmpty()) continue;
 
@@ -209,18 +194,12 @@ public class AddressTxAmountProcessor {
                 addressTxAmountStorage.save(addressTxAmountListCache);
             }
 
-            if (addresseCache.size() > 0) {
-                addressStorage.save(addresseCache);
-            }
-
             long t2 = System.currentTimeMillis();
-            log.info("Time taken to save additional address_tx_amounts records : {}, address records: {}, time: {} ms",
-                    addressTxAmountListCache.size(), addresseCache.size(), (t2 - t1));
-
+            log.info("Time taken to save additional address_tx_amounts records : {}, time: {} ms",
+                    addressTxAmountListCache.size(), (t2 - t1));
         } finally {
             pendingTxInputOutputListCache.clear();
             addressTxAmountListCache.clear();
-            addresseCache.clear();
         }
     }
 

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AddressStorageImpl.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AddressStorageImpl.java
@@ -59,9 +59,9 @@ public class AddressStorageImpl implements AddressStorage {
         int partitionSize = totalSize;
         if (totalSize > accountStoreProperties.getWriteThreadDefaultBatchSize()) {
             partitionSize = totalSize / accountStoreProperties.getWriteThreadCount();
-            log.info("\tAddress Tx Amt Partition size : {}", partitionSize);
+            log.info("\tAddress Partition size : {}", partitionSize);
         } else {
-            log.info("\tAddress Tx Amt Partition size : {}", partitionSize);
+            log.info("\tAddress Partition size : {}", partitionSize);
         }
         return partitionSize;
     }

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
@@ -30,6 +30,9 @@ public class AccountStoreAutoConfigProperties {
 
         private int balanceHistoryCleanupInterval = 300;
         private long balanceCleanupSlotCount = 43200; //2160 blocks
+
+        private int addressCacheSize = 2_000_000;
+        private int addressCacheExpiryAfterAccess = 15;
     }
 
 }

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
@@ -35,6 +35,8 @@ public class AccountStoreAutoConfiguration {
 
         accountStoreProperties.setBalanceCleanupSlotCount(properties.getAccount().getBalanceCleanupSlotCount());
 
+        accountStoreProperties.setAddressCacheSize(properties.getAccount().getAddressCacheSize());
+        accountStoreProperties.setAddressCacheExpiryAfterAccess(properties.getAccount().getAddressCacheExpiryAfterAccess());
         return accountStoreProperties;
     }
 }


### PR DESCRIPTION
- Separate AddressProcessor to save addresses
- Keep cache for existing addresses to reduce no of inserts
- Currently using Guava for caching. This will be replaced with Spring Cache later.