### PR TITLE
Add "epoch" column to local_epoch_param table

### DIFF
--- a/api-tests/epoch.http
+++ b/api-tests/epoch.http
@@ -1,0 +1,59 @@
+###
+### Get epoch params
+GET {{base_url}}/api/v1/epochs/parameters
+
+> {%
+    client.test("Get epoch parameters", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.min_fee_a === 44, "Min Fin A is not 44. Actual value: " + response.body.min_fee_a)
+        client.assert(response.body.min_fee_b === 155381, "Min Fin A is not 44. Actual value: " + response.body.min_fee_b)
+        client.assert(response.body.coins_per_utxo_size === "4310", "coins_per_utxo_size is not 4310. Actual value: " + response.body.coins_per_utxo_size)
+        client.assert(response.body.cost_models.PlutusV1 !== null, "Plutus V1 Cost model is null")
+        client.assert(response.body.cost_models.PlutusV2 !== null, "Plutus V2 Cost model is null")
+    });
+%}
+
+
+###
+### Get latest epoch params
+GET {{base_url}}/api/v1/epochs/latest/parameters
+
+> {%
+    client.test("Get epoch parameters", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.min_fee_a === 44, "Min Fin A is not 44. Actual value: " + response.body.min_fee_a)
+        client.assert(response.body.min_fee_b === 155381, "Min Fin A is not 44. Actual value: " + response.body.min_fee_b)
+        client.assert(response.body.coins_per_utxo_size === "4310", "coins_per_utxo_size is not 4310. Actual value: " + response.body.coins_per_utxo_size)
+        client.assert(response.body.cost_models.PlutusV1 !== null, "Plutus V1 Cost model is null")
+        client.assert(response.body.cost_models.PlutusV2 !== null, "Plutus V2 Cost model is null")
+    });
+%}
+
+###
+### Get latest epoch
+GET {{base_url}}/api/v1/epochs/latest
+
+> {%
+    client.test("Get latest epoch", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.epoch > 1, "Latest epoch not found. Actual value: " + JSON.stringify(response.body))
+
+        client.global.set("current_epoch", response.body.epoch);
+    });
+%}
+
+###
+### Get epoch params
+GET {{base_url}}/api/v1/epochs/{{current_epoch}}/parameters
+
+> {%
+    client.test("Get epoch parameters by epoch", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.min_fee_a === 44, "Min Fin A is not 44. Actual value: " + response.body.min_fee_a)
+        client.assert(response.body.min_fee_b === 155381, "Min Fin A is not 44. Actual value: " + response.body.min_fee_b)
+        client.assert(response.body.coins_per_utxo_size === "4310", "coins_per_utxo_size is not 4310. Actual value: " + response.body.coins_per_utxo_size)
+        client.assert(response.body.cost_models.PlutusV1 !== null, "Plutus V1 Cost model is null")
+        client.assert(response.body.cost_models.PlutusV2 !== null, "Plutus V2 Cost model is null")
+    });
+%}
+

--- a/api-tests/http-client.env.json
+++ b/api-tests/http-client.env.json
@@ -1,0 +1,9 @@
+{
+  "dev": {
+    "base_url": "http://localhost:8080"
+  },
+  "devkit": {
+    "base_url": "http://localhost:8080",
+    "admin_url": "http://localhost:10000"
+  }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -256,7 +256,7 @@ public class BlockFetchService implements BlockChainDataListener {
         log.info("Writing genesis block to cursor -->");
         cursorService.setCursor(new Cursor(genesisBlockEvent.getSlot(), genesisBlockEvent.getBlockHash(), 0L, null, genesisBlockEvent.getEra()));
         if (genesisBlockEvent.getEra().getValue() > Era.Byron.getValue()) { //If Genesis block is not byron era. Possible for preview and local devnet
-            eraService.saveEra(genesisBlockEvent.getEra(), genesisBlockEvent.getSlot(), genesisBlockEvent.getBlockHash(), genesisBlockEvent.getBlock());
+            eraService.saveEra(genesisBlockEvent.getEra(), 0, genesisBlockEvent.getBlockHash(), 0);
         }
     }
 

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -21,6 +24,7 @@ public class EraService {
     private final EpochConfig epochConfig;
     private final GenesisConfig genesisConfig;
     private final StoreProperties storeProperties;
+    private final TipFinderService tipFinderService;
 
     private Era prevEra;
     private long shelleyStartSlot = -1;
@@ -120,6 +124,22 @@ public class EraService {
         } else {
             long slotsFromShelleyStart = slot - firstShelleySlot();
             return (shelleyEraStartTime() + slotsFromShelleyStart * (long) genesisConfig.slotDuration(Era.Shelley));
+        }
+    }
+
+    /**
+     * Get current epoch number directly from the tip
+     * This method can only be used when the node is in shelley or post shelley era
+     * @return current epoch number
+     */
+    public Optional<Integer> getCurrentEpoch() {
+        var tip = tipFinderService.getTip().block(Duration.ofSeconds(5));
+
+        if (tip != null) {
+            int epoch = epochConfig.epochFromSlot(firstShelleySlot(), Era.Shelley, tip.getPoint().getSlot());
+            return Optional.of(epoch);
+        } else {
+            return Optional.empty();
         }
     }
 

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/EraServiceTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/EraServiceTest.java
@@ -34,12 +34,15 @@ class EraServiceTest {
     @Mock
     private StoreProperties storeProperties;
 
+    @Mock
+    private TipFinderService tipFinderService;
+
     @InjectMocks
     private EraService eraService;
 
     @BeforeEach
     void setup() {
-        eraService = new EraService(eraStorage, cursorStorage, epochConfig, genesisConfig, storeProperties);
+        eraService = new EraService(eraStorage, cursorStorage, epochConfig, genesisConfig, storeProperties, tipFinderService);
     }
 
     @Test

--- a/stores-api/epoch-api/src/main/java/com/bloxbean/cardano/yaci/store/api/epoch/controller/LocalEpochController.java
+++ b/stores-api/epoch-api/src/main/java/com/bloxbean/cardano/yaci/store/api/epoch/controller/LocalEpochController.java
@@ -3,7 +3,7 @@ package com.bloxbean.cardano.yaci.store.api.epoch.controller;
 import com.bloxbean.cardano.yaci.store.api.epoch.dto.EpochNo;
 import com.bloxbean.cardano.yaci.store.epoch.dto.ProtocolParamsDto;
 import com.bloxbean.cardano.yaci.store.epoch.mapper.DomainMapper;
-import com.bloxbean.cardano.yaci.store.epoch.service.LocalProtocolParamService;
+import com.bloxbean.cardano.yaci.store.epoch.service.LocalEpochParamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.PostConstruct;
@@ -19,13 +19,13 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("${apiPrefix}/epochs")
-@Tag(name = "Local Epoch Service", description = "Get epoch params directly from local Cardano Node through n2c local query")
+@Tag(name = "Local Epoch Service", description = "Get epoch params directly from local Cardano Node through n2c local query.")
 @Slf4j
-@ConditionalOnBean(LocalProtocolParamService.class)
+@ConditionalOnBean(LocalEpochParamService.class)
 @ConditionalOnExpression("${store.epoch.endpoints.epoch.local.enabled:false}")
 public class LocalEpochController {
 
-    private final LocalProtocolParamService protocolParamService;
+    private final LocalEpochParamService protocolParamService;
     private final DomainMapper mapper = DomainMapper.INSTANCE;
 
     @PostConstruct
@@ -33,11 +33,10 @@ public class LocalEpochController {
         log.info("LocalEpochController initialized >>>");
     }
 
-    public LocalEpochController(LocalProtocolParamService protocolParamService) {
+    public LocalEpochController(LocalEpochParamService protocolParamService) {
         this.protocolParamService = protocolParamService;
     }
 
-    //TODO -- This is a workaround for now. As we keep only the current protocol params now
     @GetMapping("parameters")
     @Operation(summary = "Latest Epoch's Protocol Parameters", description = "Get the protocol parameters of the latest epoch. It fetches the protocol parameters from the local node through n2c local query.")
     public ProtocolParamsDto getProtocolParams() {
@@ -52,15 +51,19 @@ public class LocalEpochController {
         return getProtocolParams();
     }
 
-    @Operation(summary = "Get protocol parameters. The {number} path variable is ignored. So any value can be passed. It always returns current protocol parameters. It fetches the protocol parameters from the local node through n2c local query.")
+    @Operation(summary = "Get protocol parameters for an epoch if exists. It fetches the protocol parameters from the local node through n2c local query. If the protocol param doesn't exist for an old epoch, it return status code 404.")
     @GetMapping("{number}/parameters")
     public ProtocolParamsDto getProtocolParams(@PathVariable Integer number) {
-        return getProtocolParams();
+        return protocolParamService.getProtocolParams(number)
+                .map(mapper::toProtocolParamsDto)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Protocol params not found for epoch : " + number));
     }
 
-    @Operation(summary = "This is a dummy endpoint for now. It returns a hardcode value, 1")
+    @Operation(summary = "Get the latest epoch no")
     @GetMapping("latest")
     public EpochNo getLatestEpoch() {
-        return new EpochNo(1);
+        return protocolParamService.getMaxEpoch()
+                .map(EpochNo::new)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Latest epoch not found"));
     }
 }

--- a/stores/epoch/build.gradle
+++ b/stores/epoch/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     api project(":components:common")
     api project(":components:events")
+    api project(":components:core")
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     implementation libs.cardano.client.backend

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/EpochStoreConfiguration.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/EpochStoreConfiguration.java
@@ -1,14 +1,17 @@
 package com.bloxbean.cardano.yaci.store.epoch;
 
 import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import com.bloxbean.cardano.yaci.store.epoch.storage.LocalEpochParamsStorage;
 import com.bloxbean.cardano.yaci.store.epoch.storage.ProtocolParamsProposalStorage;
 import com.bloxbean.cardano.yaci.store.epoch.storage.ProtocolParamsProposalStorageReader;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.EpochParamStorageImpl;
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.LocalEpochParamsStorageImpl;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.ProtocolParamsProposalStorageImpl;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.ProtocolParamsProposalStorageReaderImpl;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.mapper.ProtocolParamsMapper;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.CostModelRepository;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.EpochParamRepository;
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.LocalEpochParamsRepository;
 import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.ProtocolParamsProposalRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -51,5 +54,11 @@ public class EpochStoreConfiguration {
     public ProtocolParamsProposalStorageReader protocolParamsProposalStorageReader(ProtocolParamsProposalRepository protocolParamsProposalReadRepository,
                                                                             ProtocolParamsMapper protocolParamsMapper) {
         return new ProtocolParamsProposalStorageReaderImpl(protocolParamsProposalReadRepository, protocolParamsMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LocalEpochParamsStorage localEpochParamsStorage(LocalEpochParamsRepository localProtocolParamsRepository) {
+        return new LocalEpochParamsStorageImpl(localProtocolParamsRepository);
     }
 }

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/processor/LocalEpochParamsScheduler.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/processor/LocalEpochParamsScheduler.java
@@ -1,6 +1,6 @@
 package com.bloxbean.cardano.yaci.store.epoch.processor;
 
-import com.bloxbean.cardano.yaci.store.epoch.service.LocalProtocolParamService;
+import com.bloxbean.cardano.yaci.store.epoch.service.LocalEpochParamService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -9,12 +9,12 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.TimeUnit;
 
 @Component
-@ConditionalOnBean(LocalProtocolParamService.class)
+@ConditionalOnBean(LocalEpochParamService.class)
 @Slf4j
-public class LocalProtocolParamsScheduler {
-    private LocalProtocolParamService protocolParamService;
+public class LocalEpochParamsScheduler {
+    private LocalEpochParamService protocolParamService;
 
-    public LocalProtocolParamsScheduler(LocalProtocolParamService protocolParamService) {
+    public LocalEpochParamsScheduler(LocalEpochParamService protocolParamService) {
         this.protocolParamService = protocolParamService;
     }
 

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/LocalEpochParamsStorage.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/LocalEpochParamsStorage.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yaci.store.epoch.storage;
+
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+
+import java.util.Optional;
+
+public interface LocalEpochParamsStorage {
+    void save(EpochParam epochParam);
+
+    Optional<EpochParam> getEpochParam(int epoch);
+
+    Optional<EpochParam> getLatestEpochParam();
+
+    Optional<Integer> getMaxEpoch();
+}

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/LocalEpochParamsStorageImpl.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/LocalEpochParamsStorageImpl.java
@@ -1,0 +1,51 @@
+package com.bloxbean.cardano.yaci.store.epoch.storage.impl;
+
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.LocalEpochParamsStorage;
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.model.LocalEpochParamsEntity;
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.LocalEpochParamsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LocalEpochParamsStorageImpl implements LocalEpochParamsStorage {
+    private final LocalEpochParamsRepository localEpochParamsRepository;
+
+    @Override
+    public void save(EpochParam epochParam) {
+        if (epochParam == null) return;
+
+        LocalEpochParamsEntity entity = LocalEpochParamsEntity.builder()
+                .epoch(epochParam.getEpoch())
+                .protocolParams(epochParam.getParams())
+                .build();
+
+        localEpochParamsRepository.save(entity);
+    }
+
+    @Override
+    public Optional<EpochParam> getEpochParam(int epoch) {
+        return localEpochParamsRepository.findById(epoch)
+                .map(entity -> EpochParam.builder()
+                        .epoch(entity.getEpoch())
+                        .params(entity.getProtocolParams())
+                        .build());
+    }
+
+    @Override
+    public Optional<EpochParam> getLatestEpochParam() {
+        return localEpochParamsRepository.findLatest()
+                .map(entity -> EpochParam.builder()
+                        .epoch(entity.getEpoch())
+                        .params(entity.getProtocolParams())
+                        .build());
+    }
+
+    @Override
+    public Optional<Integer> getMaxEpoch() {
+        return localEpochParamsRepository.findMaxEpoch();
+    }
+}

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/model/LocalEpochParamsEntity.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/model/LocalEpochParamsEntity.java
@@ -1,7 +1,6 @@
 package com.bloxbean.cardano.yaci.store.epoch.storage.impl.model;
 
 import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
-import com.bloxbean.cardano.yaci.store.common.model.BaseEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,19 +11,25 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "local_protocol_params")
-public class LocalProtocolParamsEntity extends BaseEntity {
+@Table(name = "local_epoch_param")
+public class LocalEpochParamsEntity {
     @Id
-    private Long id;
+    private Integer epoch;
 
     @Type(JsonType.class)
     @Column(name = "params")
     private ProtocolParams protocolParams;
 
+    @UpdateTimestamp
+    @Column(name = "update_datetime")
+    private LocalDateTime updateDateTime;
 }

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/repository/LocalEpochParamsRepository.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/repository/LocalEpochParamsRepository.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.model.LocalEpochParamsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LocalEpochParamsRepository extends JpaRepository<LocalEpochParamsEntity, Integer> {
+
+    @Query("SELECT e FROM LocalEpochParamsEntity e ORDER BY e.epoch DESC limit 1")
+    Optional<LocalEpochParamsEntity> findLatest();
+
+    @Query("select max(ep.epoch) from EpochParamEntity ep")
+    Optional<Integer> findMaxEpoch();
+}

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/repository/LocalProtocolParamsRepository.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/repository/LocalProtocolParamsRepository.java
@@ -1,9 +1,0 @@
-package com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository;
-
-import com.bloxbean.cardano.yaci.store.epoch.storage.impl.model.LocalProtocolParamsEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface LocalProtocolParamsRepository extends JpaRepository<LocalProtocolParamsEntity, Long> {
-}

--- a/stores/epoch/src/main/resources/db/store/h2/V0_500_1__init.sql
+++ b/stores/epoch/src/main/resources/db/store/h2/V0_500_1__init.sql
@@ -1,10 +1,8 @@
-drop table if exists local_protocol_params;
-create table local_protocol_params
+drop table if exists local_epoch_param;
+create table local_epoch_param
 (
-    id   bigint
-        primary key,
+    epoch integer primary key,
     params json,
-    create_datetime  timestamp,
     update_datetime  timestamp
 );
 

--- a/stores/epoch/src/main/resources/db/store/mysql/V0_500_1__init.sql
+++ b/stores/epoch/src/main/resources/db/store/mysql/V0_500_1__init.sql
@@ -1,10 +1,8 @@
-drop table if exists local_protocol_params;
-create table local_protocol_params
+drop table if exists local_epoch_param;
+create table local_epoch_param
 (
-    id   bigint
-        primary key,
+    epoch integer primary key,
     params json,
-    create_datetime  timestamp,
     update_datetime  timestamp
 );
 

--- a/stores/epoch/src/main/resources/db/store/postgresql/V0_500_1__init.sql
+++ b/stores/epoch/src/main/resources/db/store/postgresql/V0_500_1__init.sql
@@ -1,10 +1,8 @@
-drop table if exists local_protocol_params;
-create table local_protocol_params
+drop table if exists local_epoch_param;
+create table local_epoch_param
 (
-    id   bigint
-        primary key,
+    epoch integer primary key,
     params jsonb,
-    create_datetime  timestamp,
     update_datetime  timestamp
 );
 

--- a/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/LocalEpochParamsSchedulerTest.java
+++ b/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/LocalEpochParamsSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.bloxbean.cardano.yaci.store.epoch.processor;
 
-import com.bloxbean.cardano.yaci.store.epoch.service.LocalProtocolParamService;
+import com.bloxbean.cardano.yaci.store.epoch.service.LocalEpochParamService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,16 +9,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class LocalProtocolParamsSchedulerTest {
+class LocalEpochParamsSchedulerTest {
     @Mock
-    private LocalProtocolParamService protocolParamService;
+    private LocalEpochParamService protocolParamService;
 
     @InjectMocks
-    private LocalProtocolParamsScheduler localProtocolParamsSchduler;
+    private LocalEpochParamsScheduler localProtocolParamsSchduler;
 
     @Test
     void testScheduleFetchAndSetCurrentProtocolParams() {
-        localProtocolParamsSchduler = new LocalProtocolParamsScheduler(protocolParamService);
+        localProtocolParamsSchduler = new LocalEpochParamsScheduler(protocolParamService);
 
         localProtocolParamsSchduler.scheduleFetchAndSetCurrentProtocolParams();
         Mockito.verify(protocolParamService, Mockito.times(1)).fetchAndSetCurrentProtocolParams();

--- a/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/LocalEpochParamsStorageImplTest.java
+++ b/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/storage/impl/LocalEpochParamsStorageImplTest.java
@@ -1,0 +1,126 @@
+package com.bloxbean.cardano.yaci.store.epoch.storage.impl;
+
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.LocalEpochParamsStorage;
+import com.bloxbean.cardano.yaci.store.epoch.storage.impl.repository.LocalEpochParamsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class LocalEpochParamsStorageImplTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private LocalEpochParamsRepository repository;
+
+    private LocalEpochParamsStorage localProtocolParamsStorage;
+
+    @BeforeEach
+    public void setup() {
+        localProtocolParamsStorage = new LocalEpochParamsStorageImpl(repository);
+    }
+
+    @Test
+    void saveAndGet() {
+        prepareData();
+
+        assertThat(repository.count()).isEqualTo(5);
+        assertThat(localProtocolParamsStorage.getEpochParam(209).isPresent()).isTrue();
+        localProtocolParamsStorage.getEpochParam(209).ifPresent(e -> {
+            assertEquals(209, e.getEpoch());
+            assertEquals(10, e.getParams().getMaxEpoch());
+            assertEquals(44, e.getParams().getMinFeeA());
+            assertEquals(1001, e.getParams().getMinFeeB());
+        });
+    }
+
+    @Test
+    void getEpochParam() {
+        prepareData();
+        localProtocolParamsStorage.getEpochParam(209).ifPresent(e -> {
+            assertEquals(209, e.getEpoch());
+            assertEquals(10, e.getParams().getMaxEpoch());
+            assertEquals(44, e.getParams().getMinFeeA());
+            assertEquals(1001, e.getParams().getMinFeeB());
+        });
+        assertThat(localProtocolParamsStorage.getEpochParam(209)).isPresent();
+
+        localProtocolParamsStorage.getEpochParam(210).ifPresent(e -> {
+            assertEquals(210, e.getEpoch());
+            assertEquals(11, e.getParams().getMaxEpoch());
+            assertEquals(45, e.getParams().getMinFeeA());
+            assertEquals(1002, e.getParams().getMinFeeB());
+        });
+        assertThat(localProtocolParamsStorage.getEpochParam(210)).isPresent();
+    }
+
+    @Test
+    void getLatestEpochParam() {
+        prepareData();
+        assertThat(localProtocolParamsStorage.getLatestEpochParam()).isPresent();
+        localProtocolParamsStorage.getLatestEpochParam().ifPresent(e -> {
+            assertEquals(211, e.getEpoch());
+            assertEquals(12, e.getParams().getMaxEpoch());
+            assertEquals(46, e.getParams().getMinFeeA());
+            assertEquals(1003, e.getParams().getMinFeeB());
+        });
+    }
+
+    private void prepareData() {
+        EpochParam epochParam209 = EpochParam.builder()
+                .epoch(209)
+                .params(ProtocolParams.builder()
+                        .maxEpoch(10)
+                        .minFeeA(44)
+                        .minFeeB(1001)
+                        .build()).build();
+
+        EpochParam epochParam210 = EpochParam.builder()
+                .epoch(210)
+                .params(ProtocolParams.builder()
+                        .maxEpoch(11)
+                        .minFeeA(45)
+                        .minFeeB(1002)
+                        .build()).build();
+
+        EpochParam epochParam211 = EpochParam.builder()
+                .epoch(211)
+                .params(ProtocolParams.builder()
+                        .maxEpoch(12)
+                        .minFeeA(46)
+                        .minFeeB(1003)
+                        .build()).build();
+
+
+        EpochParam epochParam208 = EpochParam.builder()
+                .epoch(208)
+                .params(ProtocolParams.builder()
+                        .maxEpoch(8)
+                        .minFeeA(46)
+                        .minFeeB(900)
+                        .build()).build();
+
+        EpochParam epochParam207 = EpochParam.builder()
+                .epoch(207)
+                .params(ProtocolParams.builder()
+                        .maxEpoch(7)
+                        .minFeeA(47)
+                        .minFeeB(900)
+                        .build()).build();
+
+        localProtocolParamsStorage.save(epochParam209);
+        localProtocolParamsStorage.save(epochParam210);
+        localProtocolParamsStorage.save(epochParam211);
+        localProtocolParamsStorage.save(epochParam208);
+        localProtocolParamsStorage.save(epochParam207);
+    }
+}


### PR DESCRIPTION
- Rename local_protocol_params to local_epoch_param
- Add epoch column
- http tests for `LocalEpochController`
- Fix initial era's slot and block in Era table for custom network and preview when the chain doesn't start with Byron era. The existing value "-1" for block and slot provide wrong epoch no. Instead of -1, now the value is set to 0.
- EraService has a new method `getCurrentEpoch` to get the current epoch calculated from current tip directly from node.