### PR TITLE
feat: added get BlocksByEpochAPI + readded pages to blocks API

### DIFF
--- a/stores-api/blocks-api/src/main/java/com/bloxbean/cardano/yaci/store/api/blocks/controller/BlockController.java
+++ b/stores-api/blocks-api/src/main/java/com/bloxbean/cardano/yaci/store/api/blocks/controller/BlockController.java
@@ -43,6 +43,16 @@ public class BlockController {
         }
     }
 
+    @GetMapping("epoch/{epoch}")
+    @Operation(summary = "Block List by Epoch", description = "Get blocks by epoch number.")
+    public ResponseEntity<BlocksPage> getBlocksByEpoch(@PathVariable int epoch, @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
+                                                           @RequestParam(name = "count", defaultValue = "10") @Min(1) @Max(100) int count){
+        int p = page;
+        if (p > 0)
+            p = p - 1;
+        return ResponseEntity.ok(blockService.getBlocksByEpoch(epoch, p, count));
+    }
+
     @GetMapping
     @Operation(summary = "Block List", description = "Get blocks by page number and count.")
     public ResponseEntity<BlocksPage> getBlocks(@RequestParam(name = "page", defaultValue = "0") @Min(0) int page,

--- a/stores-api/blocks-api/src/main/java/com/bloxbean/cardano/yaci/store/api/blocks/service/BlockService.java
+++ b/stores-api/blocks-api/src/main/java/com/bloxbean/cardano/yaci/store/api/blocks/service/BlockService.java
@@ -34,4 +34,8 @@ public class BlockService {
     public Optional<Block> getLatestBlock() {
         return blockReader.findRecentBlock();
     }
+
+    public BlocksPage getBlocksByEpoch(int epoch, int page, int count) {
+        return blockReader.findBlocksByEpoch(epoch, page, count);
+    }
 }

--- a/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/BlockStorageReader.java
+++ b/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/BlockStorageReader.java
@@ -21,4 +21,6 @@ public interface BlockStorageReader {
     List<PoolBlock> findBlocksBySlotLeaderAndEpoch(String slotLeader, int epoch);
 
     int totalBlocksInEpoch(int epochNumber);
+
+    BlocksPage findBlocksByEpoch(int epoch, int page, int count);
 }

--- a/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/repository/BlockRepository.java
+++ b/stores/blocks/src/main/java/com/bloxbean/cardano/yaci/store/blocks/storage/impl/repository/BlockRepository.java
@@ -1,8 +1,8 @@
 package com.bloxbean.cardano.yaci.store.blocks.storage.impl.repository;
 
 import com.bloxbean.cardano.yaci.store.blocks.storage.impl.model.BlockEntity;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -25,11 +25,14 @@ public interface BlockRepository extends JpaRepository<BlockEntity, String> {
     List<BlockEntity> findByEpochNumber(int epochNumber);
 
     @Query("select b from BlockEntity b")
-    Slice<BlockEntity> findAllBlocks(Pageable pageable);
+    Page<BlockEntity> findAllBlocks(Pageable pageable);
 
     List<BlockEntity> getBlockEntitiesBySlotLeaderAndEpochNumber(String slotLeader, int epochNumber);
 
     @Query("select count(b.number) from BlockEntity b where b.epochNumber = :epochNumber")
     int totalBlocksInEpoch(int epochNumber);
+
+
+    Page<BlockEntity> findByEpochNumber(int epochNumber, Pageable pageable);
 }
 


### PR DESCRIPTION
Hi,
I added a small API to the blocks controller to get Blocks by Epoch. We can discuss how the Endpoint should be called, currently just a placeholder.
Additionally I readded the Page to get Blocks. This allows users to easier query how many blocks are present at all. 

I assume you had a reason, why you removed the `Page` object and replaced it with `slice`. Was it due to performance?
I'm currently only letting this run on preprod, so can't say anything about speed on mainnet. 
I'll test soon. 