### PR TITLE
feat: #449 store reward from treasury withdrawal action

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/TreasuryWithdrawalProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/TreasuryWithdrawalProcessor.java
@@ -1,0 +1,115 @@
+package com.bloxbean.cardano.yaci.store.governanceaggr.processor;
+
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yaci.core.model.governance.actions.TreasuryWithdrawalsAction;
+import com.bloxbean.cardano.yaci.store.client.governance.ProposalStateClient;
+import com.bloxbean.cardano.yaci.store.common.domain.GovActionProposal;
+import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
+import com.bloxbean.cardano.yaci.store.events.domain.*;
+import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorageReader;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class TreasuryWithdrawalProcessor {
+
+    private final ProposalStateClient proposalStateClient;
+    private final ApplicationEventPublisher publisher;
+    private final StakingCertificateStorageReader stakingCertificateStorageReader;
+    private final ObjectMapper objectMapper;
+
+    public TreasuryWithdrawalProcessor(ProposalStateClient proposalStateClient, ApplicationEventPublisher publisher,
+                                       StakingCertificateStorageReader stakingCertificateStorageReader, ObjectMapper objectMapper) {
+        this.proposalStateClient = proposalStateClient;
+        this.publisher = publisher;
+        this.stakingCertificateStorageReader = stakingCertificateStorageReader;
+        this.objectMapper = objectMapper;
+    }
+
+    @EventListener
+    public void handleTreasuryWithdrawal(ProposalStatusCapturedEvent event) {
+        int currentEpoch = event.getEpoch();
+        long slot = event.getSlot();
+
+        List<GovActionProposal> ratifiedProposalsInPrevEpoch =
+                proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, currentEpoch);
+
+        List<RewardRestAmt> rewardRestAmts = new ArrayList<>();
+        List<RewardRestAmt> unclaimedRewardRestAmts = new ArrayList<>();
+
+        for (var proposal : ratifiedProposalsInPrevEpoch) {
+            if (proposal.getType() != GovActionType.TREASURY_WITHDRAWALS_ACTION) {
+                continue;
+            }
+
+            try {
+                TreasuryWithdrawalsAction treasuryWithdrawalsAction = objectMapper.treeToValue(proposal.getDetails(), TreasuryWithdrawalsAction.class);
+                var withdrawals = treasuryWithdrawalsAction.getWithdrawals();
+
+                for (var withdrawal : withdrawals.entrySet()) {
+                    String addressHash = withdrawal.getKey();
+                    BigInteger amount = withdrawal.getValue();
+
+                    Address address = new Address(HexUtil.decodeHexString(addressHash));
+
+                    var regCert = stakingCertificateStorageReader
+                            .getRegistrationByStakeAddress(address.getAddress(), slot)
+                            .orElse(null);
+
+                    if (regCert == null || regCert.getType() == CertificateType.STAKE_DEREGISTRATION
+                            || regCert.getType() == CertificateType.UNREG_CERT) { //account not found or deregistered
+                        // TODO: verify this case
+                        log.info("Address is not registered. or deregistered :{}", address.getAddress());
+                        unclaimedRewardRestAmts.add(RewardRestAmt.builder()
+                                .address(address.getAddress())
+                                .type(RewardRestType.treasury)
+                                .amount(amount)
+                                .build());
+                    } else {
+                        rewardRestAmts.add(RewardRestAmt.builder()
+                                .address(address.getAddress())
+                                .type(RewardRestType.treasury)
+                                .amount(amount)
+                                .build());
+                    }
+
+
+                }
+            } catch (JsonProcessingException e) {
+                log.error("Error converting to TreasuryWithdrawalsAction", e);
+            }
+        }
+
+        if (!rewardRestAmts.isEmpty()) {
+            var rewardRestEvent = RewardRestEvent.builder()
+                    .earnedEpoch(currentEpoch)
+                    .spendableEpoch(currentEpoch + 1)
+                    .slot(slot)
+                    .rewards(rewardRestAmts)
+                    .build();
+            publisher.publishEvent(rewardRestEvent);
+        }
+
+        if (!unclaimedRewardRestAmts.isEmpty()) {
+            var unclaimedRewardRestEvent = UnclaimedRewardRestEvent.builder()
+                    .earnedEpoch(currentEpoch)
+                    .spendableEpoch(currentEpoch + 1)
+                    .slot(slot)
+                    .rewards(unclaimedRewardRestAmts)
+                    .build();
+            publisher.publishEvent(unclaimedRewardRestEvent);
+        }
+    }
+}

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/TreasuryWithdrawalProcessorTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/TreasuryWithdrawalProcessorTest.java
@@ -1,0 +1,197 @@
+package com.bloxbean.cardano.yaci.store.governanceaggr.processor;
+
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yaci.core.model.governance.actions.TreasuryWithdrawalsAction;
+import com.bloxbean.cardano.yaci.store.client.governance.ProposalStateClient;
+import com.bloxbean.cardano.yaci.store.common.domain.GovActionProposal;
+import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
+import com.bloxbean.cardano.yaci.store.events.domain.*;
+import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
+import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorageReader;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TreasuryWithdrawalProcessorTest {
+
+    @Mock
+    private ProposalStateClient proposalStateClient;
+
+    @Mock
+    private ApplicationEventPublisher publisher;
+
+    @Mock
+    private StakingCertificateStorageReader stakingCertificateStorageReader;
+
+    private TreasuryWithdrawalProcessor treasuryWithdrawalProcessor;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        treasuryWithdrawalProcessor = new TreasuryWithdrawalProcessor(proposalStateClient, publisher, stakingCertificateStorageReader, objectMapper);
+    }
+
+    @Test
+    void testHandleTreasuryWithdrawal_noEnactedProposals_found() {
+        ProposalStatusCapturedEvent event = ProposalStatusCapturedEvent.builder()
+                .epoch(100)
+                .slot(1234L)
+                .build();
+
+        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, 100))
+                .thenReturn(Collections.emptyList());
+
+        treasuryWithdrawalProcessor.handleTreasuryWithdrawal(event);
+
+        verify(publisher, never()).publishEvent(any(RewardRestEvent.class));
+        verify(publisher, never()).publishEvent(any(UnclaimedRewardRestEvent.class));
+    }
+
+    @Test
+    void testHandleTreasuryWithdrawal_proposalsButNoTreasuryType_noEventsPublished() {
+        ProposalStatusCapturedEvent event = ProposalStatusCapturedEvent.builder()
+                .epoch(100)
+                .slot(1234L)
+                .build();
+
+        GovActionProposal ratifiedProposalInPrevEpoch = new GovActionProposal();
+
+        ratifiedProposalInPrevEpoch.setEpoch(100);
+        ratifiedProposalInPrevEpoch.setType(GovActionType.NEW_CONSTITUTION);
+
+        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, 100))
+                .thenReturn(Collections.singletonList(ratifiedProposalInPrevEpoch));
+
+        treasuryWithdrawalProcessor.handleTreasuryWithdrawal(event);
+
+        verify(publisher, never()).publishEvent(any(RewardRestEvent.class));
+        verify(publisher, never()).publishEvent(any(UnclaimedRewardRestEvent.class));
+    }
+
+    @Test
+    void testHandleTreasuryWithdrawal_treasuryTypeButInvalidJson_noEventsPublished() {
+        ProposalStatusCapturedEvent event = ProposalStatusCapturedEvent.builder()
+                .epoch(100)
+                .slot(1234L)
+                .build();
+
+        GovActionProposal proposal = new GovActionProposal();
+
+        proposal.setEpoch(100);
+        proposal.setType(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        JsonNode invalidJsonNode = objectMapper.createObjectNode().put("invalid", "data");
+        proposal.setDetails(invalidJsonNode);
+
+        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, 100))
+                .thenReturn(Collections.singletonList(proposal));
+
+
+        treasuryWithdrawalProcessor.handleTreasuryWithdrawal(event);
+
+        verify(publisher, never()).publishEvent(any(RewardRestEvent.class));
+        verify(publisher, never()).publishEvent(any(UnclaimedRewardRestEvent.class));
+    }
+
+    @Test
+    void testHandleTreasuryWithdrawal_validTreasuryProposal_someAddresses() throws Exception {
+        int epoch = 100;
+        long slot = 2000;
+
+        ProposalStatusCapturedEvent event = ProposalStatusCapturedEvent.builder()
+                .epoch(epoch)
+                .slot(slot)
+                .build();
+
+        Map<String, BigInteger> withdrawalsMap = new HashMap<>();
+
+        String addressA = "e0720bce084cdd9ca5c9ee13a69052a24b53031aba67258e777e45cf03"; // stake_test1upeqhnsgfnweefwfacf6dyzj5f94xqc6hfnjtrnh0ezu7qclg7p6m
+        String addressB = "e003a6388659a93f8d463fbd1537b9039c72e76c623158b4c8c061dea8"; // stake_test1uqp6vwyxtx5nlr2x87732daeqww89emvvgc43dxgcpsaa2q6klkvm
+        withdrawalsMap.put(addressA, BigInteger.valueOf(1000));
+        withdrawalsMap.put(addressB, BigInteger.valueOf(2000));
+
+        TreasuryWithdrawalsAction treasuryWithdrawalsAction = TreasuryWithdrawalsAction.builder()
+                .withdrawals(withdrawalsMap)
+                .policyHash("186e32faa80a26810392fda6d559c7ed4721a65ce1c9d4ef3e1c87b4")
+                .build();
+
+        GovActionProposal proposal = new GovActionProposal();
+
+        proposal.setEpoch(epoch);
+        proposal.setType(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+        JsonNode detailsNode = objectMapper.valueToTree(treasuryWithdrawalsAction);
+        proposal.setDetails(detailsNode);
+
+        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, epoch))
+                .thenReturn(Collections.singletonList(proposal));
+
+        StakeRegistrationDetail stakingCertA = new StakeRegistrationDetail();
+        stakingCertA.setType(CertificateType.STAKE_REGISTRATION);
+
+        when(stakingCertificateStorageReader.getRegistrationByStakeAddress(anyString(), eq(slot)))
+                .thenAnswer(invocation -> {
+                    String stakeAddr = invocation.getArgument(0, String.class);
+                    if (stakeAddr.equals("stake_test1upeqhnsgfnweefwfacf6dyzj5f94xqc6hfnjtrnh0ezu7qclg7p6m")) {
+                        return Optional.of(stakingCertA);
+                    } else {
+                        return Optional.empty();
+                    }
+                });
+
+        treasuryWithdrawalProcessor.handleTreasuryWithdrawal(event);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(publisher, times(2)).publishEvent(eventCaptor.capture());
+
+        List<Object> publishedEvents = eventCaptor.getAllValues();
+        assertEquals(2, publishedEvents.size());
+
+        RewardRestEvent rewardEvent = null;
+        UnclaimedRewardRestEvent unclaimedEvent = null;
+
+        for (Object e : publishedEvents) {
+            if (e instanceof RewardRestEvent) {
+                rewardEvent = (RewardRestEvent) e;
+            } else if (e instanceof UnclaimedRewardRestEvent) {
+                unclaimedEvent = (UnclaimedRewardRestEvent) e;
+            }
+        }
+
+        assertNotNull(rewardEvent);
+        assertEquals(epoch, rewardEvent.getEarnedEpoch());
+        assertEquals(epoch + 1, rewardEvent.getSpendableEpoch());
+        assertEquals(slot, rewardEvent.getSlot());
+        assertEquals(1, rewardEvent.getRewards().size());
+        RewardRestAmt rrA = rewardEvent.getRewards().get(0);
+        assertEquals("stake_test1upeqhnsgfnweefwfacf6dyzj5f94xqc6hfnjtrnh0ezu7qclg7p6m", rrA.getAddress());
+        assertEquals(BigInteger.valueOf(1000), rrA.getAmount());
+        assertEquals(RewardRestType.treasury, rrA.getType());
+
+        assertNotNull(unclaimedEvent);
+        assertEquals(epoch, unclaimedEvent.getEarnedEpoch());
+        assertEquals(epoch + 1, unclaimedEvent.getSpendableEpoch());
+        assertEquals(slot, unclaimedEvent.getSlot());
+        assertEquals(1, unclaimedEvent.getRewards().size());
+        RewardRestAmt rrB = unclaimedEvent.getRewards().get(0);
+        assertEquals("stake_test1uqp6vwyxtx5nlr2x87732daeqww89emvvgc43dxgcpsaa2q6klkvm", rrB.getAddress());
+        assertEquals(BigInteger.valueOf(2000), rrB.getAmount());
+        assertEquals(RewardRestType.treasury, rrB.getType());
+    }
+}

--- a/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/domain/RewardRestType.java
+++ b/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/domain/RewardRestType.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.events.domain;
 
 public enum RewardRestType {
-    proposal_refund
+    proposal_refund,
+    treasury
 }


### PR DESCRIPTION
- Store the reward in the 'reward_rest' table, where the earned_epoch is the ratified epoch, and the spendable epoch is the earned_epoch plus 1 (the enacted epoch). The reward type is 'treasury'.
- Verified with yaci-devkit: The effect of this reward type on epoch stake is similar to that of the proposal refund.