### PR TITLE
Update Cardano config and Docker images to rc6

### DIFF
--- a/docker/application.properties
+++ b/docker/application.properties
@@ -13,7 +13,7 @@ store.cardano.protocol-magic=1
 #store.cardano.protocol-magic=2
 
 #Ucomment below for mainnet
-#store.cardano.host=relays-new.cardano-mainnet.iohk.io
+#store.cardano.host=backbone.cardano.iog.io
 #store.cardano.port=3001
 #store.cardano.protocol-magic=764824073
 
@@ -174,8 +174,23 @@ store.auto-index-management=true
 #store.staking.endpoints.pool.enabled=false
 #store.staking.endpoints.account.enabled=false
 #store.script.endpoints.script.enabled=false
-#store.governance.endpoints.govActionProposal.enabled=false
-#store.governance.endpoints.votingProcedure.enabled=false
+
+#store.governance.endpoints.committee.enabled=false
+#store.governance.endpoints.constitution.enabled=false
+#store.governance.endpoints.delegation-vote.enabled=false
+#store.governance.endpoints.drep.enabled=false
+#store.governance.endpoints.proposal.enabled=false
+#store.governance.endpoints.vote.enabled=false
+
+###############################################################
+# Local/Live Endpoint Configuration
+# If you want to enable/disable local endpoints for a store, set the following flags to true/false.
+# The default value of the flags are provided below.
+###############################################################
+#store.epoch.endpoints.epoch.local.enabled=false
+#store.governance.endpoints.committee.live.enabled=true
+#store.governance.endpoints.constitution.live.enabled=true
+#store.governance.endpoints.drep.live.enabled=true
 
 #############################################################
 # Enable Spring Boot Admin Client to monitor this application
@@ -250,6 +265,15 @@ logging.level.com.bloxbean.cardano.yaci.store.core.service=INFO
 #######################################################################################
 #store.cardano.ogmios-url=http://ogmios-host:1337
 
+#######################################################################################
+# N2c Pool Configuration
+# This is only used when n2c settings are provided.
+#######################################################################################
+#store.cardano.n2c-pool-enabled=true
+#store.cardano.n2c-max-total=10
+#store.cardano.n2c-pool-min-idle=2
+#store.cardano.n2c-pool-max-idle=5
+#store.cardano.n2c-pool-max-wait-in-millis=10000
 
 #################################################
 # Epoch aggregation interval in seconds. Epoch aggregations like total txs in an epoch, total fees in an epoch are
@@ -265,3 +289,9 @@ store.epoch-aggr.enabled=false
 store.epoch-aggr.api-enabled=true
 store.epoch-aggr.epoch-calculation-interval=14400
 store.epoch-aggr.epoch-calculation-enabled=false
+
+#######################################################################################
+# Read-Only Mode Configuration
+# Default value = "false", To disable a store, set the flag to "true"
+#######################################################################################
+#store.read-only-mode=true

--- a/docker/yaci-store-aggregation.yml
+++ b/docker/yaci-store-aggregation.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-aggregation:
-    image: bloxbean/yaci-store-aggregation-app:0.1.0-rc4
+    image: bloxbean/yaci-store-aggregation-app:0.1.0-rc6
     container_name: yaci-store-aggregation
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=aggregation}

--- a/docker/yaci-store-all.yml
+++ b/docker/yaci-store-all.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-all:
-    image: bloxbean/yaci-store-all:0.1.0-rc4
+    image: bloxbean/yaci-store-all:0.1.0-rc6
     container_name: yaci-store-all
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=yaci_store}

--- a/docker/yaci-store-utxo-indexer.yml
+++ b/docker/yaci-store-utxo-indexer.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-utxo-indexer:
-    image: bloxbean/yaci-store-utxo-indexer:0.1.0-rc4
+    image: bloxbean/yaci-store-utxo-indexer:0.1.0-rc6
     container_name: yaci-store-utxo-indexer
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=utxo_indexer}


### PR DESCRIPTION
Switched Cardano host to a new URL and added new governance and pool configuration settings in application.properties. Updated yaci-store Docker images to version 0.1.0-rc6 for various services.