### PR TITLE
Fix: treasury withdrawal ratification not working as expected with DevKit node 

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/GovernanceAggrProperties.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/GovernanceAggrProperties.java
@@ -10,17 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class GovernanceAggrProperties {
-
-    /**
-     * Indicates whether the bootstrap phase is available in the Conway era.
-     * <p>
-     * - On public networks (e.g., mainnet, preview, preprod), the Conway era includes a bootstrap phase.
-     * </p>
-     * <p>
-     * - On devnet environments (e.g., yaci-devkit), the bootstrap phase may exist or not exist
-     * </p>
-     * Default: {@code false}.
-     */
     @Builder.Default
-    private boolean isConwayBootstrapAvailable = false;
+    private boolean isDevnetConwayBootstrapAvailable = false;
 }

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/GovernanceAggrProperties.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/GovernanceAggrProperties.java
@@ -1,0 +1,26 @@
+package com.bloxbean.cardano.yaci.store.governanceaggr;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GovernanceAggrProperties {
+
+    /**
+     * Indicates whether the bootstrap phase is available in the Conway era.
+     * <p>
+     * - On public networks (e.g., mainnet, preview, preprod), the Conway era includes a bootstrap phase.
+     * </p>
+     * <p>
+     * - On devnet environments (e.g., yaci-devkit), the bootstrap phase may exist or not exist
+     * </p>
+     * Default: {@code false}.
+     */
+    @Builder.Default
+    private boolean isConwayBootstrapAvailable = false;
+}

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
@@ -1,6 +1,5 @@
 package com.bloxbean.cardano.yaci.store.governanceaggr.processor;
 
-import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.yaci.core.model.Credential;
 import com.bloxbean.cardano.yaci.core.model.governance.DrepType;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
@@ -11,7 +10,6 @@ import com.bloxbean.cardano.yaci.store.adapot.domain.EpochStake;
 import com.bloxbean.cardano.yaci.store.adapot.storage.AdaPotStorage;
 import com.bloxbean.cardano.yaci.store.adapot.storage.EpochStakeStorageReader;
 import com.bloxbean.cardano.yaci.store.client.governance.ProposalStateClient;
-import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionProposal;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
 import com.bloxbean.cardano.yaci.store.common.util.ListUtil;
@@ -24,6 +22,7 @@ import com.bloxbean.cardano.yaci.store.governance.jackson.CredentialDeserializer
 import com.bloxbean.cardano.yaci.store.governance.storage.CommitteeMemberStorage;
 import com.bloxbean.cardano.yaci.store.governance.storage.CommitteeStorage;
 import com.bloxbean.cardano.yaci.store.governance.storage.GovActionProposalStorage;
+import com.bloxbean.cardano.yaci.store.governanceaggr.GovernanceAggrProperties;
 import com.bloxbean.cardano.yaci.store.governanceaggr.domain.DRepDist;
 import com.bloxbean.cardano.yaci.store.governanceaggr.domain.GovActionProposalStatus;
 import com.bloxbean.cardano.yaci.store.governanceaggr.domain.Proposal;
@@ -78,10 +77,9 @@ public class ProposalStatusProcessor {
     private final PoolStorageReader poolStorageReader;
     private final DelegationVoteDataService delegationVoteDataService;
     private final ProposalMapper proposalMapper;
-    private final StoreProperties storeProperties;
     private final ApplicationEventPublisher publisher;
-
-    private boolean isBootstrapPhase = true;
+    private final GovernanceAggrProperties governanceAggrProperties;
+    private boolean isInConwayBootstrapPhase;
     private final ObjectMapper objectMapper;
     private final int QUERY_BATCH_SIZE = 500;
 
@@ -90,8 +88,8 @@ public class ProposalStatusProcessor {
                                    EpochParamStorage epochParamStorage, CommitteeStorage committeeStorage,
                                    VotingAggrService votingAggrService, EpochStakeStorageReader epochStakeStorage,
                                    DRepDistStorageReader dRepDistStorage, AdaPotStorage adaPotStorage,
-                                   CommitteeMemberStorage committeeMemberStorage, PoolStorage poolStorage, PoolStorageReader poolStorageReader, DelegationVoteDataService delegationVoteDataService, ProposalMapper proposalMapper, StoreProperties storeProperties,
-                                   ApplicationEventPublisher publisher) {
+                                   CommitteeMemberStorage committeeMemberStorage, PoolStorage poolStorage, PoolStorageReader poolStorageReader, DelegationVoteDataService delegationVoteDataService, ProposalMapper proposalMapper,
+                                   ApplicationEventPublisher publisher, GovernanceAggrProperties governanceAggrProperties) {
         this.govActionProposalStatusStorage = govActionProposalStatusStorage;
         this.govActionProposalStorage = govActionProposalStorage;
         this.dRepDistService = dRepDistService;
@@ -107,13 +105,15 @@ public class ProposalStatusProcessor {
         this.poolStorageReader = poolStorageReader;
         this.delegationVoteDataService = delegationVoteDataService;
         this.proposalMapper = proposalMapper;
-        this.storeProperties = storeProperties;
         this.publisher = publisher;
+        this.governanceAggrProperties = governanceAggrProperties;
 
         this.objectMapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
         module.addKeyDeserializer(Credential.class, new CredentialDeserializer());
         this.objectMapper.registerModule(module);
+
+        this.isInConwayBootstrapPhase = governanceAggrProperties.isConwayBootstrapAvailable();
     }
 
     @EventListener
@@ -139,17 +139,13 @@ public class ProposalStatusProcessor {
                         .build()
         ).toList());
 
-        if (isDevnet()) {
-            isBootstrapPhase = false;
-        }
-
         try {
-            if (isBootstrapPhase) {
+            if (isInConwayBootstrapPhase) {
                 // check if there is any enacted hard fork initiation action in the past, if so, the bootstrap phase is over
                 var enactedProposal = proposalStateClient.getLastEnactedProposal(GovActionType.HARD_FORK_INITIATION_ACTION, currentEpoch);
                 if (enactedProposal.stream().anyMatch(govActionProposalStatus
                         -> govActionProposalStatus.getGovAction().getType().equals(GovActionType.HARD_FORK_INITIATION_ACTION))) {
-                    isBootstrapPhase = false;
+                    isInConwayBootstrapPhase = false;
                 }
             }
             // take dRep stake distribution snapshot
@@ -211,7 +207,7 @@ public class ProposalStatusProcessor {
             // get votes by DRep
             List<VotingProcedure> votesByDRep = new ArrayList<>();
 
-            if (!isBootstrapPhase) {
+            if (!isInConwayBootstrapPhase) {
                 votesByDRep = votingAggrService.getVotesByDRep(epoch, proposalsForStatusCalculation.stream().map(
                         govActionProposal -> GovActionId.builder()
                                 .transactionId(govActionProposal.getTxHash())
@@ -272,7 +268,7 @@ public class ProposalStatusProcessor {
             BigInteger totalDRepStake = BigInteger.ZERO;
             BigInteger dRepAutoAbstainStake = BigInteger.ZERO;
 
-            if (!isBootstrapPhase) {
+            if (!isInConwayBootstrapPhase) {
                 totalDRepStake = dRepDistStorage.getTotalStakeForEpoch(epoch)
                         .orElse(BigInteger.ZERO);
                 dRepAutoAbstainStake = dRepDistStorage.getStakeByDRepAndEpoch(DrepType.ABSTAIN.name(), epoch).orElse(BigInteger.ZERO);
@@ -386,7 +382,7 @@ public class ProposalStatusProcessor {
                 // DRep 'no' stake
                 BigInteger dRepNoStake = null;
 
-                if (!isBootstrapPhase) {
+                if (!isInConwayBootstrapPhase) {
                     /* Calculate dRep 'yes' stake */
                     /*
                         dRepYesStake – The total stake of:
@@ -497,7 +493,7 @@ public class ProposalStatusProcessor {
                 try {
                     // get ratification result
                     RatificationResult ratificationResult = GovActionRatifier.getRatificationResult(
-                            govActionDetail, isBootstrapPhase, maxAllowedVotingEpoch, ccYesVote, ccNoVote,
+                            govActionDetail, isInConwayBootstrapPhase, maxAllowedVotingEpoch, ccYesVote, ccNoVote,
                             ccThreshold, spoYesStake, spoAbstainStake, totalPoolStake,
                             dRepYesStake, dRepNoStake, ccState, lastEnactedGovActionIdWithSamePurpose, isActionRatificationDelayed,
                             treasury,
@@ -584,11 +580,5 @@ public class ProposalStatusProcessor {
                                 .transactionId(govActionProposal.getTxHash())
                                 .build()))
                 .toList();
-    }
-
-    private boolean isDevnet() {
-        return storeProperties.getProtocolMagic() != Networks.mainnet().getProtocolMagic()
-                && storeProperties.getProtocolMagic() != Networks.preprod().getProtocolMagic()
-                && storeProperties.getProtocolMagic() != Networks.preview().getProtocolMagic();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/CommitteeVotingState.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/CommitteeVotingState.java
@@ -18,6 +18,13 @@ public class CommitteeVotingState extends VotingState {
 
     @Override
     public boolean isAccepted() {
+        if (threshold == null || yesVote == null || noVote == null) {
+            return false;
+        }
+        if (threshold.equals(BigDecimal.ZERO)) {
+            return true;
+        }
+
         int totalVotes = yesVote + noVote;
         if (totalVotes == 0) {
             return false;

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/DRepVotingState.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/DRepVotingState.java
@@ -28,6 +28,10 @@ public class DRepVotingState extends VotingState {
 
     @Override
     public boolean isAccepted() {
+        if (ccState == null || dRepVotingThresholds == null || yesVoteStake == null || noVoteStake == null) {
+            return false;
+        }
+
         BigInteger totalExcludingAbstainStake = yesVoteStake.add(noVoteStake);
         double acceptedStakeRatio;
         if (totalExcludingAbstainStake.equals(BigInteger.ZERO)) {

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/GovActionRatifier.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/GovActionRatifier.java
@@ -123,9 +123,9 @@ public class GovActionRatifier {
             case TREASURY_WITHDRAWALS_ACTION:
                 TreasuryWithdrawalsAction treasuryWithdrawalsAction = (TreasuryWithdrawalsAction) govAction;
                 withdrawalCanWithdraw = GovernanceActionUtil.withdrawalCanWithdraw(treasuryWithdrawalsAction, treasury);
-                spoVotingState = buildSPOVotingState(govAction, spoYesVoteStake, spoAbstainVoteStake, spoTotalStake, ccState, currentEpochParam);
+                dRepVotingState = buildDRepVotingState(govAction, dRepYesVoteStake, dRepNoVoteStake, ccState, currentEpochParam);
                 committeeVotingState = buildCommitteeVotingState(govAction, ccYesVote, ccNoVote, ccThreshold);
-                isAccepted = committeeVotingState.isAccepted() && spoVotingState.isAccepted();
+                isAccepted = committeeVotingState.isAccepted() && dRepVotingState.isAccepted();
                 isNotDelayed = true;
 
                 break;

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/SPOVotingState.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/rule/SPOVotingState.java
@@ -30,6 +30,10 @@ public class SPOVotingState extends VotingState {
         boolean result;
         double acceptedStakeRatio;
 
+        if (poolVotingThresholds == null || yesVoteStake == null || abstainVoteStake == null || totalStake == null || ccState == null) {
+            return false;
+        }
+
         if (totalStake.equals(BigInteger.ZERO) || abstainVoteStake.equals(totalStake)) {
             acceptedStakeRatio = 0;
         } else {

--- a/config/application-ledger-state.properties
+++ b/config/application-ledger-state.properties
@@ -23,7 +23,7 @@ store.adapot.update-reward-db-batch-size=200
 
 # Governance aggregation properties
 store.governance-aggr.enabled=true
-store.governance-aggr.conway-bootstrap-available=true
+#store.governance-aggr.devnet-conway-bootstrap-available=true
 
 #store.utxo.save-address=true
 #store.utxo.address-cache-enabled=true

--- a/config/application-ledger-state.properties
+++ b/config/application-ledger-state.properties
@@ -23,6 +23,7 @@ store.adapot.update-reward-db-batch-size=200
 
 # Governance aggregation properties
 store.governance-aggr.enabled=true
+store.governance-aggr.conway-bootstrap-available=true
 
 #store.utxo.save-address=true
 #store.utxo.address-cache-enabled=true

--- a/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
+++ b/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "store", ignoreUnknownFields = true)
-public class GovernanceAggrStoreAutoConfigProperties {
+public class GovernanceAggrAutoConfigProperties {
     private GovernanceAggr governanceAggr;
 
     @Getter
@@ -16,6 +16,7 @@ public class GovernanceAggrStoreAutoConfigProperties {
         private boolean enabled = false;
         private boolean apiEnabled = true;
         private Endpoints endpoints = new Endpoints();
+        private boolean conwayBootstrapAvailable = false;
     }
 
     @Getter

--- a/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
+++ b/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
@@ -16,7 +16,7 @@ public class GovernanceAggrAutoConfigProperties {
         private boolean enabled = false;
         private boolean apiEnabled = true;
         private Endpoints endpoints = new Endpoints();
-        private boolean conwayBootstrapAvailable = false;
+        private boolean devnetConwayBootstrapAvailable = false;
     }
 
     @Getter

--- a/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrStoreAutoConfiguration.java
+++ b/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrStoreAutoConfiguration.java
@@ -1,15 +1,28 @@
 package com.bloxbean.cardano.yaci.store.starter.governanceaggr;
 
 import com.bloxbean.cardano.yaci.store.governanceaggr.GovernanceAggrConfiguration;
+import com.bloxbean.cardano.yaci.store.governanceaggr.GovernanceAggrProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
-@EnableConfigurationProperties(GovernanceAggrStoreAutoConfigProperties.class)
+@EnableConfigurationProperties(GovernanceAggrAutoConfigProperties.class)
 @Import({GovernanceAggrConfiguration.class, GovernanceAggrConfiguration.class})
 @Slf4j
 public class GovernanceAggrStoreAutoConfiguration {
 
+    @Autowired
+    GovernanceAggrAutoConfigProperties properties;
+
+    @Bean
+    public GovernanceAggrProperties governanceAggrProperties() {
+        GovernanceAggrProperties governanceAggrProperties = new GovernanceAggrProperties();
+        governanceAggrProperties.setConwayBootstrapAvailable(properties.getGovernanceAggr().isConwayBootstrapAvailable());
+
+        return governanceAggrProperties;
+    }
 }

--- a/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrStoreAutoConfiguration.java
+++ b/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrStoreAutoConfiguration.java
@@ -21,7 +21,7 @@ public class GovernanceAggrStoreAutoConfiguration {
     @Bean
     public GovernanceAggrProperties governanceAggrProperties() {
         GovernanceAggrProperties governanceAggrProperties = new GovernanceAggrProperties();
-        governanceAggrProperties.setConwayBootstrapAvailable(properties.getGovernanceAggr().isConwayBootstrapAvailable());
+        governanceAggrProperties.setDevnetConwayBootstrapAvailable(properties.getGovernanceAggr().isDevnetConwayBootstrapAvailable());
 
         return governanceAggrProperties;
     }


### PR DESCRIPTION
- In governance-rule, use DRep info instead of SPO info when the action is treasury withdrawal.
- In governance-rule, check for null in DRepVotingState, SPOVotingState, CommiteeVotingState
- In class ProposalStatusProcessor:
   - Rename isBootstrapPhase -> isInConwayBootstrapPhase
   - When retrieving the treasury value (The value helps us check whether a withdrawal is possible), use current epoch (the epoch at the time we calculate gov action status)
- Rename GovernanceAggrStoreAutoConfigProperties -> GovernanceAggrAutoConfigProperties
- Add property to check Conway bootstrap is available in devnet network