### PR TITLE
feat: Pool support for N2c connections

### DIFF
--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/api/account/service/AccountService.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/api/account/service/AccountService.java
@@ -7,8 +7,8 @@ import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.DelegationsAnd
 import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.DelegationsAndRewardAccountsResult;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.helper.LocalClientProvider;
-import com.bloxbean.cardano.yaci.helper.LocalStateQueryClient;
 import com.bloxbean.cardano.yaci.store.account.domain.StakeAccountRewardInfo;
+import com.bloxbean.cardano.yaci.store.core.service.local.LocalClientProviderManager;
 import com.bloxbean.cardano.yaci.store.core.storage.api.EraStorage;
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -25,17 +25,12 @@ import java.util.Set;
 @Slf4j
 @ConditionalOnExpression("'${store.cardano.n2c-node-socket-path:}' != '' || '${store.cardano.n2c-host:}' != ''")
 public class AccountService {
-    private final LocalStateQueryClient localStateQueryClient;
     private final EraStorage eraStorage;
+    private final LocalClientProviderManager localClientProviderManager;
 
-    public AccountService(@Nullable LocalClientProvider localClientProvider, EraStorage eraStorage) {
-        if (localClientProvider != null) {
-            this.localStateQueryClient = localClientProvider.getLocalStateQueryClient();
-            log.info("Account Controller initialized >>>");
-        } else
-            localStateQueryClient = null;
-
+    public AccountService(@Nullable LocalClientProviderManager localClientProviderManager, EraStorage eraStorage) {
         this.eraStorage = eraStorage;
+        this.localClientProviderManager = localClientProviderManager;
     }
 
     /**
@@ -45,19 +40,23 @@ public class AccountService {
      * @return StakeAccountInfo
      */
     public Optional<StakeAccountRewardInfo> getAccountInfo(String stakeAddress) {
-        if (localStateQueryClient == null) {
-            log.info("LocalStateQueryClient is not initialized. Please check if n2c-node-socket-path or n2c-host is configured properly.");
-            return Optional.empty();
-        }
+        if (localClientProviderManager == null)
+            throw new IllegalStateException("LocalClientProvider is not initialized. Please check n2c configuration.");
 
-        Address address = new Address(stakeAddress);
-        DelegationsAndRewardAccountsResult delegationsAndRewardAccountsResult = null;
-        Era lqEra = eraStorage.findCurrentEra()
-                .map(cardanoEra -> cardanoEra.getEra())
-                .map(e -> Era.valueOf(e.name())).orElse(Era.Babbage);
+        Optional<LocalClientProvider> localClientProvider = localClientProviderManager.getLocalClientProvider();
+        try {
+            var localStateQueryClient = localClientProvider.map(LocalClientProvider::getLocalStateQueryClient).orElse(null);
+            if (localStateQueryClient == null) {
+                log.info("LocalStateQueryClient is not initialized. Please check if n2c-node-socket-path or n2c-host is configured properly.");
+                return Optional.empty();
+            }
 
-        //TODO -- This is a temporary impelementation. It is not scalable with synchronized block
-        synchronized (this) {
+            Address address = new Address(stakeAddress);
+            DelegationsAndRewardAccountsResult delegationsAndRewardAccountsResult = null;
+            Era lqEra = eraStorage.findCurrentEra()
+                    .map(cardanoEra -> cardanoEra.getEra())
+                    .map(e -> Era.valueOf(e.name())).orElse(Era.Babbage);
+
             //Try to release first before a new query to avoid stale data
             try {
                 localStateQueryClient.release().block(Duration.ofSeconds(5));
@@ -68,20 +67,22 @@ public class AccountService {
             Mono<DelegationsAndRewardAccountsResult> mono =
                     localStateQueryClient.executeQuery(new DelegationsAndRewardAccountsQuery(lqEra, Set.of(address)));
             delegationsAndRewardAccountsResult = mono.block(Duration.ofSeconds(5));
+
+            if (delegationsAndRewardAccountsResult == null) {
+                return Optional.empty();
+            }
+
+            String poolId = delegationsAndRewardAccountsResult.getDelegations() != null ?
+                    delegationsAndRewardAccountsResult.getDelegations().getOrDefault(address, null) : null;
+            if (poolId != null)
+                poolId = Bech32.encode(HexUtil.decodeHexString(poolId), "pool");
+
+            BigInteger rewards = delegationsAndRewardAccountsResult.getRewards() != null ?
+                    delegationsAndRewardAccountsResult.getRewards().getOrDefault(address, BigInteger.ZERO) : BigInteger.ZERO;
+
+            return Optional.of(new StakeAccountRewardInfo(stakeAddress, poolId, rewards));
+        } finally {
+            localClientProviderManager.close(localClientProvider.get());
         }
-
-        if (delegationsAndRewardAccountsResult == null) {
-            return Optional.empty();
-        }
-
-        String poolId = delegationsAndRewardAccountsResult.getDelegations() != null ?
-                delegationsAndRewardAccountsResult.getDelegations().getOrDefault(address, null) : null;
-        if (poolId != null)
-            poolId = Bech32.encode(HexUtil.decodeHexString(poolId), "pool");
-
-        BigInteger rewards = delegationsAndRewardAccountsResult.getRewards() != null ?
-                delegationsAndRewardAccountsResult.getRewards().getOrDefault(address, BigInteger.ZERO) : BigInteger.ZERO;
-
-        return Optional.of(new StakeAccountRewardInfo(stakeAddress, poolId, rewards));
     }
 }

--- a/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/exception/RestResponseEntityExceptionHandler.java
+++ b/applications/aggregation-app/src/main/java/com/bloxbean/cardano/yaci/store/aggregation/exception/RestResponseEntityExceptionHandler.java
@@ -20,4 +20,13 @@ public class RestResponseEntityExceptionHandler
         return handleExceptionInternal(ex, bodyOfResponse,
                 new HttpHeaders(), HttpStatus.NOT_IMPLEMENTED, request);
     }
+
+    @ExceptionHandler(value
+            = { IllegalStateException.class })
+    protected ResponseEntity<Object> handleIllegalStateException(
+            RuntimeException ex, WebRequest request) {
+        String bodyOfResponse = "Unexpected error : " + ex.getMessage();
+        return handleExceptionInternal(ex, bodyOfResponse,
+                new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
 }

--- a/applications/all/src/main/java/com/bloxbean/cardano/yaci/store/app/exception/RestResponseEntityExceptionHandler.java
+++ b/applications/all/src/main/java/com/bloxbean/cardano/yaci/store/app/exception/RestResponseEntityExceptionHandler.java
@@ -20,4 +20,13 @@ public class RestResponseEntityExceptionHandler
         return handleExceptionInternal(ex, bodyOfResponse,
                 new HttpHeaders(), HttpStatus.NOT_IMPLEMENTED, request);
     }
+
+    @ExceptionHandler(value
+            = { IllegalStateException.class })
+    protected ResponseEntity<Object> handleIllegalStateException(
+            RuntimeException ex, WebRequest request) {
+        String bodyOfResponse = "Unexpected error : " + ex.getMessage();
+        return handleExceptionInternal(ex, bodyOfResponse,
+                new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
 }

--- a/applications/utxo-indexer/src/main/java/com/bloxbean/cardano/yaci/store/app/utxo/exception/RestResponseEntityExceptionHandler.java
+++ b/applications/utxo-indexer/src/main/java/com/bloxbean/cardano/yaci/store/app/utxo/exception/RestResponseEntityExceptionHandler.java
@@ -20,4 +20,13 @@ public class RestResponseEntityExceptionHandler
         return handleExceptionInternal(ex, bodyOfResponse,
                 new HttpHeaders(), HttpStatus.NOT_IMPLEMENTED, request);
     }
+
+    @ExceptionHandler(value
+            = { IllegalStateException.class })
+    protected ResponseEntity<Object> handleIllegalStateException(
+            RuntimeException ex, WebRequest request) {
+        String bodyOfResponse = "Unexpected error : " + ex.getMessage();
+        return handleExceptionInternal(ex, bodyOfResponse,
+                new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
 }

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -95,4 +95,16 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
     private int jooqWriteBatchSize = 3000;
     @Builder.Default
     private int writeThreadCount = 5;
+
+    //n2c pool configuration
+    @Builder.Default
+    private boolean n2cPoolEnabled = false;
+    @Builder.Default
+    private int n2cPoolMaxTotal = 10;
+    @Builder.Default
+    private int n2cPoolMinIdle = 2;
+    @Builder.Default
+    private int n2cPoolMaxIdle = 5;
+    @Builder.Default
+    private int n2cPoolMaxWaitInMillis = 10000;
 }

--- a/components/core/build.gradle
+++ b/components/core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
         exclude group: "com.bloxbean.cardano", module: "cardano-client-core"
     }
     implementation libs.cardano.client.lib
+    implementation libs.apache.commons.pool
 
     testImplementation libs.assertj.core
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderManager.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderManager.java
@@ -1,0 +1,113 @@
+package com.bloxbean.cardano.yaci.store.core.service.local;
+
+import com.bloxbean.cardano.yaci.helper.LocalClientProvider;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * This class manages the LocalClientProvider instances. It creates new instances if pool is disabled. If pool is enabled,
+ * it borrows the LocalClientProvider from the pool and returns it back to the pool after use.
+ * <p>
+ * The LocalClientProvider is used to query local ledger state, monitor mempool transactions or submit transaction using Node-to-client.
+ * </p>
+ * <p>
+ * To enable pool, set store.cardano.n2c-pool-enabled=true in application.properties
+ * </p>
+ */
+@Service
+@Slf4j
+@ConditionalOnExpression("'${store.cardano.n2c-node-socket-path:}' != '' || '${store.cardano.n2c-host:}' != ''")
+public class LocalClientProviderManager {
+    private final GenericObjectPool<LocalClientProvider> localClientProviderPool;
+
+    private String n2cSocket;
+    private String n2cHost;
+    private int n2cPort;
+    private long protocolMagic;
+
+    private boolean isNodeSocketFileEnabled;
+    private boolean isNodeHostEnabled;
+
+    private boolean isPoolEnabled;
+
+    public LocalClientProviderManager(@Qualifier("localClientProviderPool") @Nullable GenericObjectPool<LocalClientProvider> localClientProviderPool,
+                                      StoreProperties storeProperties) {
+        this.localClientProviderPool = localClientProviderPool;
+
+        this.n2cSocket = storeProperties.getN2cNodeSocketPath();
+        this.n2cHost = storeProperties.getN2cHost();
+        this.n2cPort = storeProperties.getN2cPort();
+        this.protocolMagic = storeProperties.getProtocolMagic();
+
+        this.isPoolEnabled = storeProperties.isN2cPoolEnabled();
+
+        if (n2cSocket != null && !n2cSocket.isEmpty()) {
+            isNodeSocketFileEnabled = true;
+        } else if (n2cHost != null && !n2cHost.isEmpty()) {
+            isNodeHostEnabled = true;
+        }
+
+        log.info("LocalClientProviders initialized >>>");
+        if (localClientProviderPool != null)
+            log.info("LocalClientProvider pool enabled");
+        else
+            log.info("LocalClientProvider pool disabled");
+    }
+
+    public Optional<LocalClientProvider> getLocalClientProvider() {
+        if (isPoolEnabled) {
+            try {
+                var provider = localClientProviderPool.borrowObject();
+                if (log.isDebugEnabled())
+                    log.debug("Borrowed LocalClientProvider from pool");
+                return Optional.of(provider);
+            } catch (Exception e) {
+                throw new IllegalStateException("Error getting LocalClientProvider from pool", e);
+            }
+        } else {
+            if (log.isDebugEnabled())
+                log.debug("Creating new LocalClientProvider");
+            return getNewLocalClientProvider();
+        }
+    }
+
+    public Optional<LocalClientProvider> getNewLocalClientProvider() {
+        LocalClientProvider localClientProvider = null;
+        if (isNodeSocketFileEnabled) {
+            localClientProvider = new LocalClientProvider(n2cSocket, protocolMagic);
+        } else if (isNodeHostEnabled) {
+            localClientProvider = new LocalClientProvider(n2cHost, n2cPort, protocolMagic);
+        } else {
+            log.error("LocalClientProvider not initialized. Please check the configuration");
+        }
+
+        localClientProvider.suppressConnectionInfoLog(true);
+        localClientProvider.start();
+
+        return Optional.ofNullable(localClientProvider);
+    }
+
+    public void close(LocalClientProvider localClientProvider) {
+        if (isPoolEnabled) {
+            if (log.isDebugEnabled())
+                log.debug("Returning LocalClientProvider to pool");
+            try {
+                localClientProviderPool.returnObject(localClientProvider);
+            } catch (Exception e) {
+                log.error("Error returning LocalClientProvider to pool", e);
+            }
+        } else {
+            if(localClientProvider != null) {
+                localClientProvider.shutdown();
+            }
+        }
+
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderManager.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderManager.java
@@ -61,6 +61,11 @@ public class LocalClientProviderManager {
             log.info("LocalClientProvider pool disabled");
     }
 
+    /**
+     * Get LocalClientProvider instance. If pool is enabled, it borrows the LocalClientProvider from the pool.
+     * If pool is disabled, it creates a new LocalClientProvider instance.
+     * @return LocalClientProvider
+     */
     public Optional<LocalClientProvider> getLocalClientProvider() {
         if (isPoolEnabled) {
             try {
@@ -78,6 +83,10 @@ public class LocalClientProviderManager {
         }
     }
 
+    /**
+     * Creates a new LocalClientProvider instance
+     * @return LocalClientProvider
+     */
     public Optional<LocalClientProvider> getNewLocalClientProvider() {
         LocalClientProvider localClientProvider = null;
         if (isNodeSocketFileEnabled) {
@@ -94,6 +103,10 @@ public class LocalClientProviderManager {
         return Optional.ofNullable(localClientProvider);
     }
 
+    /**
+     * Returns the LocalClientProvider to the pool if pool is enabled. If pool is disabled, it shuts down the LocalClientProvider.
+     * @param localClientProvider
+     */
     public void close(LocalClientProvider localClientProvider) {
         if (isPoolEnabled) {
             if (log.isDebugEnabled())

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderPoolObjectFactory.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/local/LocalClientProviderPoolObjectFactory.java
@@ -1,0 +1,88 @@
+package com.bloxbean.cardano.yaci.store.core.service.local;
+
+import com.bloxbean.cardano.yaci.core.protocol.localstate.queries.BlockHeightQuery;
+import com.bloxbean.cardano.yaci.helper.LocalClientProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+
+import java.time.Duration;
+
+/**
+ * Factory class to create LocalClientProvider object and manage it in a pool
+ */
+@Slf4j
+public class LocalClientProviderPoolObjectFactory extends BasePooledObjectFactory<LocalClientProvider> {
+
+    private String nodeSocketPath;
+    private String host;
+    private int port;
+    private long protocolMagic;
+
+    private boolean isNodeSocketPathEnable;
+    private boolean isNodeHostPortEnable;
+
+    public LocalClientProviderPoolObjectFactory(String host, int port, long protocolMagic) {
+        this.host = host;
+        this.port = port;
+        this.protocolMagic = protocolMagic;
+        this.isNodeHostPortEnable = true;
+    }
+
+    public LocalClientProviderPoolObjectFactory(String nodeSocketPath, long protocolMagic) {
+        this.nodeSocketPath = nodeSocketPath;
+        this.protocolMagic = protocolMagic;
+        this.isNodeSocketPathEnable = true;
+    }
+
+    @Override
+    public void destroyObject(PooledObject<LocalClientProvider> p) {
+        p.getObject().shutdown();
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<LocalClientProvider> p) {
+        try {
+            var blockHeight = p.getObject().getLocalStateQueryClient().executeQuery(new BlockHeightQuery()).block(Duration.ofSeconds(3));
+            if (log.isDebugEnabled())
+                log.debug("Validating LocalClientProvider. BlockHeight: {}", blockHeight);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public PooledObject<LocalClientProvider> wrap(LocalClientProvider obj) {
+        return new DefaultPooledObject<>(obj);
+    }
+
+    @Override
+    public void activateObject(PooledObject<LocalClientProvider> p) {
+        if (log.isDebugEnabled())
+            log.debug("Activating LocalClientProvider");
+    }
+
+    @Override
+    public LocalClientProvider create() throws Exception {
+        LocalClientProvider localClientProvider = null;
+        if(isNodeSocketPathEnable) {
+            localClientProvider = new LocalClientProvider(nodeSocketPath, protocolMagic);
+        } else if (isNodeHostPortEnable) {
+            localClientProvider = new LocalClientProvider(host, port, protocolMagic);
+        } else {
+            throw new IllegalArgumentException("Either nodeSocketPath or nodeHost/nodePort should be enabled");
+        }
+
+        if (localClientProvider != null) {
+            localClientProvider.suppressConnectionInfoLog(true);
+            localClientProvider.start();
+        }
+
+        return localClientProvider;
+
+    }
+
+}
+

--- a/config/application.properties
+++ b/config/application.properties
@@ -303,3 +303,13 @@ logging.level.com.bloxbean.cardano.yaci.store.core.service=INFO
 # Ogmios URL to enable both Tx submission and Tx script cost evaluation through Ogmios
 #######################################################################################
 #store.cardano.ogmios-url=http://ogmios-host:1337
+
+#######################################################################################
+# N2c Pool Configuration
+# This is only used when n2c settings are provided.
+#######################################################################################
+#store.cardano.n2c-pool-enabled=true
+#store.cardano.n2c-max-total=10
+#store.cardano.n2c-pool-min-idle=2
+#store.cardano.n2c-pool-max-idle=5
+#store.cardano.n2c-pool-max-wait-in-millis=10000

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.3.0-beta15-09a327c-SNAPSHOT"
+yaci = "com.bloxbean.cardano:yaci:0.3.0-beta15-997dc42-SNAPSHOT"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.5.1"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.5.1"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.5.1"
@@ -22,3 +22,4 @@ rocksdb="org.rocksdb:rocksdbjni:8.9.1"
 messagepack-jackson="org.msgpack:jackson-dataformat-msgpack:0.9.6"
 
 parallel-collector="com.pivovarit:parallel-collectors:3.0.0"
+apache-commons-pool="org.apache.commons:commons-pool2:2.12.0"

--- a/starters/spring-boot-starter/build.gradle
+++ b/starters/spring-boot-starter/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     api(libs.guava)
     api(libs.springdoc.openapi.starter.webmvc.ui)
 
+    implementation libs.apache.commons.pool
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -57,6 +57,13 @@ public class YaciStoreProperties {
         //This is only required when the genesis hash can't be fetched from the network.
         // In that case, the default genesis hash will be used
         private String defaultGenesisHash = "Genesis";
+
+        //n2c pool configuration
+        private boolean n2cPoolEnabled = false;
+        private int n2cPoolMaxTotal = 10;
+        private int n2cPoolMinIdle = 2;
+        private int n2cPoolMaxIdle = 5;
+        private int n2cPoolMaxWaitInMillis = 10000;
     }
 
     @Getter


### PR DESCRIPTION
To fix https://github.com/bloxbean/yaci-store/issues/341

- Added n2c pool support with Apache commons pool2
- Pool can be enabled/disabled through config
- If disabled, a new connection will be created/closed for every request
- `LocalClientProviderManager.getLocalClientProvider()` can be used to get a LocalClientProvider. If pool is enabled, it will return LocalClientProvider from the pool, otherwise a new object will be created.
- `LocalClientProviderManager.getNewLocalClientProvider()` can be used to get a new LocalClientProvider