### PR TITLE
Fix job restart

### DIFF
--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/config/AccountBatchConfiguration.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/config/AccountBatchConfiguration.java
@@ -34,6 +34,7 @@ public class AccountBatchConfiguration {
     private final StartService startService;
     private final AccountStoreProperties accountStoreProperties;
     private final DSLContext dsl;
+    private final PlatformTransactionManager platformTransactionManager;
 
     @Bean
     public Job accountBalanceJob() {
@@ -103,7 +104,7 @@ public class AccountBatchConfiguration {
 
     @Bean
     public Tasklet accountBalanceTasklet() {
-        return new AddressAggregationTasklet(accountStoreProperties, dsl);
+        return new AddressAggregationTasklet(accountStoreProperties, dsl, platformTransactionManager);
     }
 
     //--- Stake Address Balance Calculation
@@ -137,7 +138,7 @@ public class AccountBatchConfiguration {
 
     @Bean
     public Tasklet stakeAddressBalanceTasklet() {
-        return new StakeAddressAggregationTasklet(accountStoreProperties, dsl);
+        return new StakeAddressAggregationTasklet(accountStoreProperties, dsl, platformTransactionManager);
     }
 
     @Bean
@@ -149,7 +150,7 @@ public class AccountBatchConfiguration {
 
     @Bean
     public Tasklet accountConfigUpdateTasklet() {
-        return new AccountConfigUpdateTasklet(accountConfigService, startService);
+        return new AccountConfigUpdateTasklet(accountConfigService, startService, platformTransactionManager);
     }
 
     @Bean

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AccountConfigUpdateTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AccountConfigUpdateTasklet.java
@@ -10,6 +10,8 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.bloxbean.cardano.yaci.store.account.job.AccountJobConstants.*;
 
 @RequiredArgsConstructor
@@ -43,7 +45,15 @@ public class AccountConfigUpdateTasklet implements Tasklet {
         accountConfigService.upateConfig(ConfigIds.LAST_ACCOUNT_BALANCE_PROCESSED_BLOCK, null, snapshotBlock, snapshotBlockHash, snapshotSlot);
 
         log.info("<<<< Starting the sync process after updating account config >>>>");
-        startService.start();
+
+        Thread.startVirtualThread(() -> {
+            log.info("Waiting for 10 seconds before starting the sync process ...");
+            try {
+                TimeUnit.SECONDS.sleep(10);
+            } catch (InterruptedException e) {
+            }
+            startService.start();
+        });
 
         return RepeatStatus.FINISHED;
     }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AccountConfigUpdateTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AccountConfigUpdateTasklet.java
@@ -38,8 +38,11 @@ public class AccountConfigUpdateTasklet implements Tasklet {
             return RepeatStatus.FINISHED;
         }
 
+        log.info(">>> Updating account config with snapshot block: {}, snapshot block hash: {}, snapshot slot: {}", snapshotBlock, snapshotBlockHash, snapshotSlot);
+
         accountConfigService.upateConfig(ConfigIds.LAST_ACCOUNT_BALANCE_PROCESSED_BLOCK, null, snapshotBlock, snapshotBlockHash, snapshotSlot);
 
+        log.info("<<<< Starting the sync process after updating account config >>>>");
         startService.start();
 
         return RepeatStatus.FINISHED;

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AddressAggregationTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AddressAggregationTasklet.java
@@ -102,7 +102,7 @@ public class AddressAggregationTasklet implements Tasklet {
                 .set(ADDRESS_BALANCE.BLOCK, excluded(ADDRESS_BALANCE.BLOCK))
                 .set(ADDRESS_BALANCE.BLOCK_TIME, excluded(ADDRESS_BALANCE.BLOCK_TIME))
                 .set(ADDRESS_BALANCE.EPOCH, excluded(ADDRESS_BALANCE.EPOCH));
-        insertQuery.execute();
+        insertQuery.queryTimeout(300).execute();
     }
 
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AddressAggregationTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/AddressAggregationTasklet.java
@@ -85,6 +85,7 @@ public class AddressAggregationTasklet implements Tasklet {
                                                 .in(select(ADDRESS.ADDRESS_)
                                                         .from(ADDRESS)
                                                         .where(ADDRESS.ID.between(from, to))
+                                                        .limit(to - from + 1)
                                                 )
                                         )
                                 )

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
@@ -101,6 +101,7 @@ public class StakeAddressAggregationTasklet implements Tasklet {
                 .set(STAKE_ADDRESS_BALANCE.BLOCK, excluded(STAKE_ADDRESS_BALANCE.BLOCK))
                 .set(STAKE_ADDRESS_BALANCE.BLOCK_TIME, excluded(STAKE_ADDRESS_BALANCE.BLOCK_TIME))
                 .set(STAKE_ADDRESS_BALANCE.EPOCH, excluded(STAKE_ADDRESS_BALANCE.EPOCH))
+                .queryTimeout(300)
                 .execute();
     }
 

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
@@ -59,6 +59,10 @@ public class StakeAddressAggregationTasklet implements Tasklet {
 
         boolean shouldContinue = to < finalEndOffset;
 
+        if (!shouldContinue) {
+            log.info("Stake address aggregation completed for partition. {}", chunkContext.getStepContext().getId());
+        }
+
         return shouldContinue ? RepeatStatus.CONTINUABLE : RepeatStatus.FINISHED;
     }
 

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/job/StakeAddressAggregationTasklet.java
@@ -62,7 +62,7 @@ public class StakeAddressAggregationTasklet implements Tasklet {
         return shouldContinue ? RepeatStatus.CONTINUABLE : RepeatStatus.FINISHED;
     }
 
-    private void calculateStakeAddressBalance(long startOffset, long to, Long snapshotSlot) {
+    private void calculateStakeAddressBalance(long from, long to, Long snapshotSlot) {
         dsl.insertInto(STAKE_ADDRESS_BALANCE,
                         STAKE_ADDRESS_BALANCE.ADDRESS,
                         STAKE_ADDRESS_BALANCE.QUANTITY,
@@ -85,7 +85,8 @@ public class StakeAddressAggregationTasklet implements Tasklet {
                                 .and(ADDRESS_TX_AMOUNT.STAKE_ADDRESS
                                         .in(select(field("address", String.class))
                                                 .from(table(STAKE_ADDRESS_TEMP_TABLE))
-                                                .where(field("id", Long.class).between(startOffset, to))
+                                                .where(field("id", Long.class).between(from, to))
+                                                .limit(to - from + 1)
                                         )
                                 ).and(ADDRESS_TX_AMOUNT.UNIT.eq(LOVELACE))
                         )

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/service/BalanceSnapshotService.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/service/BalanceSnapshotService.java
@@ -100,7 +100,6 @@ public class BalanceSnapshotService {
         //Take balance snapshot
         log.info("Trying to take balance snapshot at block : {}, slot: {}", block, slot);
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("time", System.currentTimeMillis())
                 .addLong(SNAPSHOT_BLOCK, block)
                 .addLong(SNAPSHOT_SLOT, slot)
                 .addString(SNAPSHOT_BLOCKHASH, blockHash)

--- a/components/job/scripts/job_reset.sql
+++ b/components/job/scripts/job_reset.sql
@@ -1,0 +1,1 @@
+truncate batch_job_instance cascade;


### PR DESCRIPTION
- Added "limit" to "select address" query to avoid full scan of address_tx_amount table.
- Remove "time" from job parameter to keep 1 job instance per snapshot block