### PR TITLE
Utxo and Balance Pruning Service - Optimization (WIP)

### DIFF
--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
@@ -40,4 +40,13 @@ public class AccountStoreProperties {
 
     @Builder.Default
     private String balanceCalcBatchMode = "utxo";
+
+    @Builder.Default
+    private boolean pruningEnabled = false;
+
+    @Builder.Default
+    private int pruningBatchSize = 3000;
+
+    @Builder.Default
+    private int pruningInterval = 86400;
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/scheduler/BalancePruningService.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/scheduler/BalancePruningService.java
@@ -1,0 +1,182 @@
+package com.bloxbean.cardano.yaci.store.account.scheduler;
+
+import com.bloxbean.cardano.yaci.store.account.AccountStoreProperties;
+import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.events.EpochChangeEvent;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.DSLContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+@ConditionalOnProperty(
+        value="store.account.pruning-enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+@RequiredArgsConstructor
+@Slf4j
+public class BalancePruningService {
+    private final CursorService cursorService;
+    private final AccountStoreProperties accountStoreProperties;
+    private final DSLContext dslContext;
+    private final PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate transactionTemplate;
+
+    private AtomicBoolean isPruning = new AtomicBoolean(false);
+
+    @PostConstruct
+    public void init() {
+        log.info("<< Balance Pruning Service Enabled >>");
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Scheduled(fixedRateString = "${store.account.pruning-interval:86400}", timeUnit = TimeUnit.SECONDS, initialDelay = 60)
+    public void handleUtxoPruning() {
+        if (accountStoreProperties.isHistoryCleanupEnabled()) {
+            if (log.isDebugEnabled())
+                log.debug("Account balance pruning is disabled as history cleanup is enabled. Skipping this run !!!");
+            return;
+        }
+
+        if (isPruning.get()) {
+            log.info("Account balance pruning is already in progress. Skipping this run !!!");
+            return;
+        }
+
+        Thread.startVirtualThread(() -> deleteAddressBalance());
+    }
+
+    @EventListener
+    @Transactional
+    public void handleEpochChangeEvent(EpochChangeEvent epochChangeEvent) {
+        if (accountStoreProperties.isHistoryCleanupEnabled()) {
+            log.info("Account balance pruning is disabled as history cleanup is enabled. Skipping this run !!!");
+            return;
+        }
+
+        if (isPruning.get()) {
+            log.info("Account Balance pruning is already in progress. Skipping this run !!!");
+            return;
+        }
+
+        Thread.startVirtualThread(() -> deleteAddressBalance());
+    }
+
+    private void deleteAddressBalance() {
+        isPruning.set(true);
+        try {;
+            cursorService.getCursor().ifPresent(cursor -> {
+                long deleteBlockCount = accountStoreProperties.getBalanceCleanupSlotCount() / 20;
+                var block = cursor.getBlock() - deleteBlockCount;
+
+                log.info(">> Pruning account balance records before block: {}", cursor.getBlock() - deleteBlockCount);
+
+                if (block > 0) {
+                    long t1 = System.currentTimeMillis();
+                    long deleteCount = performAddressBalanceDelete(block);
+                    long deleteStakeCount = performStakeAddressBalanceDelete(block);
+                    long t2 = System.currentTimeMillis();
+                    log.info(">> Deleted {} address_balance, {} stake_address_balance - before block {}, Time taken: {} ms",
+                            deleteCount, deleteStakeCount, block, (t2 - t1));
+                }
+            });
+        } finally {
+            isPruning.set(false);
+        }
+    }
+
+    private long performAddressBalanceDelete(long block) {
+        int count = 0;
+        long totalCount = 0;
+        int limit = accountStoreProperties.getPruningBatchSize();
+
+        int repeatCount = 0;
+        do {
+            count = transactionTemplate.execute(status -> {
+                String query = """
+                                WITH rows_to_delete AS (SELECT address, unit, slot
+                                                        FROM address_balance a1
+                                                        WHERE a1.block < ?
+                                                          AND EXISTS (SELECT 1
+                                                                      FROM address_balance a2
+                                                                      WHERE a1.address = a2.address
+                                                                        AND a1.unit = a2.unit
+                                                                        AND a1.block < a2.block)                                                          
+                                                        LIMIT ?
+                                                        )
+                                delete
+                                FROM address_balance
+                                WHERE (address, unit, slot) IN (SELECT address, unit, slot FROM rows_to_delete)
+                            """;
+
+                return dslContext.execute(query, block, limit);
+            });
+
+            totalCount += count;
+            if (log.isDebugEnabled())
+                log.debug("Deleted {} address_balance records", count);
+
+            repeatCount++;
+            if (repeatCount % 20 == 0) {
+                log.info("Total address_balance records deleted: {}", totalCount);
+            }
+
+        } while (count > 0);
+
+        return totalCount;
+    }
+
+    private long performStakeAddressBalanceDelete(long block) {
+        int count = 0;
+        long totalCount = 0;
+        int limit = accountStoreProperties.getPruningBatchSize();
+
+        int repeatCount = 0;
+        do {
+            count = transactionTemplate.execute(status -> {
+                String query = """
+                                WITH rows_to_delete AS (SELECT address, slot
+                                                        FROM stake_address_balance a1
+                                                        WHERE a1.block < ?
+                                                          AND EXISTS (SELECT 1
+                                                                      FROM stake_address_balance a2
+                                                                      WHERE a1.address = a2.address                                                                    
+                                                                        AND a1.block < a2.block)                                                          
+                                                        LIMIT ?
+                                                        )
+                                delete
+                                FROM stake_address_balance
+                                WHERE (address, slot) IN (SELECT address, slot FROM rows_to_delete)
+                            """;
+
+                return dslContext.execute(query, block, limit);
+            });
+
+            totalCount += count;
+            if (log.isDebugEnabled())
+                log.debug("Deleted {} stake_address_balance records", count);
+
+            repeatCount++;
+            if (repeatCount % 20 == 0) {
+                log.info("Total stake_address_balance records deleted: {}", totalCount);
+            }
+
+        } while (count > 0);
+
+        return totalCount;
+    }
+}

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/scheduler/BalancePruningService.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/scheduler/BalancePruningService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.account.scheduler;
 
 import com.bloxbean.cardano.yaci.store.account.AccountStoreProperties;
 import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.core.service.EraService;
 import com.bloxbean.cardano.yaci.store.events.EpochChangeEvent;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Slf4j
 public class BalancePruningService {
     private final CursorService cursorService;
+    private final EraService eraService;
     private final AccountStoreProperties accountStoreProperties;
     private final DSLContext dslContext;
     private final PlatformTransactionManager transactionManager;
@@ -47,13 +50,12 @@ public class BalancePruningService {
     @Scheduled(fixedRateString = "${store.account.pruning-interval:86400}", timeUnit = TimeUnit.SECONDS, initialDelay = 60)
     public void handleUtxoPruning() {
         if (accountStoreProperties.isHistoryCleanupEnabled()) {
-            if (log.isDebugEnabled())
-                log.debug("Account balance pruning is disabled as history cleanup is enabled. Skipping this run !!!");
+            log.info("Account balance pruning is disabled as history cleanup is enabled. Skipping this run !!!");
             return;
         }
 
         if (isPruning.get()) {
-            log.info("Account balance pruning is already in progress. Skipping this run !!!");
+            log.debug("Account balance pruning is already in progress. Skipping this run !!!");
             return;
         }
 
@@ -69,7 +71,7 @@ public class BalancePruningService {
         }
 
         if (isPruning.get()) {
-            log.info("Account Balance pruning is already in progress. Skipping this run !!!");
+            log.debug("Account Balance pruning is already in progress. Skipping this run !!!");
             return;
         }
 
@@ -80,18 +82,23 @@ public class BalancePruningService {
         isPruning.set(true);
         try {;
             cursorService.getCursor().ifPresent(cursor -> {
-                long deleteBlockCount = accountStoreProperties.getBalanceCleanupSlotCount() / 20;
-                var block = cursor.getBlock() - deleteBlockCount;
+                var fromSlot = cursor.getSlot() - accountStoreProperties.getBalanceCleanupSlotCount();
 
-                log.info(">> Pruning account balance records before block: {}", cursor.getBlock() - deleteBlockCount);
+                log.info(">> Pruning account balance records before slot: {}", fromSlot);
 
-                if (block > 0) {
+                if (cursor.getEra() != null) {
+                    long blockTime = eraService.blockTime(cursor.getEra(), fromSlot);
+                    Instant instant = Instant.ofEpochMilli(blockTime * 1000);
+                    log.info(">> Pruning account balance records before {}", instant.toString());
+                }
+
+                if (fromSlot > 0) {
                     long t1 = System.currentTimeMillis();
-                    long deleteCount = performAddressBalanceDelete(block);
-                    long deleteStakeCount = performStakeAddressBalanceDelete(block);
+                    long deleteCount = performAddressBalanceDelete(fromSlot);
+                    long deleteStakeCount = performStakeAddressBalanceDelete(fromSlot);
                     long t2 = System.currentTimeMillis();
-                    log.info(">> Deleted {} address_balance, {} stake_address_balance - before block {}, Time taken: {} ms",
-                            deleteCount, deleteStakeCount, block, (t2 - t1));
+                    log.info(">> Deleted {} address_balance, {} stake_address_balance - before slot {}, Time taken: {} ms",
+                            deleteCount, deleteStakeCount, fromSlot, (t2 - t1));
                 }
             });
         } finally {
@@ -99,7 +106,7 @@ public class BalancePruningService {
         }
     }
 
-    private long performAddressBalanceDelete(long block) {
+    private long performAddressBalanceDelete(long fromSlot) {
         int count = 0;
         long totalCount = 0;
         int limit = accountStoreProperties.getPruningBatchSize();
@@ -110,12 +117,12 @@ public class BalancePruningService {
                 String query = """
                                 WITH rows_to_delete AS (SELECT address, unit, slot
                                                         FROM address_balance a1
-                                                        WHERE a1.block < ?
+                                                        WHERE a1.slot < ?
                                                           AND EXISTS (SELECT 1
                                                                       FROM address_balance a2
                                                                       WHERE a1.address = a2.address
                                                                         AND a1.unit = a2.unit
-                                                                        AND a1.block < a2.block)                                                          
+                                                                        AND a1.slot < a2.slot)                                                          
                                                         LIMIT ?
                                                         )
                                 delete
@@ -123,7 +130,7 @@ public class BalancePruningService {
                                 WHERE (address, unit, slot) IN (SELECT address, unit, slot FROM rows_to_delete)
                             """;
 
-                return dslContext.execute(query, block, limit);
+                return dslContext.execute(query, fromSlot, limit);
             });
 
             totalCount += count;
@@ -140,7 +147,7 @@ public class BalancePruningService {
         return totalCount;
     }
 
-    private long performStakeAddressBalanceDelete(long block) {
+    private long performStakeAddressBalanceDelete(long fromSlot) {
         int count = 0;
         long totalCount = 0;
         int limit = accountStoreProperties.getPruningBatchSize();
@@ -151,11 +158,11 @@ public class BalancePruningService {
                 String query = """
                                 WITH rows_to_delete AS (SELECT address, slot
                                                         FROM stake_address_balance a1
-                                                        WHERE a1.block < ?
+                                                        WHERE a1.slot < ?
                                                           AND EXISTS (SELECT 1
                                                                       FROM stake_address_balance a2
                                                                       WHERE a1.address = a2.address                                                                    
-                                                                        AND a1.block < a2.block)                                                          
+                                                                        AND a1.slot < a2.slot)                                                          
                                                         LIMIT ?
                                                         )
                                 delete
@@ -163,7 +170,7 @@ public class BalancePruningService {
                                 WHERE (address, slot) IN (SELECT address, slot FROM rows_to_delete)
                             """;
 
-                return dslContext.execute(query, block, limit);
+                return dslContext.execute(query, fromSlot, limit);
             });
 
             totalCount += count;

--- a/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/config/DefaultConfig.java
+++ b/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/config/DefaultConfig.java
@@ -9,6 +9,7 @@ import org.jooq.DSLContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @ConditionalOnProperty(name = "store.extensions.utxo-storage-type",
@@ -18,8 +19,11 @@ import org.springframework.context.annotation.Configuration;
 public class DefaultConfig {
 
     @Bean
-    public UtxoStorage utxoStorage(UtxoRepository utxoRepository, TxInputRepository spentOutputRepository,
-                                   DSLContext dsl, UtxoCache utxoCache) {
-        return new DummyDBUtxoStorage(utxoRepository, spentOutputRepository, dsl, utxoCache);
+    public UtxoStorage utxoStorage(UtxoRepository utxoRepository,
+                                   TxInputRepository spentOutputRepository,
+                                   DSLContext dsl,
+                                   UtxoCache utxoCache,
+                                   PlatformTransactionManager transactionManager) {
+        return new DummyDBUtxoStorage(utxoRepository, spentOutputRepository, dsl, utxoCache, transactionManager);
     }
 }

--- a/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/storage/DummyDBUtxoStorage.java
+++ b/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/storage/DummyDBUtxoStorage.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yaci.store.utxo.storage.impl.UtxoStorageImpl;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.TxInputRepository;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.UtxoRepository;
 import org.jooq.DSLContext;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.List;
 
@@ -15,8 +16,12 @@ import java.util.List;
  */
 public class DummyDBUtxoStorage extends UtxoStorageImpl {
 
-    public DummyDBUtxoStorage(UtxoRepository utxoRepository, TxInputRepository spentOutputRepository, DSLContext dsl, UtxoCache utxoCache) {
-        super(utxoRepository, spentOutputRepository, dsl, utxoCache);
+    public DummyDBUtxoStorage(UtxoRepository utxoRepository,
+                              TxInputRepository spentOutputRepository,
+                              DSLContext dsl,
+                              UtxoCache utxoCache,
+                              PlatformTransactionManager transactionManager) {
+        super(utxoRepository, spentOutputRepository, dsl, utxoCache, transactionManager);
     }
 
     @Override

--- a/sql/address_balance_cleanup.sql
+++ b/sql/address_balance_cleanup.sql
@@ -1,0 +1,26 @@
+DO
+$$
+    DECLARE
+        deleted_rows int;
+    BEGIN
+        LOOP
+            WITH rows_to_delete AS (SELECT address, unit, slot
+                                    FROM address_balance
+                                    WHERE block < :block_number
+                                      AND EXISTS (SELECT 1
+                                                  FROM address_balance AS a2
+                                                  WHERE address_balance.address = a2.address
+                                                    AND address_balance.unit = a2.unit
+                                                    AND address_balance.block < a2.block)
+                                    LIMIT 5000)
+            DELETE
+            FROM address_balance
+            WHERE (address, unit, slot) IN (SELECT address, unit, slot FROM rows_to_delete);
+            commit;
+
+            GET DIAGNOSTICS deleted_rows = ROW_COUNT; -- Get the number of rows deleted
+            RAISE NOTICE 'Deleted % rows in this batch.', deleted_rows; -- Output the number of rows deleted
+            EXIT WHEN deleted_rows = 0; -- Exit the loop if no rows were deleted
+        END LOOP;
+    END
+$$;

--- a/sql/stake_address_balance_cleanup.sql
+++ b/sql/stake_address_balance_cleanup.sql
@@ -1,0 +1,25 @@
+DO
+$$
+    DECLARE
+        deleted_rows int;
+    BEGIN
+        LOOP
+            WITH rows_to_delete AS (SELECT address, slot
+                                    FROM stake_address_balance
+                                    WHERE block < :block_number
+                                      AND EXISTS (SELECT 1
+                                                  FROM stake_address_balance AS a2
+                                                  WHERE stake_address_balance.address = a2.address
+                                                    AND stake_address_balance.block < a2.block)
+                                    LIMIT 5000)
+            DELETE
+            FROM stake_address_balance
+            WHERE (address, slot) IN (SELECT address, slot FROM rows_to_delete);
+            commit;
+
+            GET DIAGNOSTICS deleted_rows = ROW_COUNT; -- Get the number of rows deleted
+            RAISE NOTICE 'Deleted % rows in this batch.', deleted_rows; -- Output the number of rows deleted
+            EXIT WHEN deleted_rows = 0; -- Exit the loop if no rows were deleted
+        END LOOP;
+    END
+$$;

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
@@ -34,6 +34,19 @@ public class AccountStoreAutoConfigProperties {
         private int balanceCalcJobBatchSize = 1000;
         private int balanceCalcJobPartitionSize = 10;
         private String balanceCalcBatchMode = "utxo";
+
+        /**
+         * Enable Address Balance and Stake Address Balance Pruning (History records)
+         */
+        private boolean pruningEnabled = false;
+        /**
+         * Pruning batch size
+         */
+        private int pruningBatchSize = 3000;
+        /**
+         * Pruning interval in seconds
+         */
+        private int pruningInterval = 86400;
     }
 
 }

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
@@ -39,6 +39,10 @@ public class AccountStoreAutoConfiguration {
         accountStoreProperties.setBalanceCalcJobPartitionSize(properties.getAccount().getBalanceCalcJobPartitionSize());
         accountStoreProperties.setBalanceCalcBatchMode(properties.getAccount().getBalanceCalcBatchMode());
 
+        accountStoreProperties.setPruningEnabled(properties.getAccount().isPruningEnabled());
+        accountStoreProperties.setPruningBatchSize(properties.getAccount().getPruningBatchSize());
+        accountStoreProperties.setPruningInterval(properties.getAccount().getPruningInterval());
+
         return accountStoreProperties;
     }
 }

--- a/starters/admin-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/admin/AdminStoreProperties.java
+++ b/starters/admin-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/admin/AdminStoreProperties.java
@@ -12,7 +12,18 @@ public class AdminStoreProperties {
 
     @Getter
     @Setter
-    public static final class Admin  {
-       private boolean apiEnabled = false;
+    public static final class Admin {
+        /**
+         * Enable admin api
+         */
+        private boolean apiEnabled = false;
+        /**
+         * Enable auto recovery
+         */
+        private boolean autoRecoveryEnabled = false;
+        /**
+         * Health check interval in seconds for auto recovery
+         */
+        private long healthCheckInterval = 120;
     }
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreConfiguration.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
@@ -37,8 +38,8 @@ public class UtxoStoreConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public UtxoStorage utxoStorage(UtxoRepository utxoRepository, TxInputRepository spentOutputRepository, DSLContext dslContext, UtxoCache utxoCache) {
-        return new UtxoStorageImpl(utxoRepository, spentOutputRepository, dslContext, utxoCache);
+    public UtxoStorage utxoStorage(UtxoRepository utxoRepository, TxInputRepository spentOutputRepository, DSLContext dslContext, UtxoCache utxoCache, PlatformTransactionManager transactionManager) {
+        return new UtxoStorageImpl(utxoRepository, spentOutputRepository, dslContext, utxoCache, transactionManager);
     }
 
     @Bean

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/scheduler/UtxoPruningService.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/scheduler/UtxoPruningService.java
@@ -36,7 +36,7 @@ public class UtxoPruningService {
         log.info("<< Utxo Pruning Service Enabled >>");
     }
 
-    @Scheduled(fixedRateString = "${store.utxo.pruning-interval:1440}", timeUnit = TimeUnit.MINUTES)
+    @Scheduled(fixedRateString = "${store.utxo.pruning-interval:86400}", timeUnit = TimeUnit.SECONDS, initialDelay = 120)
     public void handleUtxoPruning() {
         if (isPruning.get()) {
             log.info("Utxo pruning is already in progress. Skipping this run !!!");


### PR DESCRIPTION
- Added batch deletion for utxo pruning service
- Initial implementation of Balance Pruning Service (Optional) : This is an optional service that can be used as an alternative to the current real-time history cleanup by enabling a flag. This service deletes historical records in the background.
- Added admin related properties to auto-configuration
- History cleanup SQL script that can be run in the PostgreSQL CLI.