### PR TITLE
chore: Create a separate table utxo_amount for utxo amounts

### DIFF
--- a/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/storage/DummyDBUtxoStorage.java
+++ b/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/storage/DummyDBUtxoStorage.java
@@ -39,8 +39,4 @@ public class DummyDBUtxoStorage extends UtxoStorageImpl {
         return 0;
     }
 
-    @Override
-    public int deleteBySpentAndBlockLessThan(Long block) {
-        return 0;
-    }
 }

--- a/applications/aggregation-app/src/main/resources/sql/create-index.sql
+++ b/applications/aggregation-app/src/main/resources/sql/create-index.sql
@@ -15,6 +15,15 @@ CREATE INDEX if not exists idx_address_utxo_owner_stakekey_hash
 CREATE INDEX if not exists idx_address_utxo_epoch
     ON address_utxo(epoch);
 
+CREATE INDEX if not exists idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX if not exists idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX if not exists idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
+
 -- account balance
 
 CREATE INDEX if not exists idx_address_balance_address

--- a/applications/aggregation-app/src/main/resources/sql/drop-index.sql
+++ b/applications/aggregation-app/src/main/resources/sql/drop-index.sql
@@ -5,6 +5,10 @@ drop index idx_address_utxo_owner_paykey_hash;
 drop index idx_address_utxo_owner_stakekey_hash;
 drop index idx_address_utxo_epoch;
 
+drop index idx_utxo_amount_unit;
+drop index idx_utxo_amount_policy;
+drop index idx_utxo_amount_asset_name;
+
 -- account balance
 drop index idx_address_balance_address;
 drop index idx_address_balance_block_time;

--- a/applications/aggregation-app/src/main/resources/sql/mysql/create-index.sql
+++ b/applications/aggregation-app/src/main/resources/sql/mysql/create-index.sql
@@ -15,6 +15,15 @@ CREATE INDEX idx_address_utxo_owner_stakekey_hash
 CREATE INDEX idx_address_utxo_epoch
     ON address_utxo(epoch);
 
+CREATE INDEX idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
+
 -- account balance
 
 CREATE INDEX idx_address_balance_address

--- a/applications/aggregation-app/src/main/resources/sql/mysql/drop-index.sql
+++ b/applications/aggregation-app/src/main/resources/sql/mysql/drop-index.sql
@@ -5,6 +5,10 @@ drop index idx_address_utxo_owner_paykey_hash on address_utxo;
 drop index idx_address_utxo_owner_stakekey_hash on address_utxo;
 drop index idx_address_utxo_epoch on address_utxo;
 
+drop index idx_utxo_amount_unit on utxo_amount;
+drop index idx_utxo_amount_policy on utxo_amount;
+drop index idx_utxo_amount_asset_name on utxo_amount;
+
 -- account balance
 drop index idx_address_balance_address on address_balance;
 drop index idx_address_balance_block_time on address_balance;

--- a/applications/all/src/main/resources/sql/create-index.sql
+++ b/applications/all/src/main/resources/sql/create-index.sql
@@ -30,6 +30,15 @@ CREATE INDEX if not exists idx_address_utxo_owner_stakekey_hash
 CREATE INDEX if not exists idx_address_utxo_epoch
     ON address_utxo(epoch);
 
+CREATE INDEX if not exists idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX if not exists idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX if not exists idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
+
 -- asset store
 
 CREATE INDEX if not exists idx_assets_tx_hash

--- a/applications/all/src/main/resources/sql/drop-index.sql
+++ b/applications/all/src/main/resources/sql/drop-index.sql
@@ -14,6 +14,10 @@ drop index idx_address_utxo_owner_paykey_hash;
 drop index idx_address_utxo_owner_stakekey_hash;
 drop index idx_address_utxo_epoch;
 
+drop index idx_utxo_amount_unit;
+drop index idx_utxo_amount_policy;
+drop index idx_utxo_amount_asset_name;
+
 -- assets store
 drop index idx_assets_tx_hash;
 drop index idx_assets_policy;

--- a/applications/all/src/main/resources/sql/mysql/create-index.sql
+++ b/applications/all/src/main/resources/sql/mysql/create-index.sql
@@ -30,6 +30,15 @@ CREATE INDEX idx_address_utxo_owner_stakekey_hash
 CREATE INDEX idx_address_utxo_epoch
     ON address_utxo(epoch);
 
+CREATE INDEX idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
+
 -- asset store
 
 CREATE INDEX idx_assets_tx_hash

--- a/applications/all/src/main/resources/sql/mysql/drop-index.sql
+++ b/applications/all/src/main/resources/sql/mysql/drop-index.sql
@@ -14,6 +14,10 @@ drop index idx_address_utxo_owner_paykey_hash on address_utxo;
 drop index idx_address_utxo_owner_stakekey_hash on address_utxo;
 drop index idx_address_utxo_epoch on address_utxo;
 
+drop index idx_utxo_amount_unit on utxo_amount;
+drop index idx_utxo_amount_policy on utxo_amount;
+drop index idx_utxo_amount_asset_name on utxo_amount;
+
 -- assets store
 drop index idx_assets_tx_hash on assets;
 drop index idx_assets_policy  on assets;

--- a/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorage.java
+++ b/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorage.java
@@ -173,11 +173,6 @@ public class RocksDBUtxoStorage implements UtxoStorage {
 
     }
 
-    @Override
-    public int deleteBySpentAndBlockLessThan(Long block) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
     @SneakyThrows
     @EventListener
     public void handleCommitEvent(CommitEvent commitEvent) {

--- a/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorageReader.java
+++ b/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorageReader.java
@@ -1,6 +1,5 @@
 package com.bloxbean.cardano.yaci.store.extensions.utxo.rocksdb;
 
-import com.bloxbean.cardano.yaci.core.util.Tuple;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
@@ -122,21 +121,6 @@ public class RocksDBUtxoStorageReader implements UtxoStorageReader {
 
     @Override
     public List<AddressUtxo> findUtxoByStakeAddressAndAsset(String stakeAddress, String unit, int page, int count, Order order) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
-    @Override
-    public List<Long> findNextAvailableBlocks(Long block, int limit) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
-    @Override
-    public List<AddressUtxo> findUnspentUtxosBetweenBlocks(Long startBlock, Long endBlock) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
-    @Override
-    public List<Tuple<AddressUtxo, TxInput>> findSpentUtxosBetweenBlocks(Long startBlock, Long endBlock) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreConfiguration.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreConfiguration.java
@@ -39,6 +39,6 @@ public class UtxoStoreConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public UtxoStorageReader utxoStorageReader(UtxoRepository utxoRepository, TxInputRepository spentOutputRepository, DSLContext dslContext) {
-        return new UtxoStorageReaderImpl(utxoRepository, spentOutputRepository, dslContext);
+        return new UtxoStorageReaderImpl(utxoRepository);
     }
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorage.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorage.java
@@ -15,5 +15,4 @@ public interface UtxoStorage {
     List<AddressUtxo> findAllByIds(List<UtxoKey> utxoKeys);
     int deleteUnspentBySlotGreaterThan(Long slot);
     int deleteSpentBySlotGreaterThan(Long slot);
-    int deleteBySpentAndBlockLessThan(Long block);
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorageReader.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorageReader.java
@@ -1,8 +1,6 @@
 package com.bloxbean.cardano.yaci.store.utxo.storage;
 
-import com.bloxbean.cardano.yaci.core.util.Tuple;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
-import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
 
@@ -20,7 +18,4 @@ public interface UtxoStorageReader {
     List<AddressUtxo> findUtxoByStakeAddress(String stakeAddress, int page, int count, Order order);
     List<AddressUtxo> findUtxoByStakeAddressAndAsset(String stakeAddress, String unit, int page, int count, Order order);
     List<AddressUtxo> findAllByIds(List<UtxoKey> utxoKeys);
-    List<Long> findNextAvailableBlocks(Long block, int limit);
-    List<AddressUtxo> findUnspentUtxosBetweenBlocks(Long startBlock, Long endBlock);
-    List<Tuple<AddressUtxo, TxInput>> findSpentUtxosBetweenBlocks(Long startBlock, Long endBlock);
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageReaderImpl.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageReaderImpl.java
@@ -1,40 +1,27 @@
 package com.bloxbean.cardano.yaci.store.utxo.storage.impl;
 
-import com.bloxbean.cardano.yaci.core.util.Tuple;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
-import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
 import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorageReader;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.mapper.UtxoMapper;
-import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.AddressUtxoEntity;
-import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.TxInputEntity;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.UtxoId;
-import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.TxInputRepository;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.UtxoRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.jooq.DSLContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.ADDRESS_UTXO;
-import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.TX_INPUT;
-import static org.jooq.impl.DSL.field;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UtxoStorageReaderImpl implements UtxoStorageReader {
 
     private final UtxoRepository utxoRepository;
-    private final TxInputRepository spentOutputRepository;
-    private final DSLContext dsl;
     private final UtxoMapper mapper = UtxoMapper.INSTANCE;
 
     @Override
@@ -55,47 +42,25 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
 
     @Override
     public List<AddressUtxo> findUtxosByAsset(String unit, int page, int count, Order order) {
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
-        var query = dsl
-                .select(ADDRESS_UTXO.fields())
-                .from(ADDRESS_UTXO)
-                .leftJoin(TX_INPUT)
-                .using(field(ADDRESS_UTXO.TX_HASH), field(ADDRESS_UTXO.OUTPUT_INDEX))
-                .where(field(ADDRESS_UTXO.AMOUNTS).cast(String.class).contains("\"unit\": \""+unit+"\""))
-                .and(TX_INPUT.TX_HASH.isNull())
-                //.orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: Ordering
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        return query.fetch().into(AddressUtxo.class);
+        return utxoRepository.findByAssetUnit(unit, pageable)
+                .map(mapper::toAddressUtxo)
+                .toList();
     }
 
     @Override
     public List<AddressUtxo> findUtxoByAddressAndAsset(String address, String unit, int page, int count, Order order) {
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
-        var query = dsl
-                .select(ADDRESS_UTXO.fields())
-                .from(ADDRESS_UTXO)
-                .leftJoin(TX_INPUT)
-                .using(field(ADDRESS_UTXO.TX_HASH), field(ADDRESS_UTXO.OUTPUT_INDEX))
-                .where(ADDRESS_UTXO.OWNER_ADDR.eq(address))
-                .and(TX_INPUT.TX_HASH.isNull())
-                .and(field(ADDRESS_UTXO.AMOUNTS).cast(String.class).contains("\"unit\": \""+unit+"\""))
-                //.orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: Ordering
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        return query.fetch().into(AddressUtxo.class);
+        return utxoRepository.findByAddressAndAssetUnit(address, unit, pageable)
+                .map(mapper::toAddressUtxo)
+                .toList();
     }
 
     @Override
     public List<AddressUtxo> findUtxoByPaymentCredential(@NonNull String paymentCredential, int page, int count, Order order) {
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
         return utxoRepository.findUnspentByOwnerPaymentCredential(paymentCredential, pageable)
                 .stream()
@@ -105,28 +70,16 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
 
     @Override
     public List<AddressUtxo> findUtxoByPaymentCredentialAndAsset(String paymentCredential, String unit, int page, int count, Order order) {
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
-        var query = dsl
-                .select(ADDRESS_UTXO.fields())
-                .from(ADDRESS_UTXO)
-                .leftJoin(TX_INPUT)
-                .using(field(ADDRESS_UTXO.TX_HASH), field(ADDRESS_UTXO.OUTPUT_INDEX))
-                .where(ADDRESS_UTXO.OWNER_PAYMENT_CREDENTIAL.eq(paymentCredential))
-                .and(TX_INPUT.TX_HASH.isNull())
-                .and(field(ADDRESS_UTXO.AMOUNTS).cast(String.class).contains("\"unit\": \""+unit+"\""))
-                //.orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc()) //TODO ordering
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        return query.fetch().into(AddressUtxo.class);
+        return utxoRepository.findByOwnerPaymentCredentialAndAssetUnit(paymentCredential, unit, pageable)
+                .map(mapper::toAddressUtxo)
+                .toList();
     }
 
     @Override
     public List<AddressUtxo> findUtxoByStakeAddress(@NonNull String stakeAddress, int page, int count, Order order) {
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
         return utxoRepository.findUnspentByOwnerStakeAddr(stakeAddress, pageable)
                 .stream()
@@ -138,27 +91,11 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
     public List<AddressUtxo> findUtxoByStakeAddressAndAsset(@NonNull String stakeAddress, String unit, int page, int count, Order order) {
         stakeAddress = stakeAddress.trim();
 
-        Pageable pageable = PageRequest.of(page, count)
-                .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+        Pageable pageable = getPageable(page, count, order);
 
-        var query = dsl
-                .select(ADDRESS_UTXO.fields())
-                .from(ADDRESS_UTXO)
-                .leftJoin(TX_INPUT)
-                .using(field(ADDRESS_UTXO.TX_HASH), field(ADDRESS_UTXO.OUTPUT_INDEX))
-                .where(ADDRESS_UTXO.OWNER_STAKE_ADDR.eq(stakeAddress))
-                .and(TX_INPUT.TX_HASH.isNull())
-                .and(field(ADDRESS_UTXO.AMOUNTS).cast(String.class).contains("\"unit\": \""+unit+"\""))
-                // .orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: ordering
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        return query.fetch().into(AddressUtxo.class);
-    }
-
-    @Override
-    public List<Long> findNextAvailableBlocks(Long block, int limit) {
-        return utxoRepository.findNextAvailableBlocks(block, limit);
+        return utxoRepository.findByOwnerStakeAddressAndAssetUnit(stakeAddress, unit, pageable)
+                .map(mapper::toAddressUtxo)
+                .toList();
     }
 
     @Override
@@ -170,32 +107,6 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
         return utxoRepository.findAllById(utxoIds)
                 .stream().map(mapper::toAddressUtxo)
                 .toList();
-    }
-
-    @Override
-    public List<AddressUtxo> findUnspentUtxosBetweenBlocks(Long startBlock, Long endBlock) {
-        return utxoRepository.findByBlockNumberBetween(startBlock, endBlock)
-                .stream().map(mapper::toAddressUtxo)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    @Override
-    public List<Tuple<AddressUtxo, TxInput>> findSpentUtxosBetweenBlocks(Long startBlock, Long endBlock) {
-        List<Object[]> objects = utxoRepository.findBySpentAtBlockBetween(startBlock, endBlock);
-        if (objects == null)
-            return Collections.emptyList();
-
-        return objects.stream().map(result -> {
-            var addressUtxoEntity = (AddressUtxoEntity) result[0];
-            var addressUtxo = mapper.toAddressUtxo(addressUtxoEntity);
-
-            var txInputEntity = (TxInputEntity) result[1];
-            var txInput = mapper.toTxInput(txInputEntity);
-
-            return new Tuple<>(addressUtxo, txInput);
-        }).collect(Collectors.toList());
-
     }
 
     private static PageRequest getPageable(int page, int count, Order order) {

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/mapper/UtxoMapperDecorator.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/mapper/UtxoMapperDecorator.java
@@ -22,6 +22,14 @@ public class UtxoMapperDecorator implements UtxoMapper {
             entity.setOwnerAddrFull(addressUtxo.getOwnerAddr());
         }
 
+        entity.getAmounts()
+                .stream()
+                .forEach(amtEntity -> {
+                    amtEntity.setTxHash(entity.getTxHash());
+                    amtEntity.setOutputIndex(entity.getOutputIndex());
+                    amtEntity.setSlot(entity.getSlot());
+                });
+
         return entity;
     }
 

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AddressUtxoEntity.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AddressUtxoEntity.java
@@ -1,15 +1,12 @@
 package com.bloxbean.cardano.yaci.store.utxo.storage.impl.model;
 
-import com.bloxbean.cardano.yaci.store.common.domain.Amt;
 import com.bloxbean.cardano.yaci.store.common.model.BlockAwareEntity;
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.Type;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -58,8 +55,8 @@ public class AddressUtxoEntity extends BlockAwareEntity {
     @Column(name = "lovelace_amount")
     private BigInteger lovelaceAmount;
 
-    @Type(JsonType.class)
-    private List<Amt> amounts;
+    @OneToMany(mappedBy = "addressUtxo", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<AmtEntity> amounts;
 
     @Column(name = "data_hash")
     private String dataHash;

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AmountId.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AmountId.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.yaci.store.utxo.storage.impl.model;
+
+import jakarta.persistence.Column;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class AmountId implements Serializable {
+    @Column(name = "tx_hash")
+    private String txHash;
+    @Column(name = "output_index")
+    private Integer outputIndex;
+    @Column(name = "unit")
+    private String unit;
+}

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AmtEntity.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/model/AmtEntity.java
@@ -1,0 +1,49 @@
+package com.bloxbean.cardano.yaci.store.utxo.storage.impl.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigInteger;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "utxo_amount")
+@IdClass(AmountId.class)
+public class AmtEntity {
+    @Id
+    @Column(name = "tx_hash")
+    private String txHash;
+    @Id
+    @Column(name = "output_index")
+    private Integer outputIndex;
+    @Id
+    @Column(name = "unit")
+    private String unit;
+
+    @Column(name = "policy")
+    private String policyId;
+
+    @Column(name = "asset_name")
+    private String assetName;
+
+    @Column(name = "quantity")
+    private BigInteger quantity;
+
+    @Column(name = "slot")
+    private Long slot;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "tx_hash", referencedColumnName = "tx_hash", insertable = false, updatable = false),
+            @JoinColumn(name = "output_index", referencedColumnName = "output_index", insertable = false, updatable = false)
+    })
+    private AddressUtxoEntity addressUtxo;
+}

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/repository/AmtRepository.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/repository/AmtRepository.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.AmountId;
+import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.AmtEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AmtRepository extends JpaRepository<AmtEntity, AmountId> {
+    int deleteBySlotGreaterThan(Long slot);
+}
+

--- a/stores/utxo/src/main/resources/db/store/h2/V0_200_1__init.sql
+++ b/stores/utxo/src/main/resources/db/store/h2/V0_200_1__init.sql
@@ -2,13 +2,12 @@
 drop table if exists address_utxo;
 create table address_utxo
 (
-    output_index          int          not null,
     tx_hash               varchar(64) not null,
+    output_index          int          not null,
     slot                  bigint,
     block_hash            varchar(64),
     epoch                 int,
     lovelace_amount       bigint       null,
-    amounts               json         null,
     data_hash             varchar(64) null,
     inline_datum          clob     null,
     owner_addr            varchar(500) null,
@@ -45,6 +44,31 @@ CREATE INDEX idx_reference_script_hash
 
 CREATE INDEX idx_address_utxo_epoch
     ON address_utxo(epoch);
+
+drop table if exists utxo_amount;
+create table utxo_amount
+(
+    tx_hash                 varchar(64) not null,
+    output_index            int      not null,
+    unit                    varchar(255),
+    quantity                numeric(38)  null,
+    policy                  varchar(56),
+    asset_name              varchar(255),
+    slot                    bigint,
+    primary key (tx_hash, output_index, unit)
+);
+
+CREATE INDEX idx_utxo_amount_slot
+    ON utxo_amount(slot);
+
+CREATE INDEX idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
 
 -- tx_input
 drop table if exists tx_input;

--- a/stores/utxo/src/main/resources/db/store/mysql/V0_200_1__init.sql
+++ b/stores/utxo/src/main/resources/db/store/mysql/V0_200_1__init.sql
@@ -2,13 +2,12 @@
 drop table if exists address_utxo;
 create table address_utxo
 (
-    output_index          smallint    not null,
     tx_hash               varchar(64) not null,
+    output_index          smallint    not null,
     slot                  bigint,
     block_hash            varchar(64),
     epoch                 int,
     lovelace_amount       bigint       null,
-    amounts               json         null,
     data_hash             varchar(64) null,
     inline_datum          longtext     null,
     owner_addr            varchar(500) null,
@@ -45,6 +44,32 @@ CREATE INDEX idx_reference_script_hash
 
 CREATE INDEX idx_address_utxo_epoch
     ON address_utxo(epoch);
+
+-- utxo_amount
+drop table if exists utxo_amount;
+create table utxo_amount
+(
+    tx_hash                 varchar(64)   not null,
+    output_index            smallint      not null,
+    unit                    varchar(255),
+    quantity                numeric(38)  null,
+    policy                  varchar(56),
+    asset_name              varchar(255),
+    slot                    bigint,
+    primary key (tx_hash, output_index, unit)
+);
+
+CREATE INDEX idx_utxo_amount_slot
+    ON utxo_amount(slot);
+
+CREATE INDEX idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
 
 -- tx_input
 drop table if exists tx_input;

--- a/stores/utxo/src/main/resources/db/store/postgresql/V0_200_1__init.sql
+++ b/stores/utxo/src/main/resources/db/store/postgresql/V0_200_1__init.sql
@@ -2,13 +2,12 @@
 drop table if exists address_utxo;
 create table address_utxo
 (
-    output_index          smallint      not null,
     tx_hash               varchar(64) not null,
+    output_index          smallint    not null,
     slot                  bigint,
     block_hash            varchar(64),
     epoch                 integer,
     lovelace_amount       bigint       null,
-    amounts               jsonb,
     data_hash             varchar(64),
     inline_datum          text,
     owner_addr            varchar(500),
@@ -45,6 +44,31 @@ CREATE INDEX idx_reference_script_hash
 
 CREATE INDEX idx_address_utxo_epoch
     ON address_utxo(epoch);
+
+drop table if exists utxo_amount;
+create table utxo_amount
+(
+    tx_hash                 varchar(64) not null,
+    output_index            smallint    not null,
+    unit                    varchar(255),
+    quantity                numeric(38)  null,
+    policy                  varchar(56),
+    asset_name              varchar(255),
+    slot                    bigint,
+    primary key (tx_hash, output_index, unit)
+);
+
+CREATE INDEX idx_utxo_amount_slot
+    ON utxo_amount(slot);
+
+CREATE INDEX idx_utxo_amount_unit
+    ON utxo_amount(unit);
+
+CREATE INDEX idx_utxo_amount_policy
+    ON utxo_amount(policy);
+
+CREATE INDEX idx_utxo_amount_asset_name
+    ON utxo_amount(asset_name);
 
 
 -- tx_input

--- a/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoRollbackProcessorIT.java
+++ b/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoRollbackProcessorIT.java
@@ -1,16 +1,22 @@
 package com.bloxbean.cardano.yaci.store.utxo.processor;
 
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
 import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorage;
+import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.AmtRepository;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.UtxoRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.SqlGroup;
 
+import java.math.BigInteger;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SpringBootTest
 public class UtxoRollbackProcessorIT {
@@ -21,21 +27,147 @@ public class UtxoRollbackProcessorIT {
     @Autowired
     private UtxoRepository utxoRepository;
 
+    @Autowired
+    private AmtRepository amtRepository;
+
+    @Autowired
+    private UtxoStorage utxoStorage;
 
     @Test
-    @SqlGroup({
-            @Sql(value = "classpath:scripts/address_utxo_data.sql", executionPhase = BEFORE_TEST_METHOD)
-    })
     void givenRollbackEvent_shouldDeleteAddressUtxos() throws Exception {
+        AddressUtxo utxo1 = AddressUtxo.builder()
+                .txHash("143844cb3e41c41d6c1e2aec22b83bf909d3ea286eb2bc8c806c8b99b11774c7")
+                .outputIndex(0)
+                .ownerAddr("addr_test1wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeAddr("stake_test1wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeCredential("wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .lovelaceAmount(adaToLovelace(1000))
+                .amounts(List.of(Amt.builder()
+                        .unit("lovelace")
+                        .quantity(BigInteger.valueOf(1000))
+                        .build(),
+                        Amt.builder()
+                                .unit("0254a6ffa78edb03ea8933dbd4ca078758dbfc0fc6bb0d28b7a9c89f4c454e4649")
+                                .quantity(BigInteger.valueOf(2))
+                                .build()
+                )).slot(2000L)
+                .blockNumber(200L)
+                .blockTime(1600098L)
+                .build();
+
+        AddressUtxo utxo2 = AddressUtxo.builder()
+                .txHash("243844cb3e41c41d6c1e2aec22b83bf909d3ea286eb2bc8c806c8b99b11774c7")
+                .outputIndex(2)
+                .ownerAddr("addr_test1pq6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeAddr("stake_test1pq6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeCredential("pq6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .lovelaceAmount(adaToLovelace(3))
+                .amounts(List.of(Amt.builder()
+                                .unit("lovelace")
+                                .quantity(BigInteger.valueOf(2))
+                                .build(),
+                        Amt.builder()
+                                .unit("9954a6ffa78edb03ea8933dbd4ca078758dbfc0fc6bb0d28b7a9c89f4c454e4649")
+                                .quantity(BigInteger.valueOf(333))
+                                .build(),
+                        Amt.builder()
+                                .unit("8854a6ffa78edb03ea8933dbd4ca078758dbfc0fc6bb0d28b7a9c89f4c454e4649")
+                                .quantity(BigInteger.valueOf(2))
+                                .build()
+                )).slot(3000L)
+                .blockNumber(300L)
+                .blockTime(1600098L)
+                .build();
+
+        AddressUtxo utxo3 = AddressUtxo.builder()
+                .txHash("343844cb3e41c41d6c1e2aec22b83bf909d3ea286eb2bc8c806c8b99b11774c7")
+                .outputIndex(0)
+                .ownerAddr("addr_test1wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeAddr("stake_test1wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeCredential("wz6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .lovelaceAmount(adaToLovelace(8))
+                .amounts(List.of(Amt.builder()
+                                .unit("lovelace")
+                                .quantity(BigInteger.valueOf(8))
+                                .build()
+                )).slot(4000L)
+                .blockNumber(400L)
+                .blockTime(1600098L)
+                .build();
+
+        AddressUtxo utxo4 = AddressUtxo.builder()
+                .txHash("443844cb3e41c41d6c1e2aec22b83bf909d3ea286eb2bc8c806c8b99b11774c7")
+                .outputIndex(45)
+                .ownerAddr("addr_test1lm6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeAddr("stake_test1lm6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .ownerStakeCredential("lm6zjuut6mx93dw8jvksqx4zh5zul6j8qg992myvw575gdsgwxjuc")
+                .lovelaceAmount(adaToLovelace(9000))
+                .amounts(List.of(Amt.builder()
+                                .unit("lovelace")
+                                .quantity(BigInteger.valueOf(9000))
+                                .build(),
+                        Amt.builder()
+                                .unit("1454a6ffa78edb03ea8933dbd4ca078758dbfc0fc6bb0d28b7a9c89f4c454e4649")
+                                .quantity(BigInteger.valueOf(56666666))
+                                .build()
+                )).slot(5000L)
+                .blockNumber(500L)
+                .blockTime(1600098L)
+                .build();
+
+        var utxos = List.of(utxo1, utxo2, utxo3, utxo4);
+
+        //Save utxos
+        utxoStorage.saveUnspent(utxos);
+
+        var utxoKeys = utxos.stream()
+                        .map(utxo -> new UtxoKey(utxo.getTxHash(), utxo.getOutputIndex()))
+                        .toList();
+
+        var savedUtxos = utxoStorage.findAllByIds(utxoKeys);
+        var saveAmts = amtRepository.findAll();
+
+        //Assert saved data
+        assertThat(savedUtxos.size()).isEqualTo(4);
+        assertThat(savedUtxos.get(0).getAmounts().size() > 0);
+        assertThat(saveAmts.size()).isEqualTo(8);
+
+        //Rollback
         RollbackEvent rollbackEvent = RollbackEvent.builder()
-                .rollbackTo(new Point(44185446, "925347abf637eb2d436349b78589bb257e396c0a4cc133236b76e56ffebc57bb"))
-                .currentPoint(new Point(44185802, "64069e4f2351d25a572189c0df03f2c9e0a1200b9fe897cc5fb74106ed6ed6ad"))
+                .rollbackTo(new Point(3000, "925347abf637eb2d436349b78589bb257e396c0a4cc133236b76e56ffebc57bb"))
+                .currentPoint(new Point(9000, "64069e4f2351d25a572189c0df03f2c9e0a1200b9fe897cc5fb74106ed6ed6ad"))
                 .build();
 
         utxoRollbackProcessor.handleRollbackEvent(rollbackEvent);
 
-        int count = utxoRepository.findAll().size();
-        assertThat(count).isEqualTo(14);
+        var allUtxos = utxoRepository.findAll();
+        var allAmts = amtRepository.findAll();
+
+        assertThat(allUtxos).hasSize(2);
+        assertThat(allAmts).hasSize(5);
+
+        assertThat(allUtxos.get(0).getTxHash()).isEqualTo(utxo1.getTxHash());
+        assertThat(allUtxos.get(0).getOutputIndex()).isEqualTo(utxo1.getOutputIndex());
+        assertThat(allUtxos.get(0).getSlot()).isEqualTo(utxo1.getSlot());
+        assertThat(allUtxos.get(0).getBlockNumber()).isEqualTo(utxo1.getBlockNumber());
+        assertThat(allUtxos.get(0).getAmounts()).hasSize(utxo1.getAmounts().size());
+        assertThat(allUtxos.get(0).getAmounts().stream().map(amtEntity -> Amt.builder()
+                .unit(amtEntity.getUnit())
+                .quantity(amtEntity.getQuantity())
+                .build()
+        ).toList()).contains(utxo1.getAmounts().toArray(new Amt[0]));
+
+        assertThat(allUtxos.get(1).getTxHash()).isEqualTo(utxo2.getTxHash());
+        assertThat(allUtxos.get(1).getOutputIndex()).isEqualTo(utxo2.getOutputIndex());
+        assertThat(allUtxos.get(1).getSlot()).isEqualTo(utxo2.getSlot());
+        assertThat(allUtxos.get(1).getBlockNumber()).isEqualTo(utxo2.getBlockNumber());
+        assertThat(allUtxos.get(1).getAmounts()).hasSize(utxo2.getAmounts().size());
+        assertThat(allUtxos.get(1).getAmounts().stream().map(amtEntity -> Amt.builder()
+                .unit(amtEntity.getUnit())
+                .quantity(amtEntity.getQuantity())
+                .build()
+        ).toList()).contains(utxo2.getAmounts().toArray(new Amt[0]));
+
     }
 
 }

--- a/stores/utxo/src/test/resources/application.yml
+++ b/stores/utxo/src/test/resources/application.yml
@@ -39,5 +39,6 @@ logging:
 store:
   cardano:
     protocol-magic: 764824073
+  sync-auto-start: false
 
 


### PR DESCRIPTION
Currently, the ``address_utxo`` table is used to store UTXOs, including their amounts. The ``amount`` field is a JSON field used to store a json array of amounts for the UTXO. This simplifies the saving and retrieval of UTXO in one query.

However, this creates complexity when we need to calculate the account balance based on current UTXOs. The application needs to retrieve all UTXO records for an address to the application layer and perform the aggregation in the Java layer. Also, searching by unit, policy, etc., requires a JSON query.

**Requirements:**
- Balance aggregation using utxos in db queries
- Simplify utxo search by unit, policy, asset name

**Changes**

- Create a new table utxo_amount to store UTXO amounts with the primary key tx_hash, output_index, and unit.
- Update all read queries.

**Performance**

- There is no major performance impact on sync time due to this change for test networks.

**TODO:** Mainnet sync test pending
