### PR TITLE
Real-time balance history deletion

### DIFF
--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreConfiguration.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreConfiguration.java
@@ -37,8 +37,8 @@ public class AccountStoreConfiguration {
     @ConditionalOnMissingBean
     public AccountBalanceStorage accountBalanceStorage(AddressBalanceRepository addressBalanceRepository,
                                                        StakeBalanceRepository stakeBalanceRepository, DSLContext dslContext,
-                                                       StoreProperties storeProperties) {
-        return new AccountBalanceStorageImpl(addressBalanceRepository, stakeBalanceRepository, dslContext, storeProperties);
+                                                       StoreProperties storeProperties, AccountStoreProperties accountStoreProperties) {
+        return new AccountBalanceStorageImpl(addressBalanceRepository, stakeBalanceRepository, dslContext, storeProperties, accountStoreProperties);
     }
 
     @Bean

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
@@ -22,6 +22,8 @@ public class AccountStoreProperties {
     private int balanceHistoryCleanupInterval = 300;
     @Builder.Default
     private long balanceCleanupSlotCount = 43200; //2160 blocks
+    @Builder.Default
+    private long balanceCleanupBatchThreshold = 20000;
 
     @Builder.Default
     private boolean saveAddressTxAmount = false;

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/AccountBalanceStorage.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/AccountBalanceStorage.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.account.storage;
 import com.bloxbean.cardano.yaci.store.account.domain.AddressBalance;
 import com.bloxbean.cardano.yaci.store.account.domain.StakeAddressBalance;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import org.springframework.data.util.Pair;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,13 +45,37 @@ public interface AccountBalanceStorage {
 
     /**
      * Delete all address balances before the slot except the top one
+     * This method is called when {@link #isBatchDeleteSupported()} returns false.
      * This is called to clean history data
+     * <p></p>
+     * This is deprecated and should not be used. Use {@link #deleteAddressBalanceBeforeSlotExceptTop(List, long)}
+     *
      * @param address address
      * @param unit unit
      * @param slot slot
      * @return number of records deleted
      */
+    @Deprecated
     int deleteAddressBalanceBeforeSlotExceptTop(String address, String unit, long slot);
+
+    /**
+     * Delete all address balance records before the slot except the top one. This method is called when batch delete is supported.
+     * {@link #isBatchDeleteSupported()}
+     * This is called to clean history data
+     * @param addresUnits List of Pairs of address and unit
+     * @param slot slot
+     * @return number of records deleted
+     */
+    int deleteAddressBalanceBeforeSlotExceptTop(List<Pair<String,String>> addresUnits, long slot);
+
+    /**
+     * Check if batch delete is supported.
+     * If supported, {@link #deleteAddressBalanceBeforeSlotExceptTop(List, long)} will be called during history cleanup.
+     * @return
+     */
+    default boolean isBatchDeleteSupported() {
+        return false;
+    }
 
     /**
      * Delete all address balances after the slot
@@ -99,11 +124,23 @@ public interface AccountBalanceStorage {
     /**
      * Delete all stake address balances before the slot except the top one
      * This is called to clean history data
+     * <p></p>
+     * This method is deprecated and should not be used. Use {@link #deleteStakeBalanceBeforeSlotExceptTop(List, long)}
      * @param address address
      * @param slot slot
      * @return number of records deleted
      */
     int deleteStakeBalanceBeforeSlotExceptTop(String address, long slot);
+
+    /**
+     * Delete all stake address balances before the slot except the top. This method is called when batch delete is supported.
+     * {@link #isBatchDeleteSupported()}
+     * This is called to clean history data
+     * @param addresses List of addresses
+     * @param slot slot
+     * @return number of records deleted
+     */
+    int deleteStakeBalanceBeforeSlotExceptTop(List<String> addresses, long slot);
 
     /**
      * Delete all stake address balances after the slot

--- a/extensions/account-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/account/rocksdb/RocksDBAccountBalanceStorageImpl.java
+++ b/extensions/account-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/account/rocksdb/RocksDBAccountBalanceStorageImpl.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.util.Pair;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -137,6 +138,11 @@ public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
+    @Override
+    public int deleteAddressBalanceBeforeSlotExceptTop(List<Pair<String, String>> addressUnitPairs, long slot) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
     @SneakyThrows
     @Override
     public int deleteAddressBalanceBySlotGreaterThan(Long slot) {
@@ -230,6 +236,11 @@ public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
 
     @Override
     public int deleteStakeBalanceBeforeSlotExceptTop(String address, long slot) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public int deleteStakeBalanceBeforeSlotExceptTop(List<String> addresses, long slot) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
@@ -24,6 +24,7 @@ public class AccountStoreAutoConfigProperties {
 
         private int balanceHistoryCleanupInterval = 300;
         private long balanceCleanupSlotCount = 43200; //2160 blocks
+        private long balanceCleanupBatchThreshold = 20000;
 
         private boolean saveAddressTxAmount = false;
         private boolean addressTxAmountIncludeZeroAmount = false;

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
@@ -29,6 +29,7 @@ public class AccountStoreAutoConfiguration {
         accountStoreProperties.setStakeAddressBalanceEnabled(properties.getAccount().isStakeAddressBalanceEnabled());
 
         accountStoreProperties.setBalanceCleanupSlotCount(properties.getAccount().getBalanceCleanupSlotCount());
+        accountStoreProperties.setBalanceCleanupBatchThreshold(properties.getAccount().getBalanceCleanupBatchThreshold());
 
         accountStoreProperties.setSaveAddressTxAmount(properties.getAccount().isSaveAddressTxAmount());
         accountStoreProperties.setAddressTxAmountIncludeZeroAmount(properties.getAccount().isAddressTxAmountIncludeZeroAmount());

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -185,6 +185,8 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setUseVirtualThreadForBatchProcessing(properties.getExecutor().isUseVirtualThreadForBatchProcessing());
         storeProperties.setUseVirtualThreadForEventProcessing(properties.getExecutor().isUseVirtualThreadForEventProcessing());
 
+        storeProperties.setProcessingThreadsTimeout(properties.getExecutor().getProcessingThreadsTimeout());
+
         storeProperties.setDbBatchSize(properties.getDb().getBatchSize());
         storeProperties.setDbParallelInsert(properties.getDb().isParallelInsert());
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -75,6 +75,10 @@ public class YaciStoreProperties {
         private int blocksPartitionSize=10;
         private boolean useVirtualThreadForBatchProcessing;
         private boolean useVirtualThreadForEventProcessing;
+        /**
+         * Timeout in seconds for processing threads
+         */
+        private int processingThreadsTimeout = 5;
     }
 
     @Getter

--- a/stores-api/utxo-api/build.gradle
+++ b/stores-api/utxo-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(":stores:utxo")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
 
     testImplementation project(':starters:spring-boot-starter')
 }

--- a/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/UtxoApiConfiguration.java
+++ b/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/UtxoApiConfiguration.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.api.utxo;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
 @ConditionalOnProperty(name = {"store.utxo.enabled", "store.utxo.api-enabled"},
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
         matchIfMissing = true
 )
 @ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.api.utxo"})
+@EnableRetry
 public class UtxoApiConfiguration {
 
 }

--- a/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/client/RetryableUtxoClient.java
+++ b/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/client/RetryableUtxoClient.java
@@ -1,0 +1,69 @@
+package com.bloxbean.cardano.yaci.store.api.utxo.client;
+
+import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Utxo;
+import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Retryable Utxo client. Retries 5 times with backoff delay of 2 sec and multiplier of 2.
+ * If the retry fails, it throws IllegalStateException
+ */
+@Component("retryableUtxoClient")
+@Qualifier("retryableUtxoClient")
+@Slf4j
+public class RetryableUtxoClient implements UtxoClient {
+
+    private final UtxoClient delegate;
+
+    public RetryableUtxoClient(UtxoClient utxoClient) {
+        this.delegate = utxoClient;
+    }
+
+    @Retryable(value = {Exception.class}, maxAttempts = 5, backoff = @Backoff(delay = 2000, multiplier = 2))
+    @Override
+    public List<AddressUtxo> getUtxosByIds(List<UtxoKey> utxoIds) {
+        if (log.isDebugEnabled()) {
+            log.info("Trying to get utxo by ids.." + utxoIds);
+        }
+
+        var utxos = delegate.getUtxosByIds(utxoIds);
+
+        if (utxos.size() != utxoIds.size()) {
+            var fetchedUtxoKeys = utxos.stream().map(addressUtxo -> new UtxoKey(addressUtxo.getTxHash(), addressUtxo.getOutputIndex()))
+                    .toList();
+            var missingKeys = utxoIds.stream().filter(utxoKey -> !fetchedUtxoKeys.contains(utxoKey)).toList();
+
+            throw new IllegalStateException("Utxos not found for all ids : " + missingKeys);
+        } else
+            return utxos;
+    }
+
+    @Retryable(value = {Exception.class}, maxAttempts = 5, backoff = @Backoff(delay = 2000, multiplier = 2))
+    @Override
+    public Optional<AddressUtxo> getUtxoById(UtxoKey utxoId) {
+        if (log.isDebugEnabled()) {
+            log.info("Trying to get utxo by id.." + utxoId);
+        }
+
+        var utxo = delegate.getUtxoById(utxoId);
+        if (utxo.isEmpty())
+            throw new IllegalStateException("Utxo not found for id" + utxoId);
+        else
+            return utxo;
+    }
+
+    @Retryable(value = {Exception.class}, maxAttempts = 5, backoff = @Backoff(delay = 2000, multiplier = 2))
+    @Override
+    public List<Utxo> getUtxoByAddress(String address, int page, int count) {
+        return delegate.getUtxoByAddress(address, page, count);
+    }
+}


### PR DESCRIPTION
- Delete balance records in batch through sql during real-time balance calculation. Currently it's done one by one.
- Introduce RetryableUtxoClient to retry in case of failure to fetch utxos. (Used in Address balance calculation and Address Tx amount processor)
- Added new properties to auto-configuration 