### PR TITLE
Feat/addr Add get transactions by address endpoint

### DIFF
--- a/api-tests/address.http
+++ b/api-tests/address.http
@@ -1,0 +1,33 @@
+###
+### Get utxos by address
+GET {{base_url}}/api/v1/addresses/addr_test1wppg9l6relcpls4u667twqyggkrpfrs5cdge9hhl9cv2upchtch0h/utxos?count=10&page=0&order=desc
+
+> {%
+    client.test("Get utxos by address", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 10, "No of returned utxos is not 10: " + response.body.length)
+    });
+%}
+
+###
+### Get transactions by address and asset
+GET {{base_url}}/api/v1/addresses/addr_test1wppg9l6relcpls4u667twqyggkrpfrs5cdge9hhl9cv2upchtch0h/utxos/c2ecc337337cf48720e3747c833c9c179e08d2ea235d9bee7afbcb1741555448?count=2&page=0&order=desc
+
+> {%
+    client.test("Get utxos by address and asset", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "No of returned utxos is not 2: " + response.body.length)
+    });
+%}
+
+###
+### Get transactions by address
+GET {{base_url}}/api/v1/addresses/addr_test1wppg9l6relcpls4u667twqyggkrpfrs5cdge9hhl9cv2upchtch0h/transactions?count=10&page=0&order=desc
+
+> {%
+    client.test("Get transactions by address", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 10, "No of returned transactions is not 10: " + response.body.length)
+    });
+%}
+

--- a/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorageReader.java
+++ b/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorageReader.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
 import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressTransaction;
 import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorageReader;
 import com.bloxbean.rocks.types.collection.RocksMap;
 import com.bloxbean.rocks.types.collection.RocksMultiZSet;
@@ -60,6 +61,11 @@ public class RocksDBUtxoStorageReader implements UtxoStorageReader {
         return utxoMap.multiGet(utxoKeys.stream()
                 .map(utxoKey -> getKey(utxoKey.getTxHash(), utxoKey.getOutputIndex()))
                 .toList());
+    }
+
+    @Override
+    public List<AddressTransaction> findTransactionsByAddress(String address, int page, int count, Order order) {
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @SneakyThrows

--- a/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/controller/AddressController.java
+++ b/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/controller/AddressController.java
@@ -65,7 +65,7 @@ public class AddressController {
     }
 
     @GetMapping("{address}/transactions")
-    @Operation(summary = "Get transactions for an address starting from the latest")
+    @Operation(summary = "Get transactions for an address (Base address or Payment address) starting from the latest")
     public List<AddressTransaction> getAddressTransactions(@PathVariable String address, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
                                                            @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
         //TODO -- Fix pagination index

--- a/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/controller/AddressController.java
+++ b/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/controller/AddressController.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.api.utxo.controller;
 import com.bloxbean.cardano.yaci.store.api.utxo.service.AddressService;
 import com.bloxbean.cardano.yaci.store.common.domain.Utxo;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressTransaction;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -30,7 +31,7 @@ public class AddressController {
     @GetMapping("{address}/utxos")
     @Operation(summary = "Get UTxOs for an address or address verification key hash (addr_vkh). If the address is a stake address, it will return UTXOs for all base addresses associated with the stake address")
     public List<Utxo> getUtxos(@PathVariable String address, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
-                               @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "asc") Order order) {
+                               @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
         //TODO -- Fix pagination index
         int p = page;
         if (p > 0)
@@ -48,7 +49,7 @@ public class AddressController {
     @GetMapping("{address}/utxos/{asset}")
     @Operation(summary = "Get UTxOs for an address or address verification key hash (addr_vkh) for a specific asset. If the address is a stake address, it will return UTXOs for all base addresses associated with the stake address")
     public List<Utxo> getUtxosForAsset(@PathVariable String address, @PathVariable String asset, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
-                                       @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "asc") Order order) {
+                                       @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
         //TODO -- Fix pagination index
         int p = page;
         if (p > 0)
@@ -61,5 +62,17 @@ public class AddressController {
         } else { //By address
             return addressService.getUtxoByAddressAndAsset(address, asset, p, count, order);
         }
+    }
+
+    @GetMapping("{address}/transactions")
+    @Operation(summary = "Get transactions for an address starting from the latest")
+    public List<AddressTransaction> getAddressTransactions(@PathVariable String address, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                           @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
+        //TODO -- Fix pagination index
+        int p = page;
+        if (p > 0)
+            p = p - 1;
+
+        return addressService.getTransactionsByAddress(address, p, count, order);
     }
 }

--- a/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/service/AddressService.java
+++ b/stores-api/utxo-api/src/main/java/com/bloxbean/cardano/yaci/store/api/utxo/service/AddressService.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.client.crypto.Bech32;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.yaci.store.common.domain.Utxo;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressTransaction;
 import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorageReader;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +62,10 @@ public class AddressService {
         return utxoStorage.findUtxoByStakeAddressAndAsset(stakeAddress, asset, page, count, order)
                 .stream()
                 .map(UtxoUtil::addressUtxoToUtxo).collect(Collectors.toList());
+    }
+
+    public List<AddressTransaction> getTransactionsByAddress(@NonNull String address, int page, int count, Order order) {
+        return utxoStorage.findTransactionsByAddress(address, page, count, order);
     }
 
     private static String getPaymentCredential(String address) {

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/domain/AddressTransaction.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/domain/AddressTransaction.java
@@ -1,0 +1,21 @@
+package com.bloxbean.cardano.yaci.store.utxo.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AddressTransaction {
+    private String txHash;
+    private Long blockNumber;
+    private Long blockTime;
+}

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorageReader.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorageReader.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.utxo.storage;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressTransaction;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +19,6 @@ public interface UtxoStorageReader {
     List<AddressUtxo> findUtxoByStakeAddress(String stakeAddress, int page, int count, Order order);
     List<AddressUtxo> findUtxoByStakeAddressAndAsset(String stakeAddress, String unit, int page, int count, Order order);
     List<AddressUtxo> findAllByIds(List<UtxoKey> utxoKeys);
+
+    List<AddressTransaction> findTransactionsByAddress(String address, int page, int count, Order order);
 }


### PR DESCRIPTION
- Endpoint to get transactions by address
- Change the default ordering of other endpoints to `desc` (But ordering is not currently implemented for other endpoints in the controller)
- Http tests for address endpoints

#368 