### PR TITLE
Update to Yaci 0.3.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bloxbean.cardano
-version = 0.1.2-beta
+version = 0.1.2-beta2
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.3.4.1"
+yaci = "com.bloxbean.cardano:yaci:0.3.5"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.6.2"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.6.2"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.6.2"


### PR DESCRIPTION
- Update Yaci to version 0.3.5, which includes the proper fix for the redeemer parsing error. The previous version, 0.3.4.1, only implemented a workaround.