### PR TITLE
fix: Update data type to longtext to fix sql error

### DIFF
--- a/stores/governance/src/main/resources/db/store/mysql/V0_1100_1__init.sql
+++ b/stores/governance/src/main/resources/db/store/mysql/V0_1100_1__init.sql
@@ -168,7 +168,7 @@ CREATE INDEX idx_committee_member_slot
 CREATE TABLE constitution
 (
     active_epoch    int,
-    anchor_url      varchar,
+    anchor_url      longtext,
     anchor_hash     varchar(64),
     script          varchar(64),
     slot            bigint,


### PR DESCRIPTION
- Fix mysql data type issue for gov store migration script