### PR TITLE
Add policyId and assetName extraction for balances

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/StringUtil.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/StringUtil.java
@@ -1,8 +1,24 @@
 package com.bloxbean.cardano.yaci.store.common.util;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
 public class StringUtil {
 
     public static boolean isEmpty(String str) {
         return str == null || str.isEmpty();
+    }
+
+    public static boolean isValidUTF8(byte[] input) {
+        CharsetDecoder cs = Charset.forName("UTF-8").newDecoder();
+
+        try {
+            cs.decode(ByteBuffer.wrap(input));
+            return true;
+        } catch (CharacterCodingException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Refactored `AccountController` to include policyId and assetName for balance units. Implemented `getPolicyIdAndAssetName` utility method and added `isValidUTF8` method in `StringUtil` for proper asset name decoding.

To fix #363 