### PR TITLE
fix: Initialize GovernaceAggr to avoid NPE when the governance-aggr roperty is not there in the config file (yaci-store-all app)

### DIFF
--- a/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
+++ b/starters/governance-aggr-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/governanceaggr/GovernanceAggrAutoConfigProperties.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Setter
 @ConfigurationProperties(prefix = "store", ignoreUnknownFields = true)
 public class GovernanceAggrAutoConfigProperties {
-    private GovernanceAggr governanceAggr;
+    private GovernanceAggr governanceAggr = new GovernanceAggr();
 
     @Getter
     @Setter


### PR DESCRIPTION
- Initialize GovernaceAggr to avoid NPE when the governance-aggr roperty is not there in the config file (yaci-store-all app)