### PR TITLE
Refactor UtxoProcessor to handle transactions without collateral return

### DIFF
--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -1,6 +1,5 @@
 package com.bloxbean.cardano.yaci.store.starter.core;
 
-import com.bloxbean.cardano.yaci.core.common.Constants;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -22,9 +21,9 @@ public class YaciStoreProperties {
     @Getter
     @Setter
     public static final class Cardano {
-        private String host = Constants.MAINNET_IOHK_RELAY_ADDR;
-        private int port = Constants.MAINNET_IOHK_RELAY_PORT;
-        private long protocolMagic = Constants.MAINNET_PROTOCOL_MAGIC;
+        private String host;
+        private int port;
+        private long protocolMagic;
         private String n2cNodeSocketPath;
         private String n2cHost;
         private int n2cPort;

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
@@ -157,12 +157,9 @@ public class UtxoProcessor {
 //                    .ifPresent(existingAddressUtxo -> collateralOutputUtxo.setSpent(existingAddressUtxo.getSpent()));
         }
 
-        if (collateralOutputUtxo != null)
-            return Optional.of(new TxInputOutput(transaction.getTxHash(), collateralInputUtxos, List.of(collateralOutputUtxo)));
-        else {
-            log.warn("No input or output found for invalid transaction: " + transaction.getTxHash());
-            return Optional.empty();
-        }
+        List<AddressUtxo> outputs = collateralOutputUtxo != null? List.of(collateralOutputUtxo) : Collections.emptyList();
+
+        return Optional.of(new TxInputOutput(transaction.getTxHash(), collateralInputUtxos, outputs));
     }
 
     private AddressUtxo getAddressUtxo(@NonNull EventMetadata eventMetadata, @NonNull Utxo utxo) {

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessorTest.java
+++ b/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessorTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.utxo.processor;
 import com.bloxbean.cardano.yaci.core.model.*;
 import com.bloxbean.cardano.yaci.helper.model.Transaction;
 import com.bloxbean.cardano.yaci.helper.model.Utxo;
+import com.bloxbean.cardano.yaci.store.client.staking.StakingClient;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
@@ -10,7 +11,6 @@ import com.bloxbean.cardano.yaci.store.events.TransactionEvent;
 import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorage;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.math.BigInteger;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,6 +41,9 @@ public class UtxoProcessorTest {
     @Mock
     private ApplicationEventPublisher publisher;
 
+    @Mock
+    private StakingClient stakingClient;
+
     @InjectMocks
     private UtxoProcessor utxoProcessor;
 
@@ -53,11 +57,10 @@ public class UtxoProcessorTest {
     @BeforeEach
     public void setup() {
 //        openMocks(this);
-        utxoProcessor = new UtxoProcessor(utxoStorage, publisher, meterRegistry);
+        utxoProcessor = new UtxoProcessor(utxoStorage, publisher, stakingClient, meterRegistry);
     }
 
     @Test
-    @Disabled
     public void givenTransactionEvent_whenInputsNotResolved_createBothSpentAndUnspentOutputs() {
         List<Transaction> transactions = transactions();
         TransactionEvent transactionEvent = TransactionEvent.builder()
@@ -72,7 +75,8 @@ public class UtxoProcessorTest {
                 .build();
 
         utxoProcessor.handleTransactionEvent(transactionEvent);
-        verify(utxoStorage, times(2)).saveUnspent(argCaptor.capture());
+        verify(utxoStorage, times(1)).saveSpent(argCaptor.capture());
+        verify(utxoStorage, times(1)).saveUnspent(argCaptor.capture());
 
         List<TxInput> spentUtxos = argCaptor.getAllValues().get(0);
         List<AddressUtxo> unspentUtxos = argCaptor.getAllValues().get(1);
@@ -97,7 +101,6 @@ public class UtxoProcessorTest {
     }
 
     @Test
-    @Disabled
     public void givenTransactionEvent_whenInvalidTxn_createBothSpentAndUnspentOutputsFromCollateral() {
         List<Transaction> transactions = transactions();
         transactions.get(0).setInvalid(true);
@@ -115,10 +118,13 @@ public class UtxoProcessorTest {
                 .build();
 
         utxoProcessor.handleTransactionEvent(transactionEvent);
-        verify(utxoStorage, times(2)).saveUnspent(argCaptor.capture());
+        verify(utxoStorage, times(1)).saveSpent(argCaptor.capture());
+        verify(utxoStorage, times(1)).saveUnspent(argCaptor.capture());
 
         List<TxInput> spentUtxos = argCaptor.getAllValues().get(0);
         List<AddressUtxo> unspentUtxos = argCaptor.getAllValues().get(1);
+
+        spentUtxos.sort(Comparator.comparing(TxInput::getTxHash));
 
         assertThat(spentUtxos).hasSize(2);
         assertThat(spentUtxos.get(0).getTxHash()).isEqualTo("dddd529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8");
@@ -128,6 +134,40 @@ public class UtxoProcessorTest {
 
         assertThat(unspentUtxos.get(0).getTxHash()).isEqualTo("f0a6e529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8");
         assertThat(unspentUtxos.get(0).getAmounts().get(0).getQuantity()).isEqualTo(transactions.get(0).getCollateralReturnUtxo().getAmounts().get(0).getQuantity());
+    }
+
+    @Test
+    public void givenTransactionEvent_whenInvalidTxn_noCollateralReturn_createSpentFromCollateral() {
+        List<Transaction> transactions = transactions_noCollateralReturn();
+        transactions.get(0).setInvalid(true);
+
+        TransactionEvent transactionEvent = TransactionEvent.builder()
+                .metadata(EventMetadata.builder()
+                        .block(100)
+                        .blockHash("c2f69d97f3a11684f2a97f7c75bc50dcb18c4a01a17625d32561a7ebc219aa5e")
+                        .slot(200000)
+                        .era(Era.Shelley)
+                        .syncMode(true)
+                        .build())
+                .transactions(transactions)
+                .build();
+
+        utxoProcessor.handleTransactionEvent(transactionEvent);
+        verify(utxoStorage, times(1)).saveSpent(argCaptor.capture());
+        verify(utxoStorage, times(1)).saveUnspent(argCaptor.capture());
+
+        List<TxInput> spentUtxos = argCaptor.getAllValues().get(0);
+        List<AddressUtxo> unspentUtxos = argCaptor.getAllValues().get(1);
+
+        spentUtxos.sort(Comparator.comparing(TxInput::getTxHash));
+
+        assertThat(spentUtxos).hasSize(2);
+        assertThat(spentUtxos.get(0).getTxHash()).isEqualTo("dddd529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8");
+        assertThat(spentUtxos.get(0).getOutputIndex()).isEqualTo(4);
+        assertThat(spentUtxos.get(1).getTxHash()).isEqualTo("eeee529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8");
+        assertThat(spentUtxos.get(1).getOutputIndex()).isEqualTo(0);
+
+        assertThat(unspentUtxos).isEmpty();
     }
 
     private List<Transaction> transactions() {
@@ -153,6 +193,29 @@ public class UtxoProcessorTest {
                                         .quantity(BigInteger.valueOf(500))
                                         .build()))
                                 .build())
+                        .build()
+                )
+                .utxos(utxos(txHash, transactionOutputs()))
+                .build();
+
+        return List.of(transaction);
+    }
+
+    private List<Transaction> transactions_noCollateralReturn() {
+        String txHash = "f0a6e529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8";
+        Transaction transaction = Transaction.builder()
+                .txHash(txHash)
+                .body(TransactionBody.builder()
+                        .inputs(Set.of(
+                                new TransactionInput("aaaae529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8", 1),
+                                new TransactionInput("bbbbe529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8", 2),
+                                new TransactionInput("cccce529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8", 0)
+                        ))
+                        .outputs(transactionOutputs())
+                        .collateralInputs(Set.of(
+                                new TransactionInput("dddd529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8", 4),
+                                new TransactionInput("eeee529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8", 0)
+                        ))
                         .build()
                 )
                 .utxos(utxos(txHash, transactionOutputs()))

--- a/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessorTest.java
+++ b/stores/utxo/src/test/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessorTest.java
@@ -3,7 +3,6 @@ package com.bloxbean.cardano.yaci.store.utxo.processor;
 import com.bloxbean.cardano.yaci.core.model.*;
 import com.bloxbean.cardano.yaci.helper.model.Transaction;
 import com.bloxbean.cardano.yaci.helper.model.Utxo;
-import com.bloxbean.cardano.yaci.store.client.staking.StakingClient;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
@@ -41,9 +40,6 @@ public class UtxoProcessorTest {
     @Mock
     private ApplicationEventPublisher publisher;
 
-    @Mock
-    private StakingClient stakingClient;
-
     @InjectMocks
     private UtxoProcessor utxoProcessor;
 
@@ -57,7 +53,7 @@ public class UtxoProcessorTest {
     @BeforeEach
     public void setup() {
 //        openMocks(this);
-        utxoProcessor = new UtxoProcessor(utxoStorage, publisher, stakingClient, meterRegistry);
+        utxoProcessor = new UtxoProcessor(utxoStorage, publisher, meterRegistry);
     }
 
     @Test


### PR DESCRIPTION
- Fixed utxo processing for transactions without collateral return in UtxoProcessor. 

- Refactored tests to update the handling of spent and unspent UTXOs, including new test cases for scenarios with no collateral return.

- Remove default host/port/protocol magic as IOHK mainnet server are not available now