### PR TITLE
feat: New api endpoints NetworkInfo Api, AdaPot Api, Rewards Api and updated Epoch Stake Api with http tests

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/AdaPotConfiguration.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/AdaPotConfiguration.java
@@ -54,8 +54,10 @@ public class AdaPotConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public RewardStorageReader rewardStorageReader(InstantRewardRepository instantRewardRepository, RewardRepository rewardRepository,
+                                                   RewardRestRepository rewardRestRepository,
+                                                   UnclaimedRewardRestRepository unclaimedRewardRestRepository,
                                                    Mapper rewardMapper) {
-        return new RewardStorageReaderImpl(instantRewardRepository, rewardRepository, rewardMapper);
+        return new RewardStorageReaderImpl(instantRewardRepository, rewardRepository, rewardRestRepository, unclaimedRewardRestRepository, rewardMapper);
     }
 
     @Bean

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationService.java
@@ -141,13 +141,13 @@ public class EpochRewardCalculationService {
         }
 
         //Get MIR certificates totals by pot ..stability window ??
-        var totalRewardsTreasury = rewardStorageReader.findTotalInstanceRewardByEarnedEpochAndType(epoch - 1, InstantRewardType.treasury);
+        var totalRewardsTreasury = rewardStorageReader.findTotalInstantRewardByEarnedEpochAndType(epoch - 1, InstantRewardType.treasury);
         var mirTreasuryCertificate = MirCertificate.builder()
                 .pot(org.cardanofoundation.rewards.calculation.enums.MirPot.TREASURY)
                 .totalRewards(totalRewardsTreasury != null ? totalRewardsTreasury : BigInteger.ZERO)
                 .build();
 
-        var totalRewardsReserves = rewardStorageReader.findTotalInstanceRewardByEarnedEpochAndType(epoch - 1, InstantRewardType.reserves);
+        var totalRewardsReserves = rewardStorageReader.findTotalInstantRewardByEarnedEpochAndType(epoch - 1, InstantRewardType.reserves);
         var mirCertificateReserves = MirCertificate.builder()
                 .pot(org.cardanofoundation.rewards.calculation.enums.MirPot.RESERVES)
                 .totalRewards(totalRewardsReserves != null ? totalRewardsReserves : BigInteger.ZERO)

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/RewardStorageReader.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/RewardStorageReader.java
@@ -1,16 +1,41 @@
 package com.bloxbean.cardano.yaci.store.adapot.storage;
 
 import com.bloxbean.cardano.yaci.store.adapot.domain.InstantReward;
+import com.bloxbean.cardano.yaci.store.adapot.domain.Reward;
+import com.bloxbean.cardano.yaci.store.adapot.domain.RewardRest;
+import com.bloxbean.cardano.yaci.store.adapot.domain.UnclaimedRewardRest;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
 import com.bloxbean.cardano.yaci.store.events.domain.InstantRewardType;
 
 import java.math.BigInteger;
 import java.util.List;
 
 public interface RewardStorageReader {
-    List<InstantReward> findInstantRewardByEarnedEpoch(long epoch, int page, int count);
+    //Instant Rewards
+    List<InstantReward> findInstantRewardByEarnedEpoch(Integer epoch, int page, int count);
+    List<InstantReward> findInstantRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType, int page, int count);
+    BigInteger findTotalInstanceRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType);
 
-    List<InstantReward> findInstantRewardByEarnedEpochAndType(long epoch, InstantRewardType rewardType, int page, int count);
+    //Pool Rewards
+    List<Reward> findRewardsByEarnedEpoch(Integer epoch, int page, int count);
+    List<Reward> findRewardsBySpendableEpoch(Integer epoch, int page, int count);
 
-    BigInteger findTotalInstanceRewardByEarnedEpochAndType(long epoch, InstantRewardType rewardType);
+    List<Reward> findRewardsByAddress(String address, int page, int count, Order order);
+    List<Reward> findRewardsByAddressAndEarnedEpoch(String address, Integer epoch);
+    List<Reward> findRewardsByAddressAndSpendableEpoch(String address, Integer epoch);
+
+    //Reward Rest
+    List<RewardRest> findRewardRestByEarnedEpoch(Integer epoch, int page, int count);
+    List<RewardRest> findRewardRestBySpendableEpoch(Integer epoch, int page, int count);
+
+    List<RewardRest> findRewardRestByAddress(String address, int page, int count, Order order);
+    List<RewardRest> findRewardRestByAddressAndEarnedEpoch(String address, Integer earnedEpoch);
+    List<RewardRest> findRewardRestByAddressAndSpendableEpoch(String address, Integer spendableEpoch);
+
+    //Unclaimed Reward Rest
+    List<UnclaimedRewardRest> findUnclaimedRewardRestByEarnedEpoch(Integer epoch, int page, int count, Order order);
+    List<UnclaimedRewardRest> findUnclaimedRewardRestBySpendableEpoch(Integer epoch, int page, int count, Order order);
+
+    List<Reward> findRewardsByPoolHashAndSpendableEpoch(String poolHash, Integer spendableEpoch, int page, int count);
 
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/RewardStorageReader.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/RewardStorageReader.java
@@ -14,7 +14,7 @@ public interface RewardStorageReader {
     //Instant Rewards
     List<InstantReward> findInstantRewardByEarnedEpoch(Integer epoch, int page, int count);
     List<InstantReward> findInstantRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType, int page, int count);
-    BigInteger findTotalInstanceRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType);
+    BigInteger findTotalInstantRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType);
 
     //Pool Rewards
     List<Reward> findRewardsByEarnedEpoch(Integer epoch, int page, int count);

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/RewardStorageReaderImpl.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/RewardStorageReaderImpl.java
@@ -45,7 +45,7 @@ public class RewardStorageReaderImpl implements RewardStorageReader {
     }
 
     @Override
-    public BigInteger findTotalInstanceRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType) {
+    public BigInteger findTotalInstantRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType) {
         return instantRewardRepository.findTotalAmountByEarnedEpoch(epoch, rewardType);
     }
 

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/RewardStorageReaderImpl.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/RewardStorageReaderImpl.java
@@ -1,10 +1,16 @@
 package com.bloxbean.cardano.yaci.store.adapot.storage.impl;
 
 import com.bloxbean.cardano.yaci.store.adapot.domain.InstantReward;
+import com.bloxbean.cardano.yaci.store.adapot.domain.Reward;
+import com.bloxbean.cardano.yaci.store.adapot.domain.RewardRest;
+import com.bloxbean.cardano.yaci.store.adapot.domain.UnclaimedRewardRest;
 import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorageReader;
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.mapper.Mapper;
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository.InstantRewardRepository;
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository.RewardRepository;
+import com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository.RewardRestRepository;
+import com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository.UnclaimedRewardRestRepository;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
 import com.bloxbean.cardano.yaci.store.events.domain.InstantRewardType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -18,10 +24,12 @@ import java.util.List;
 public class RewardStorageReaderImpl implements RewardStorageReader {
     private final InstantRewardRepository instantRewardRepository;
     private final RewardRepository rewardRepository;
+    private final RewardRestRepository rewardRestRepository;
+    private final UnclaimedRewardRestRepository unclaimedRewardRestRepository;
     private final Mapper mapper;
 
     @Override
-    public List<InstantReward> findInstantRewardByEarnedEpoch(long epoch, int page, int count) {
+    public List<InstantReward> findInstantRewardByEarnedEpoch(Integer epoch, int page, int count) {
         Pageable sortedBySlot =
                 PageRequest.of(page, count, Sort.by("slot").descending());
 
@@ -29,7 +37,7 @@ public class RewardStorageReaderImpl implements RewardStorageReader {
     }
 
     @Override
-    public List<InstantReward> findInstantRewardByEarnedEpochAndType(long epoch, InstantRewardType rewardType, int page, int count) {
+    public List<InstantReward> findInstantRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType, int page, int count) {
         Pageable sortedBySlot =
                 PageRequest.of(page, count, Sort.by("slot").descending());
 
@@ -37,8 +45,145 @@ public class RewardStorageReaderImpl implements RewardStorageReader {
     }
 
     @Override
-    public BigInteger findTotalInstanceRewardByEarnedEpochAndType(long epoch, InstantRewardType rewardType) {
-        return instantRewardRepository.findTotalAmountByEarnedEpoch((int) epoch, rewardType);
+    public BigInteger findTotalInstanceRewardByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType) {
+        return instantRewardRepository.findTotalAmountByEarnedEpoch(epoch, rewardType);
+    }
+
+    @Override
+    public List<Reward> findRewardsByEarnedEpoch(Integer epoch, int page, int count) {
+        Pageable pagable =
+                PageRequest.of(page, count);
+
+        return rewardRepository.findByEarnedEpoch(epoch, pagable)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<Reward> findRewardsBySpendableEpoch(Integer epoch, int page, int count) {
+        Pageable pagable =
+                PageRequest.of(page, count);
+
+        return rewardRepository.findBySpendableEpoch(epoch, pagable)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<Reward> findRewardsByAddress(String address, int page, int count, Order order) {
+        Pageable sortedBySlot =
+                getPagableBySlotOrder(page, count, order);
+
+        return rewardRepository.findByAddress(address, sortedBySlot)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<Reward> findRewardsByAddressAndEarnedEpoch(String address, Integer epoch) {
+        return rewardRepository.findByAddressAndEarnedEpoch(address, epoch)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<Reward> findRewardsByAddressAndSpendableEpoch(String address, Integer epoch) {
+        return rewardRepository.findByAddressAndSpendableEpoch(address, epoch)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+    //-- Reward Rest
+    @Override
+    public List<RewardRest> findRewardRestByEarnedEpoch(Integer epoch, int page, int count) {
+        Pageable pagable =
+                PageRequest.of(page, count);
+
+        return rewardRestRepository.findByEarnedEpoch(epoch, pagable)
+                .stream()
+                .map(rewardEntity -> mapper.toRewardRest(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<RewardRest> findRewardRestBySpendableEpoch(Integer epoch, int page, int count) {
+        Pageable pagable =
+                PageRequest.of(page, count);
+
+        return rewardRestRepository.findBySpendableEpoch(epoch, pagable)
+                .stream()
+                .map(rewardRestEntity -> mapper.toRewardRest(rewardRestEntity))
+                .toList();
+    }
+
+    @Override
+    public List<RewardRest> findRewardRestByAddress(String address, int page, int count, Order order) {
+        Pageable sortedBySlot = getPagableBySlotOrder(page, count, order);
+
+        return rewardRestRepository.findByAddress(address, sortedBySlot)
+                .stream()
+                .map(rewardEntity -> mapper.toRewardRest(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<RewardRest> findRewardRestByAddressAndEarnedEpoch(String address, Integer earnedEpoch) {
+        return rewardRestRepository.findByAddressAndEarnedEpoch(address, earnedEpoch)
+                .stream()
+                .map(rewardEntity -> mapper.toRewardRest(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<RewardRest> findRewardRestByAddressAndSpendableEpoch(String address, Integer spendableEpoch) {
+        return rewardRestRepository.findByAddressAndSpendableEpoch(address, spendableEpoch)
+                .stream()
+                .map(rewardEntity -> mapper.toRewardRest(rewardEntity))
+                .toList();
+    }
+
+    //-- Unclaimed Reward Rest
+    @Override
+    public List<UnclaimedRewardRest> findUnclaimedRewardRestByEarnedEpoch(Integer epoch, int page, int count, Order order) {
+        Pageable sortedBySlot = getPagableBySlotOrder(page, count, order);
+
+        return unclaimedRewardRestRepository.findByEarnedEpoch(epoch, sortedBySlot)
+                .stream()
+                .map(rewardEntity -> mapper.toUnclaimedRewardRest(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<UnclaimedRewardRest> findUnclaimedRewardRestBySpendableEpoch(Integer epoch, int page, int count, Order order) {
+        Pageable sortedBySlot = getPagableBySlotOrder(page, count, order);
+
+        return unclaimedRewardRestRepository.findBySpendableEpoch(epoch, sortedBySlot)
+                .stream()
+                .map(rewardEntity -> mapper.toUnclaimedRewardRest(rewardEntity))
+                .toList();
+    }
+
+    @Override
+    public List<Reward> findRewardsByPoolHashAndSpendableEpoch(String poolHash, Integer spendableEpoch, int page, int count) {
+        Pageable pagable =
+                PageRequest.of(page, count);
+
+        return rewardRepository.findByPoolIdAndSpendableEpoch(poolHash, spendableEpoch, pagable)
+                .stream()
+                .map(rewardEntity -> mapper.toReward(rewardEntity))
+                .toList();
+    }
+
+
+    private static Pageable getPagableBySlotOrder(int page, int count, Order order) {
+        Pageable sortedBySlot =
+                PageRequest.of(page, count,  order == Order.asc ? Sort.by("slot").ascending() : Sort.by("slot").descending());
+        return sortedBySlot;
     }
 
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/InstantRewardRepository.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/InstantRewardRepository.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 @Repository
 public interface InstantRewardRepository extends JpaRepository<InstantRewardEntity, UUID> {
 
-    Slice<InstantRewardEntity> findByEarnedEpoch(Long epoch, Pageable pageable);
+    Slice<InstantRewardEntity> findByEarnedEpoch(Integer epoch, Pageable pageable);
 
-    Slice<InstantRewardEntity> findByEarnedEpochAndType(Long epoch, InstantRewardType rewardType, Pageable pageable);
+    Slice<InstantRewardEntity> findByEarnedEpochAndType(Integer epoch, InstantRewardType rewardType, Pageable pageable);
 
     @Query("SELECT SUM(m.amount) FROM InstantRewardEntity m WHERE m.earnedEpoch=:epoch and m.type=:type")
-    BigInteger findTotalAmountByEarnedEpoch(int epoch, InstantRewardType type);
+    BigInteger findTotalAmountByEarnedEpoch(Integer epoch, InstantRewardType type);
 
     int deleteBySlotGreaterThan(Long slot);
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/RewardRepository.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/RewardRepository.java
@@ -2,13 +2,14 @@ package com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository;
 
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.model.RewardEntity;
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.model.RewardId;
-import com.bloxbean.cardano.yaci.store.events.domain.RewardType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface RewardRepository extends JpaRepository<RewardEntity, RewardId> {
@@ -17,8 +18,14 @@ public interface RewardRepository extends JpaRepository<RewardEntity, RewardId> 
     @Query("delete from RewardEntity r where r.earnedEpoch = :earnedEpoch and (r.type = 'leader' or r.type = 'member')")
     int deleteLeaderMemberRewards(int earnedEpoch);
 
-    @Query("select max(r.earnedEpoch) from RewardEntity r where r.type = :rewardType")
-    Optional<Integer> getLastRewardCalculationEpoch(RewardType rewardType);
+    Slice<RewardEntity> findByEarnedEpoch(Integer epoch, Pageable pageable);
+    Slice<RewardEntity> findBySpendableEpoch(Integer epoch, Pageable pageable);
+
+    List<RewardEntity> findByAddressAndEarnedEpoch(String address, Integer earnedEpoch);
+    List<RewardEntity> findByAddressAndSpendableEpoch(String address, Integer spendableEpoch);
+    Slice<RewardEntity> findByAddress(String address, Pageable pageable);
+
+    Slice<RewardEntity> findByPoolIdAndSpendableEpoch(String poolId, Integer spendableEpoch, Pageable pageable);
 
     int deleteBySlotGreaterThan(Long slot);
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/RewardRestRepository.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/RewardRestRepository.java
@@ -2,6 +2,8 @@ package com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository;
 
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.model.RewardRestEntity;
 import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +16,13 @@ public interface RewardRestRepository extends JpaRepository<RewardRestEntity, UU
     int deleteBySlotGreaterThan(Long slot);
 
     List<RewardRestEntity> findBySpendableEpochAndType(Integer spendableEpoch, RewardRestType type);
+
+    Slice<RewardRestEntity> findByEarnedEpoch(Integer earnedEpoch, Pageable pageable);
+    Slice<RewardRestEntity> findBySpendableEpoch(Integer earnedEpoch, Pageable pageable);
+
+    List<RewardRestEntity> findByAddressAndEarnedEpoch(String address, Integer earnedEpoch);
+    List<RewardRestEntity> findByAddressAndSpendableEpoch(String address, Integer spendableEpoch);
+    Slice<RewardRestEntity> findByAddress(String address, Pageable pageable);
 
     int deleteByEarnedEpochAndType(Integer earnedEpoch, RewardRestType type);
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/UnclaimedRewardRestRepository.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/repository/UnclaimedRewardRestRepository.java
@@ -2,6 +2,8 @@ package com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository;
 
 import com.bloxbean.cardano.yaci.store.adapot.storage.impl.model.UnclaimedRewardRestEntity;
 import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +14,10 @@ import java.util.UUID;
 public interface UnclaimedRewardRestRepository extends JpaRepository<UnclaimedRewardRestEntity, UUID> {
 
     List<UnclaimedRewardRestEntity> findBySpendableEpoch(Integer spendableEpoch);
+
+    Slice<UnclaimedRewardRestEntity> findBySpendableEpoch(Integer spendableEpoch, Pageable pageable);
+
+    Slice<UnclaimedRewardRestEntity> findByEarnedEpoch(Integer earnedEpoch, Pageable pageable);
 
     int deleteByEarnedEpochAndType(Integer earnedEpoch, RewardRestType type);
 

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/util/PoolUtil.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/util/PoolUtil.java
@@ -4,7 +4,7 @@ import com.bloxbean.cardano.client.crypto.Bech32;
 import com.bloxbean.cardano.client.util.HexUtil;
 
 public class PoolUtil {
-    private static final String POOL_ID_PREFIX = "pool";
+    public static final String POOL_ID_PREFIX = "pool";
 
     public static String getBech32PoolId(String poolKeyHash) {
         return Bech32.encode(HexUtil.decodeHexString(poolKeyHash), POOL_ID_PREFIX);

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/AdaPotController.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/AdaPotController.java
@@ -1,0 +1,37 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.controller;
+
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.AdaPotDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.service.AdaPotApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController("AdaPotController")
+@RequestMapping("${apiPrefix}/adapot")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "AdaPot API", description = "APIs for adapot related data.")
+public class AdaPotController {
+    private final AdaPotApiService adaPotApiService;
+
+    @GetMapping
+    @Operation(description = "Get latest adapot")
+    public AdaPotDto getAdaPot() {
+        return adaPotApiService.getAdaPot()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Adapot not found"));
+    }
+
+    @GetMapping("/epochs/{epoch}")
+    @Operation(description = "Get adapot by epoch")
+    public AdaPotDto getAdaPotByEpoch(@PathVariable Integer epoch) {
+        return adaPotApiService.getAdaPot(epoch)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Adapot not found"));
+    }
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/EpochStakeController.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/EpochStakeController.java
@@ -1,21 +1,27 @@
 package com.bloxbean.cardano.yaci.store.api.adapot.controller;
 
+import com.bloxbean.cardano.client.crypto.Bech32;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.store.adapot.domain.EpochStake;
-import com.bloxbean.cardano.yaci.store.adapot.service.EpochRewardCalculationService;
 import com.bloxbean.cardano.yaci.store.adapot.storage.EpochStakeStorageReader;
+import com.bloxbean.cardano.yaci.store.adapot.util.PoolUtil;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigInteger;
 import java.util.List;
+
+import static com.bloxbean.cardano.yaci.store.common.util.ControllerPageUtil.adjustPage;
 
 @RestController("EpochStakeController")
 @RequestMapping("${apiPrefix}")
@@ -24,49 +30,104 @@ import java.util.List;
 @Tag(name = "EpochStake API", description = "APIs for epoch stake related data.")
 public class EpochStakeController {
     private final EpochStakeStorageReader epochStakeStorage;
-    private final EpochRewardCalculationService epochRewardCalculationService;
 
     @GetMapping("/epochs/{epoch}/total-stake")
     @Operation(description = "Get total active stake for an epoch")
-    public EpochActiveStake getTotalActiveStakeByEpoch(Integer epoch) {
+    public EpochActiveStake getTotalActiveStakeByEpoch(@PathVariable Integer epoch) {
         return epochStakeStorage.getTotalActiveStakeByEpoch(epoch)
                 .map(activeStake -> new EpochActiveStake(epoch, activeStake))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Stake not found"));
     }
 
-    @GetMapping("/epochs/{epoch}/addresses/{address}/stake")
-    @Operation(description = "Get active stake for an address for an epoch")
-    public EpochStake getActiveStakeByAddressAndEpoch(String address, Integer epoch) {
+    @GetMapping("/epochs/{epoch}/accounts/{address}/stake")
+    @Operation(description = "Get active stake for an account for an epoch")
+    public AccountActiveStake getActiveStakeByAddressAndEpoch(@PathVariable String address, @PathVariable Integer epoch) {
         return epochStakeStorage.getActiveStakeByAddressAndEpoch(address, epoch)
+                .map(epochStake -> AccountActiveStake.toDto(epochStake))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Stake not found"));
     }
 
-    @GetMapping("/epochs/{epoch}/pools/{poolId}/stake")
-    public PoolActiveStake getActiveStakeByPoolAndEpoch(String poolId, Integer epoch) {
-        return epochStakeStorage.getActiveStakeByPoolAndEpoch(poolId, epoch)
-                .map(activeStake -> new PoolActiveStake(epoch, poolId, activeStake))
+    @GetMapping("/epochs/{epoch}/pools/{poolHash}/stake")
+    @Operation(description = "Get active stake for a pool hash for an epoch")
+    public PoolActiveStake getActiveStakeByPoolAndEpoch(@PathVariable String poolHash, @PathVariable Integer epoch) {
+        if (poolHash != null && poolHash.startsWith(PoolUtil.POOL_ID_PREFIX)) {
+            poolHash = HexUtil.encodeHexString(Bech32.decode(poolHash).data);
+        }
+
+        final String _poolHash = poolHash;
+        return epochStakeStorage.getActiveStakeByPoolAndEpoch(poolHash, epoch)
+                .map(activeStake -> new PoolActiveStake(epoch, _poolHash, getBech32PoolId(_poolHash), activeStake))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Stake not found"));
     }
 
     @GetMapping("/epochs/{epoch}/stake")
     @Operation(description = "Get active stake for all pools for an epoch")
-    public List<EpochStake> getActiveStakeForAllPoolsForEpoch(Integer epoch, int page , int count) {
-        //TODO -- Fix pagination index
-        int p = page;
-        if (p > 0)
-            p = p - 1;
-        return epochStakeStorage.getAllActiveStakesByEpoch(epoch, p, count);
+    public List<AccountActiveStake> getActiveStakeForAllPoolsForEpoch(@PathVariable Integer epoch,
+                                                                      @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                                      @RequestParam(required = false, defaultValue = "0") @Min(0) int page) {
+        int p = adjustPage(page);
+        return epochStakeStorage.getAllActiveStakesByEpoch(epoch, p, count)
+                .stream().map(epochStake -> AccountActiveStake.toDto(epochStake))
+                .toList();
     }
 
+    @GetMapping("/epochs/{epoch}/pools/{poolHash}/delegators")
+    @Operation(description = "Retrieve active stakes of pool delegators for a specific pool hash during a given epoch. Supports bech32 pool ID.")
+    public List<AccountActiveStake> getPoolDelegatorsActiveStakes(@PathVariable Integer epoch, @PathVariable String poolHash,
+                                        @RequestParam(required = false, defaultValue = "0") @Min(0) int page,
+                                        @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count
+                                        ) {
+        int p = adjustPage(page);
+        if (poolHash != null && poolHash.startsWith(PoolUtil.POOL_ID_PREFIX)) {
+            poolHash = HexUtil.encodeHexString(Bech32.decode(poolHash).data);
+        }
+
+        return epochStakeStorage.getAllActiveStakesByEpochAndPool(epoch, poolHash, p, count)
+                .stream().map(epochStake -> AccountActiveStake.toDto(epochStake))
+                .toList();
+    }
+
+    /**
     //TODO -- Temporary endpoint
     @PostMapping("/calculate-rewards/epoch/{epoch}")
     public void calculateRewardsForEpoch(Integer epoch) {
         epochRewardCalculationService.fetchRewardCalcInputs(epoch);
     }
+    **/
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     record EpochActiveStake(Integer epoch, BigInteger activeStake) {
     }
 
-    record PoolActiveStake(Integer epoch, String poolId, BigInteger activeStake) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    record PoolActiveStake(Integer epoch, String poolHash, String poolId, BigInteger activeStake) {
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    record AccountActiveStake(String address, Integer epoch, BigInteger amount, String poolHash, String poolId, Integer delegationEpoch) {
+        public static AccountActiveStake toDto(EpochStake epochStake) {
+            String poolBech32Id = getBech32PoolId(epochStake.getPoolId());
+
+            return new AccountActiveStake(epochStake.getAddress(),
+                    epochStake.getActiveEpoch(),
+                    epochStake.getAmount(),
+                    epochStake.getPoolId(),
+                    poolBech32Id,
+                    epochStake.getDelegationEpoch());
+        }
+    }
+
+    private static String getBech32PoolId(String poolHash) {
+        String poolBech32Id = null;
+        try {
+            if (poolHash != null) {
+                poolBech32Id = PoolUtil.getBech32PoolId(poolHash);
+            }
+        } catch (Exception e) {}
+        return poolBech32Id;
+    }
+
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/NetworkController.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/NetworkController.java
@@ -1,0 +1,38 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.controller;
+
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.NetworkInfoDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.service.NetworkInfoApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController("NetworkController")
+@RequestMapping("${apiPrefix}")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Network API", description = "APIs for Network information")
+public class NetworkController {
+    private final NetworkInfoApiService networkInfoService;
+
+    @GetMapping("/network")
+    @Operation(description = "Get Network information (Supply and Stake)")
+    public NetworkInfoDto getNetworkInfo() {
+        return networkInfoService.getNetworkInfo()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Network info not found"));
+    }
+
+    @GetMapping("/network/epochs/{epoch}")
+    @Operation(description = "Get Network information (Supply and Stake) for an epoch")
+    public NetworkInfoDto getNetworkInfoForEpoch(@PathVariable Integer epoch) {
+        return networkInfoService.getNetworkInfo(epoch)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Network info not found for epoch " + epoch));
+    }
+
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/RewardController.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/controller/RewardController.java
@@ -1,0 +1,91 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.controller;
+
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.*;
+import com.bloxbean.cardano.yaci.store.api.adapot.service.RewardApiService;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.bloxbean.cardano.yaci.store.common.util.ControllerPageUtil.adjustPage;
+
+@RestController("RewardController")
+@RequestMapping("${apiPrefix}")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Reward API", description = "APIs for adapot related data.")
+public class RewardController {
+
+    private final RewardApiService accountRewardApiService;
+
+    //-- Account Rewards
+    @GetMapping("/accounts/{address}/rewards")
+    @Operation(summary = "Get account pool rewards", description = "Retrieve rewards for a specific account by address with pagination and sorting.")
+    public ResponseEntity<List<AddressPoolRewardDto>> getAccountRewards(@PathVariable String address, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                                        @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getPoolRewards(address, p, count, order));
+    }
+
+    @GetMapping("/accounts/{address}/epochs/{epoch}/rewards")
+    @Operation(summary = "Get account epoch pool rewards", description = "Retrieve rewards for a specific account and epoch by address and spendable epoch.")
+    public ResponseEntity<List<AddressPoolRewardDto>> getAccountEpochRewards(@PathVariable String address, @PathVariable Integer epoch) {
+        return ResponseEntity.ok(accountRewardApiService.getPoolRewardsBySpendableEpoch(address, epoch));
+    }
+
+    @GetMapping("/accounts/{address}/reward_rest")
+    @Operation(summary = "Get account reward rest", description = "Retrieve non-pool rewards by address.")
+    public ResponseEntity<List<AddressRewardRestDto>> getAccountRewardRest(@PathVariable String address, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                                           @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getRewardRest(address, p, count, order));
+    }
+
+    @Operation(summary = "Get account epoch reward rest", description = "Retrieve non-pool rewards by address and spendable epoch.")
+    @GetMapping("/accounts/{address}/epochs/{epoch}/reward_rest")
+    public ResponseEntity<List<AddressRewardRestDto>> getAccountEpochRewardRest(@PathVariable String address, @PathVariable Integer epoch) {
+        return ResponseEntity.ok(accountRewardApiService.getRewardRestBySpendableEpoch(address, epoch));
+    }
+
+    //-- Unclaimed Rewards
+    @Operation(summary = "Get unclaimed reward rest for an epoch (Spendable Epoch)", description = "Retrieve unclaimed rewards by spendable epoch with pagination and sorting.")
+    @GetMapping("/epochs/{epoch}/unclaimed_reward_rest")
+    public ResponseEntity<?> getUnclaimedRewardRest(@PathVariable Integer epoch, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                               @RequestParam(required = false, defaultValue = "0") @Min(0) int page, @RequestParam(required = false, defaultValue = "desc") Order order) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getUnclaimedRewardRestBySpendableEpoch(epoch, p, count, order));
+    }
+
+    @Operation(summary = "Get all rewards by epoch", description = "Retrieve rewards for a specific epoch with pagination.")
+    @GetMapping("/epochs/{epoch}/rewards")
+    public ResponseEntity<List<RewardDto>> getEpochRewards(@PathVariable Integer epoch, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                           @RequestParam(required = false, defaultValue = "0") @Min(0) int page) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getPoolRewards(epoch, p, count));
+    }
+
+    @Operation(summary = "Get all reward rest by epoch", description = "Retrieve all non-pool rewards for a specific epoch with pagination.")
+    @GetMapping("/epochs/{epoch}/reward_rest")
+    public ResponseEntity<List<RewardRestDto>> getEpochRewardRest(@PathVariable Integer epoch, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                                  @RequestParam(required = false, defaultValue = "0") @Min(0) int page) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getRewardRest(epoch, p, count));
+    }
+
+    //-- Rewards for a pool
+    @Operation(summary = "Get all rewards for a pool by epoch (spendable epoch)", description = "Retrieve rewards for a specific pool hash or bech32 poolId by spendable epoch with pagination.")
+    @GetMapping("/pools/{poolHash}/epochs/{epoch}/rewards")
+    public ResponseEntity<List<PoolAddressRewardDto>> getPoolRewards(@PathVariable Integer epoch, @PathVariable String poolHash, @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int count,
+                                                                     @RequestParam(required = false, defaultValue = "0") @Min(0) int page) {
+        int p = adjustPage(page);
+        return ResponseEntity.ok(accountRewardApiService.getPoolRewardsByPoolHashAndSpendableEpoch(poolHash, epoch, p, count));
+    }
+
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AdaPotDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AdaPotDto.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+/**
+ * Data Transfer Object for AdaPot
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AdaPotDto(Integer epoch,
+                        BigInteger depositsStake,
+                        BigInteger fees,
+                        BigInteger treasury,
+                        BigInteger reserves,
+                        BigInteger circulation,
+                        BigInteger distributedRewards,
+                        BigInteger undistributedRewards,
+                        BigInteger rewardsPot,
+                        BigInteger poolRewardsPot) {
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AddressPoolRewardDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AddressPoolRewardDto.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.adapot.domain.Reward;
+import com.bloxbean.cardano.yaci.store.adapot.util.PoolUtil;
+import com.bloxbean.cardano.yaci.store.events.domain.RewardType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AddressPoolRewardDto(Integer epoch, BigInteger amount, String poolId, RewardType type) {
+
+    public static AddressPoolRewardDto toDto(Reward reward) {
+        String poolBech32Id = null;
+
+        try {
+            if (reward.getPoolId() != null) {
+                poolBech32Id = PoolUtil.getBech32PoolId(reward.getPoolId());
+            }
+        } catch (Exception e) {}
+
+        return new AddressPoolRewardDto(reward.getSpendableEpoch(),
+                reward.getAmount(),
+                poolBech32Id,
+                reward.getType());
+    }
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AddressRewardRestDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/AddressRewardRestDto.java
@@ -1,0 +1,21 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.adapot.domain.RewardRest;
+import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AddressRewardRestDto(Integer epoch, Integer earnedEpoch, BigInteger amount, RewardRestType type) {
+
+    public static AddressRewardRestDto toDto(RewardRest rewardRest) {
+        return new AddressRewardRestDto(rewardRest.getSpendableEpoch(),
+                rewardRest.getEarnedEpoch(),
+                rewardRest.getAmount(),
+                rewardRest.getType());
+    }
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/NetworkInfoDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/NetworkInfoDto.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record NetworkInfoDto(Supply supply, Stake stake) {
+
+    public record Supply(BigInteger max, BigInteger circulating, BigInteger treasury, BigInteger reserves) {
+    }
+
+    public record Stake(BigInteger active) {
+    }
+}
+
+

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/PoolAddressRewardDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/PoolAddressRewardDto.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.events.domain.RewardType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record PoolAddressRewardDto(String address, BigInteger reward, RewardType type, Integer earnedEpoch) {
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/RewardDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/RewardDto.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.events.domain.RewardType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record RewardDto(
+         String address,
+         Integer earnedEpoch,
+         RewardType type,
+         String poolId,
+         BigInteger amount,
+         Integer spendableEpoch
+) {
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/RewardRestDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/RewardRestDto.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record RewardRestDto(
+         String address,
+         RewardRestType type,
+         BigInteger amount,
+         Integer earnedEpoch,
+         Integer spendableEpoch
+) {
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/UnclaimedRewardRestDto.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/dto/UnclaimedRewardRestDto.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.dto;
+
+import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigInteger;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UnclaimedRewardRestDto(
+        String address,
+        RewardRestType type,
+        BigInteger amount,
+        Integer earnedEpoch,
+        Integer spendableEpoch
+        ) {
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/mapper/AdaPotDtoMapper.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/mapper/AdaPotDtoMapper.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.mapper;
+
+import com.bloxbean.cardano.yaci.store.adapot.domain.AdaPot;
+import com.bloxbean.cardano.yaci.store.adapot.domain.Reward;
+import com.bloxbean.cardano.yaci.store.adapot.domain.RewardRest;
+import com.bloxbean.cardano.yaci.store.adapot.domain.UnclaimedRewardRest;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.AdaPotDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.RewardDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.RewardRestDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.UnclaimedRewardRestDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public abstract class AdaPotDtoMapper {
+    public abstract AdaPotDto toAdaPotDto(AdaPot adaPot);
+    public abstract RewardDto toRewardDto(Reward reward);
+    public abstract RewardRestDto toRewardRestDto(RewardRest rewardRest);
+    public abstract UnclaimedRewardRestDto unclaimedRewardRestDto(UnclaimedRewardRest unclaimedRewardRest);
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/AdaPotApiService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/AdaPotApiService.java
@@ -1,0 +1,28 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.service;
+
+import com.bloxbean.cardano.yaci.store.adapot.storage.AdaPotStorage;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.AdaPotDto;
+import com.bloxbean.cardano.yaci.store.api.adapot.mapper.AdaPotDtoMapper;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdaPotApiService {
+    private final AdaPotStorage adaPotStorage;
+    private final EpochParamStorage epochParamStorage;
+    private final AdaPotDtoMapper adaPotDtoMapper;
+
+    public Optional<AdaPotDto> getAdaPot() {
+        int currentEpoch = epochParamStorage.getMaxEpoch();
+        return getAdaPot(currentEpoch);
+    }
+
+    public Optional<AdaPotDto> getAdaPot(int epoch) {
+        return adaPotStorage.findByEpoch(epoch)
+                .map( adaPotDtoMapper::toAdaPotDto);
+    }
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/NetworkInfoApiService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/NetworkInfoApiService.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.service;
+
+import com.bloxbean.cardano.yaci.store.adapot.storage.AdaPotStorage;
+import com.bloxbean.cardano.yaci.store.adapot.storage.EpochStakeStorageReader;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.NetworkInfoDto;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NetworkInfoApiService {
+    private final EpochStakeStorageReader epochStakeStorage;
+    private final AdaPotStorage adaPotStorage;
+    private final EpochParamStorage epochParamStorage;
+    private final GenesisConfig genesisConfig;
+
+    public Optional<NetworkInfoDto> getNetworkInfo() {
+        int currentEpoch = epochParamStorage.getMaxEpoch();
+        return getNetworkInfo(currentEpoch);
+    }
+
+    public Optional<NetworkInfoDto> getNetworkInfo(int epoch) {
+        var adaPotOpt = adaPotStorage.findByEpoch(epoch);
+
+        var maxSupply = genesisConfig.getMaxLovelaceSupply();
+
+        var supply = adaPotOpt.map(adaPot ->
+                new NetworkInfoDto.Supply(maxSupply, adaPot.getCirculation(), adaPot.getTreasury(), adaPot.getReserves())
+        ).orElse(new NetworkInfoDto.Supply(maxSupply, null, null, null));
+
+        var totalActiveStake = epochStakeStorage.getTotalActiveStakeByEpoch(epoch);
+
+        var stake = new NetworkInfoDto.Stake(totalActiveStake.orElse(null));
+
+        return Optional.of(new NetworkInfoDto(supply, stake));
+    }
+}

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/RewardApiService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/api/adapot/service/RewardApiService.java
@@ -1,0 +1,86 @@
+package com.bloxbean.cardano.yaci.store.api.adapot.service;
+
+import com.bloxbean.cardano.client.crypto.Bech32;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorageReader;
+import com.bloxbean.cardano.yaci.store.adapot.util.PoolUtil;
+import com.bloxbean.cardano.yaci.store.api.adapot.dto.*;
+import com.bloxbean.cardano.yaci.store.api.adapot.mapper.AdaPotDtoMapper;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RewardApiService {
+    private final RewardStorageReader rewardStorageReader;
+    private final AdaPotDtoMapper adaPotDtoMapper;
+
+    //Pool rewards
+    public List<RewardDto> getPoolRewards(Integer epoch, int page, int count) {
+        return rewardStorageReader.findRewardsBySpendableEpoch(epoch, page, count)
+                .stream()
+                .map(adaPotDtoMapper::toRewardDto)
+                .toList();
+    }
+
+    public List<AddressPoolRewardDto> getPoolRewards(String address, int page, int count, Order order) {
+        return rewardStorageReader.findRewardsByAddress(address, page, count, order)
+                .stream()
+                .map(reward -> AddressPoolRewardDto.toDto(reward))
+                .toList();
+    }
+
+    public List<AddressPoolRewardDto> getPoolRewardsBySpendableEpoch(String address, Integer epoch) {
+        return rewardStorageReader.findRewardsByAddressAndSpendableEpoch(address, epoch)
+                .stream()
+                .map(reward -> AddressPoolRewardDto.toDto(reward))
+                .toList();
+    }
+
+    //Reward Rest
+
+    public List<RewardRestDto> getRewardRest(Integer epoch, int page, int count) {
+        return rewardStorageReader.findRewardRestBySpendableEpoch(epoch, page, count)
+                .stream()
+                .map(adaPotDtoMapper::toRewardRestDto)
+                .toList();
+    }
+
+    public List<AddressRewardRestDto> getRewardRest(String address, int page, int count, Order order) {
+        return rewardStorageReader.findRewardRestByAddress(address, page, count, order)
+                .stream()
+                .map(rewardRest -> AddressRewardRestDto.toDto(rewardRest))
+                .toList();
+    }
+
+    public List<AddressRewardRestDto> getRewardRestBySpendableEpoch(String address, Integer epoch) {
+        return rewardStorageReader.findRewardRestByAddressAndSpendableEpoch(address, epoch)
+                .stream()
+                .map(rewardRest -> AddressRewardRestDto.toDto(rewardRest))
+                .toList();
+    }
+
+    //Unclaimed Reward Rest
+    public List<UnclaimedRewardRestDto> getUnclaimedRewardRestBySpendableEpoch(Integer epoch, int page, int count, Order order) {
+        return rewardStorageReader.findUnclaimedRewardRestBySpendableEpoch(epoch, page, count, order)
+                .stream()
+                .map(adaPotDtoMapper::unclaimedRewardRestDto)
+                .toList();
+    }
+
+    //-- Rewards for Pool
+    public List<PoolAddressRewardDto> getPoolRewardsByPoolHashAndSpendableEpoch(String poolHash, Integer epoch, int page, int count) {
+        if (poolHash != null && poolHash.startsWith(PoolUtil.POOL_ID_PREFIX)) { //It's a Bech32 encoded pool id
+            poolHash = HexUtil.encodeHexString(Bech32.decode(poolHash).data);
+        }
+
+        return rewardStorageReader.findRewardsByPoolHashAndSpendableEpoch(poolHash, epoch, page, count)
+                .stream()
+                .map(reward -> new PoolAddressRewardDto(reward.getAddress(), reward.getAmount(), reward.getType(), reward.getEarnedEpoch()))
+                .toList();
+    }
+
+}

--- a/aggregates/adapot/src/main/resources/db/store/h2/V0_1300_2__indexes.sql
+++ b/aggregates/adapot/src/main/resources/db/store/h2/V0_1300_2__indexes.sql
@@ -13,4 +13,14 @@ CREATE INDEX idx_reward_spendable_epoch
 CREATE INDEX idx_epoch_stake_active_epoch
     ON epoch_stake (active_epoch);
 
+CREATE INDEX idx_epoch_stake_active_epoch_pool_id
+    ON epoch_stake (active_epoch, pool_id);
 
+CREATE INDEX idx_reward_rest_address
+    ON reward_rest (address);
+
+CREATE INDEX idx_reward_rest_earned_epoch
+    ON reward_rest (earned_epoch);
+
+CREATE INDEX idx_reward_rest_spendable_epoch
+    ON reward_rest (spendable_epoch);

--- a/aggregates/adapot/src/main/resources/db/store/mysql/V0_1300_2__indexes.sql
+++ b/aggregates/adapot/src/main/resources/db/store/mysql/V0_1300_2__indexes.sql
@@ -13,4 +13,14 @@ CREATE INDEX idx_reward_spendable_epoch
 CREATE INDEX idx_epoch_stake_active_epoch
     ON epoch_stake (active_epoch);
 
+CREATE INDEX idx_epoch_stake_active_epoch_pool_id
+    ON epoch_stake (active_epoch, pool_id);
 
+CREATE INDEX idx_reward_rest_address
+    ON reward_rest (address);
+
+CREATE INDEX idx_reward_rest_earned_epoch
+    ON reward_rest (earned_epoch);
+
+CREATE INDEX idx_reward_rest_spendable_epoch
+    ON reward_rest (spendable_epoch);

--- a/aggregates/adapot/src/main/resources/db/store/postgresql/V0_1300_2__indexes.sql
+++ b/aggregates/adapot/src/main/resources/db/store/postgresql/V0_1300_2__indexes.sql
@@ -13,5 +13,15 @@ CREATE INDEX idx_reward_spendable_epoch
 CREATE INDEX idx_epoch_stake_active_epoch
     ON epoch_stake (active_epoch);
 
+CREATE INDEX idx_epoch_stake_active_epoch_pool_id
+    ON epoch_stake (active_epoch, pool_id);
 
+CREATE INDEX idx_reward_rest_address
+    ON reward_rest (address);
+
+CREATE INDEX idx_reward_rest_earned_epoch
+    ON reward_rest (earned_epoch);
+
+CREATE INDEX idx_reward_rest_spendable_epoch
+    ON reward_rest (spendable_epoch);
 

--- a/api-tests/adapot.http
+++ b/api-tests/adapot.http
@@ -1,0 +1,49 @@
+###
+### Get Latest Adapot
+
+GET {{base_url}}/api/v1/adapot
+
+> {%
+    client.test("Get latest adapot", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const adapot = response.body;
+
+        client.assert(adapot.epoch > 100, "Adapot epoch should be greater than 100");
+        client.assert(adapot.deposits_stake > 1000, "Adapot deposits_stake should be greater than 0");
+        client.assert(adapot.fees > 0, "Adapot fees should be greater than 0");
+        client.assert(adapot.treasury > 1000, "Adapot treasury should be greater than 1000");
+        client.assert(adapot.reserves > 1000, "Adapot reserves should be greater than 1000");
+        client.assert(adapot.circulation > 1000, "Adapot circulation should be greater than 1000");
+        client.assert(adapot.distributed_rewards > 1000, "Adapot distributed_rewards should be greater than 1000");
+        client.assert(adapot.undistributed_rewards > 10, "Adapot total_rewards should be greater than 10");
+        client.assert(adapot.rewards_pot > 1000, "Adapot rewards_pot should be greater than 0");
+        client.assert(adapot.pool_rewards_pot > 1000, "Adapot pool_rewards_pot should be greater than 0");
+
+    });
+%}
+
+###
+### Get Adapot by epoch
+
+GET {{base_url}}/api/v1/adapot/epochs/167
+
+> {%
+    client.test("Get adapot by epoch (167)", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const adapot = response.body;
+
+        client.assert(adapot.epoch == 167, "Adapot epoch should be greater than 167");
+        client.assert(adapot.deposits_stake == 240888000000, "Adapot deposits_stake should be greater than 240888000000");
+        client.assert(adapot.fees == 16678303880, "Adapot fees should be greater than 16678303880");
+        client.assert(adapot.treasury == 1082828070444600, "Adapot treasury should be greater than 1082828070444600");
+        client.assert(adapot.reserves == 13893619082940470, "Adapot reserves should be greater than 13893619082940470");
+        client.assert(adapot.circulation == 31099921460779229, "Adapot circulation should be greater than 31099921460779229");
+        client.assert(adapot.distributed_rewards == 205332456023, "Adapot distributed_rewards should be greater than 205332456023");
+        client.assert(adapot.undistributed_rewards == 24874055551383, "Adapot total_rewards should be greater than 24874055551383");
+        client.assert(adapot.rewards_pot == 31349235009257, "Adapot rewards_pot should be greater than 31349235009257");
+        client.assert(adapot.pool_rewards_pot == 25079388007406, "Adapot pool_rewards_pot should be greater than 25079388007406");
+
+    });
+%}

--- a/api-tests/epoch-stake.http
+++ b/api-tests/epoch-stake.http
@@ -1,0 +1,104 @@
+###
+### Get Total active stake for epoch
+GET {{base_url}}/api/v1/epochs/173/total-stake
+
+> {%
+    client.test("Get total active stake for epoch", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.epoch == 173, "Epoch should be 173");
+        client.assert(response.body.active_stake == 338215903160786, "Total active stake should be 338215903160786");
+    });
+
+%}
+
+###
+### Get epoch stakes for epoch
+GET {{base_url}}/api/v1/epochs/173/stake
+
+> {%
+    client.test("Get epoch stakes for epoch", function () {
+
+        const stakes = response.body;
+
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(stakes.length > 0, "Stakes should be greater than 0");
+
+        client.assert(stakes[0].epoch == 173, "Epoch should be 173");
+        client.assert(stakes[0].address == 'stake_test17p09knny0kzwdzy4ehat8fk7wfpy7wh80kl6f637ra8h0ucs6ud6q', "address should be stake_test17p09knny0kzwdzy4ehat8fk7wfpy7wh80kl6f637ra8h0ucs6ud6q");
+        client.assert(stakes[0].amount == 5171163516, "Amount should be 5171163516");
+        client.assert(stakes[0].pool_hash == '8ffb4c8e648c0662f2a91157c92feaa95f1a3d2728eaea8257b3d8d9', "Pool hash should be 8ffb4c8e648c0662f2a91157c92feaa95f1a3d2728eaea8257b3d8d9");
+        client.assert(stakes[0].pool_id == 'pool13la5erny3srx9u4fz9tujtl2490350f89r4w4qjhk0vdjmuv78v', "Pool id should be pool13la5erny3srx9u4fz9tujtl2490350f89r4w4qjhk0vdjmuv78v");
+        client.assert(stakes[0].delegation_epoch == 125, "Delegation epoch should be 125");
+
+        stakes.forEach(function (stake) {
+            client.assert(stake.epoch == 173, "Epoch should be 173");
+            client.assert(stake.address !== null, "address should not be null");
+            client.assert(stake.amount >= 0, "Amount should be greater than 0");
+            client.assert(stake.pool_hash !== null, "Pool is null");
+            client.assert(stake.pool_id !== null, "Pool is null");
+            client.assert(stake.delegation_epoch > 0, "Delegation epoch should be greater than 0");
+        });
+
+    });
+
+%}
+
+###
+### Get total active stakes for a pool for active epoch
+
+GET {{base_url}}/api/v1/epochs/154/pools/36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138/stake
+
+> {%
+    client.test("Get total active stakes for a pool for active epoch", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.epoch == 154, "Epoch should be 154");
+        client.assert(response.body.pool_hash == "36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138", "Pool hash should be 36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138");
+        client.assert(response.body.pool_id == "pool1xm90p8nl7kaqvsskrvtyq60z70rx4afdfj4xex89u9gns62t0er", "Pool id should be pool1xm90p8nl7kaqvsskrvtyq60z70rx4afdfj4xex89u9gns62t0er");
+        client.assert(response.body.active_stake == 52757813100, "Total stake should be 52757813100");
+    });
+
+%}
+
+###
+### Get Delegators and their stakes for a pool for active epoch
+
+GET {{base_url}}/api/v1/epochs/173/pools/36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138/delegators
+
+> {%
+    client.test("Get Delegators and their stakes for a pool for active epoch", function () {
+        const delegators = response.body;
+
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(delegators[0].address == 'stake_test1up05p7mn6epqv4pc44mm5unv94kxghmgeywew08jmlfxfuc64ml4j', "address should be stake_test1up05p7mn6epqv4pc44mm5unv94kxghmgeywew08jmlfxfuc64ml4j");
+        client.assert(delegators[0].amount == 1750000, "Amount should be 1750000");
+        client.assert(delegators[0].pool_hash == "36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138", "Pool hash should be 36caf09e7ff5ba0642161b164069e2f3c66af52d4caa6c98e5e15138");
+        client.assert(delegators[0].pool_id == "pool1xm90p8nl7kaqvsskrvtyq60z70rx4afdfj4xex89u9gns62t0er", "Pool id should be pool1xm90p8nl7kaqvsskrvtyq60z70rx4afdfj4xex89u9gns62t0er");
+        client.assert(delegators[0].delegation_epoch == 136, "Delegation epoch should be 136");
+
+        delegators.forEach(function (delegator) {
+            client.assert(delegator.address !== null, "address should not be null");
+            client.assert(delegator.amount >= 0, "Amount should be greater than 0");
+            client.assert(delegator.pool_hash !== null, "Pool hash should not be null");
+            client.assert(delegator.pool_id !== null, "Pool id should not be null");
+            client.assert(delegator.delegation_epoch > 0, "Delegation epoch should be greater than 0");
+        });
+
+    });
+
+%}
+
+###
+### Get delation details of an account for a pool for active epoch
+GET {{base_url}}/api/v1/epochs/171/accounts/stake_test1uzy46dy8v60k2alyxyeakaec54258dy92qyds2qjnn2q8nclyynkt/stake
+
+> {%
+    client.test("Get delation details of an account for a pool for active epoch", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.epoch == 171, "Epoch should be 171");
+        client.assert(response.body.address == "stake_test1uzy46dy8v60k2alyxyeakaec54258dy92qyds2qjnn2q8nclyynkt", "Address should be stake_test1uzy46dy8v60k2alyxyeakaec54258dy92qyds2qjnn2q8nclyynkt");
+        client.assert(response.body.pool_hash == "209c6caf1fdabf53984cdcdce4e8d53f680165f33557a47c54b1dd6a", "Pool hash should be 209c6caf1fdabf53984cdcdce4e8d53f680165f33557a47c54b1dd6a");
+        client.assert(response.body.pool_id == "pool1yzwxetclm2l48xzvmnwwf6x48a5qze0nx4t6glz5k8wk50xl006", "Pool id should be pool1yzwxetclm2l48xzvmnwwf6x48a5qze0nx4t6glz5k8wk50xl006");
+        client.assert(response.body.amount == 1753905, "Amount should be 1753905");
+        client.assert(response.body.delegation_epoch == 163, "Delegation epoch should be 163");
+    });
+%}

--- a/api-tests/network.http
+++ b/api-tests/network.http
@@ -1,0 +1,39 @@
+###
+### Get Network latest network info
+
+GET {{base_url}}/api/v1/network
+
+> {%
+    client.test("Get latest network info", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const data = response.body;
+
+        client.assert(data.supply.max == 45000000000000000, "Max supply should be 45 billion");
+        client.assert(data.supply.circulating > 30410062068451000, "Cirtulating supply should be greater than 30410062068451000"); //just a random test value
+        client.assert(data.supply.treasury > 282501819644019, "Treasury supply should be greater than 282501819644019"); //just a random test value
+        client.assert(data.supply.reserves > 7011281492, "Reserves supply should be greater than 7011281492"); //just a random test value
+
+        client.assert(data.stake.active > 7626360795, "Active stake should be greater than 7626360795"); //just a random test value
+    });
+%}
+
+###
+### Get Network latest network info by epoch
+
+GET {{base_url}}/api/v1/network/epochs/168
+
+> {%
+    client.test("Get latest network info", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const data = response.body;
+
+        client.assert(data.supply.max == 45000000000000000, "Max supply should be 45 billion");
+        client.assert(data.supply.circulating == 31106380917059530, "Cirtulating supply should be greater than 31106380917059530");
+        client.assert(data.supply.treasury == 1089053500038405, "Treasury supply should be greater than 1089053500038405");
+        client.assert(data.supply.reserves == 13887206121913940, "Reserves supply should be greater than 13887206121913940");
+
+        client.assert(data.stake.active == 331872953241427, "Active stake should be greater than 331872953241427");
+    });
+%}

--- a/api-tests/rewards.http
+++ b/api-tests/rewards.http
@@ -1,0 +1,264 @@
+
+###
+### Get Pool rewards by epoch
+GET {{base_url}}/api/v1/pools/7facad662e180ce45e5c504957cd1341940c72a708728f7ecfc6e349/epochs/173/rewards
+
+> {%
+    client.test("Get Pool rewards by pool hash and epoch", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 10, "Rewards length should be 10");
+
+        client.assert(rewards[0].address == 'stake_test1up97ct2wt8jqlly2cnkhuwc7tvevmjpp7h6ts3rucpksy8c8cnspn', "Address should be stake_test1up97ct2wt8jqlly2cnkhuwc7tvevmjpp7h6ts3rucpksy8c8cnspn");
+        client.assert(rewards[0].reward == 838495542, "Reward should be 838495542");
+        client.assert(rewards[0].type == 'leader', "Type should be leader");
+        client.assert(rewards[0].earned_epoch == 171, "Earned epoch should be 171");
+
+        client.assert(rewards[1].address == 'stake_test1uz6fd0qe3udc6t7s2dsx0dsjm5c5zftqx930qdxvrt279zsllncju', "Address should be stake_test1uz6fd0qe3udc6t7s2dsx0dsjm5c5zftqx930qdxvrt279zsllncju");
+        client.assert(rewards[1].reward == 7248, "Reward should be 7248");
+        client.assert(rewards[1].type == 'member', "Type should be member");
+        client.assert(rewards[1].earned_epoch == 171, "Earned epoch should be 171");
+
+    });
+%}
+
+### TODO api test for unclaimed reward rest
+### Get unclaimed reward rest by epoch
+###GET {{base_url}}/api/v1/epoch/173/unclaimed_reward_rest
+
+
+###
+### Get Pool rewards by epoch (Bech32 poolId)
+
+GET {{base_url}}/api/v1/pools/pool107k26e3wrqxwghju2py40ngngx2qcu48ppeg7lk0cm35jl2aenx/epochs/173/rewards?page=1&count=5
+
+> {%
+    client.test("Get Pool rewards by pool hash and epoch", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 5, "Rewards length should be 5");
+
+        client.assert(rewards[0].address == 'stake_test1up97ct2wt8jqlly2cnkhuwc7tvevmjpp7h6ts3rucpksy8c8cnspn', "Address should be stake_test1up97ct2wt8jqlly2cnkhuwc7tvevmjpp7h6ts3rucpksy8c8cnspn");
+        client.assert(rewards[0].reward == 838495542, "Reward should be 838495542");
+        client.assert(rewards[0].type == 'leader', "Type should be leader");
+        client.assert(rewards[0].earned_epoch == 171, "Earned epoch should be 171");
+
+        client.assert(rewards[1].address == 'stake_test1uz6fd0qe3udc6t7s2dsx0dsjm5c5zftqx930qdxvrt279zsllncju', "Address should be stake_test1uz6fd0qe3udc6t7s2dsx0dsjm5c5zftqx930qdxvrt279zsllncju");
+        client.assert(rewards[1].reward == 7248, "Reward should be 7248");
+        client.assert(rewards[1].type == 'member', "Type should be member");
+        client.assert(rewards[1].earned_epoch == 171, "Earned epoch should be 171");
+
+    });
+%}
+
+###
+### Get Pool rewards by epoch (Bech32 poolId) - Page 2
+
+GET {{base_url}}/api/v1/pools/pool107k26e3wrqxwghju2py40ngngx2qcu48ppeg7lk0cm35jl2aenx/epochs/173/rewards?page=2&count=5
+
+> {%
+    client.test("Get Pool rewards by pool hash and epoch - Page2", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 5, "Rewards length should be 5");
+
+        client.assert(rewards[0].address == 'stake_test1uq0egztnavje24kpfrxrf33lgt9c3z8wyah744undatgntcse0rcq', "Address should be stake_test1uq0egztnavje24kpfrxrf33lgt9c3z8wyah744undatgntcse0rcq");
+        client.assert(rewards[0].reward == 27870416, "Reward should be 27870416");
+        client.assert(rewards[0].type == 'member', "Type should be member");
+        client.assert(rewards[0].earned_epoch == 171, "Earned epoch should be 171");
+
+    });
+%}
+
+
+###
+### Get Pool rewards by epoch (Bech32 poolId) - No values in Page n
+
+GET {{base_url}}/api/v1/pools/pool107k26e3wrqxwghju2py40ngngx2qcu48ppeg7lk0cm35jl2aenx/epochs/173/rewards?page=30&count=5
+
+> {%
+    client.test("Get Pool rewards by pool hash and epoch - No value in page", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 0, "Rewards length should be 0");
+
+    });
+%}
+
+###
+### Get Epoch Rewards
+
+GET {{base_url}}/api/v1/epochs/172/rewards
+
+> {%
+    client.test("Get Epoch Rewards", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 10, "Rewards length should be 10");
+
+        client.assert(rewards[0].address == 'stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs', "Address should be stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs");
+        client.assert(rewards[0].earned_epoch == 170, "Earned epoch should be 170");
+        client.assert(rewards[0].type == 'leader', "Type should be leader");
+        client.assert(rewards[0].pool_id == 'a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0', "Pool id should be a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0");
+        client.assert(rewards[0].amount == 371979037, "Amount should be 371979037");
+        client.assert(rewards[0].spendable_epoch == 172, "Spendable epoch should be 172");
+
+        client.assert(rewards[6].address == 'stake_test1upml2atyrs7je3s7ggks5zeclaj8tzxwt6xl62e7h04dxdqge4xf7', "Address should be stake_test1upml2atyrs7je3s7ggks5zeclaj8tzxwt6xl62e7h04dxdqge4xf7");
+        client.assert(rewards[6].earned_epoch == 170, "Earned epoch should be 170");
+        client.assert(rewards[6].type == 'member', "Type should be member");
+        client.assert(rewards[6].pool_id == 'a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0', "Pool id should be a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0");
+        client.assert(rewards[6].amount == 16328835, "Amount should be 16328835");
+        client.assert(rewards[6].spendable_epoch == 172, "Spendable epoch should be 172");
+    });
+%}
+
+###
+### Get Epoch Rewards pagination (Page 1)
+
+GET {{base_url}}/api/v1/epochs/172/rewards?page=1&count=7
+
+> {%
+    client.test("Get Epoch Rewards pagination - page1", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 7, "Rewards length should be 7");
+
+        client.assert(rewards[0].address == 'stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs', "Address should be stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs");
+        client.assert(rewards[0].earned_epoch == 170, "Earned epoch should be 170");
+        client.assert(rewards[0].type == 'leader', "Type should be leader");
+        client.assert(rewards[0].pool_id == 'a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0', "Pool id should be a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0");
+        client.assert(rewards[0].amount == 371979037, "Amount should be 371979037");
+        client.assert(rewards[0].spendable_epoch == 172, "Spendable epoch should be 172");
+
+        client.assert(rewards[6].address == 'stake_test1upml2atyrs7je3s7ggks5zeclaj8tzxwt6xl62e7h04dxdqge4xf7', "Address should be stake_test1upml2atyrs7je3s7ggks5zeclaj8tzxwt6xl62e7h04dxdqge4xf7");
+        client.assert(rewards[6].earned_epoch == 170, "Earned epoch should be 170");
+        client.assert(rewards[6].type == 'member', "Type should be member");
+        client.assert(rewards[6].pool_id == 'a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0', "Pool id should be a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0");
+        client.assert(rewards[6].amount == 16328835, "Amount should be 16328835");
+        client.assert(rewards[6].spendable_epoch == 172, "Spendable epoch should be 172");
+    });
+%}
+
+###
+### Get Epoch Rewards pagination (Page 3 Negative conditions)
+
+GET {{base_url}}/api/v1/epochs/172/rewards?page=3&count=8
+
+> {%
+    client.test("Get Epoch Rewards pagination - page3 (Negative Conditions)", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 8, "Rewards length should be 8");
+
+        client.assert(rewards[0].address != 'stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs', "Address should not be stake_test1uqthws0lx6pv5wasmgkksdam0tjsq8vr6uxc3w0tnp7sxxskswefs");
+        client.assert(rewards[0].earned_epoch == 170, "Earned epoch should be 170");
+        client.assert(rewards[0].type != 'leader', "Type should be leader");
+        client.assert(rewards[0].pool_id != 'a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0', "Pool id should not be a71a124e7504ab06afe9155efbe6b3e8f7d42efaa1662f98f11eedf0");
+        client.assert(rewards[0].amount != 371979037, "Amount should not be 371979037");
+        client.assert(rewards[0].spendable_epoch == 172, "Spendable epoch should be 172");
+
+
+    });
+%}
+
+
+###
+### Get Epoch Rewards pagination (Not found)
+
+GET {{base_url}}/api/v1/epochs/172/rewards?page=1000&count=100
+
+> {%
+    client.test("Get Epoch Rewards pagination - Not Found", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 0, "Rewards length should be 0");
+    });
+
+%}
+
+
+###
+#### //TODO -- Epoch Reward Rest Endpoint
+### GET {{base_url}}/api/v1/epoch/172/rewards_rest
+
+
+###
+### Account Rewards by Epoch
+GET {{base_url}}/api/v1/accounts/stake_test1uzzd5vuumkaq2c3a95gyt7rf28pdna4zpza9vjxmp7w00yc2rp5he/rewards
+
+> {%
+    client.test("Get Account Reward", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 10, "Rewards length should be 10");
+
+        client.assert(rewards[0].epoch >= 173, "Epoch should be greater than 173"); //As Preprod current epch > 173
+        client.assert(rewards[0].pool_id != null, "Pool is set to null");
+        client.assert(rewards[0].amount > 0, "Reward amount is greater than 0");
+        client.assert(rewards[0].type == 'member' , "Type is member");
+    });
+%}
+
+###
+### Account Rewards by Epoch Pagination test
+GET {{base_url}}/api/v1/accounts/stake_test1uzzd5vuumkaq2c3a95gyt7rf28pdna4zpza9vjxmp7w00yc2rp5he/rewards?page=3&count=6
+
+> {%
+    client.test("Get Account Reward", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 6, "Rewards length should be 6");
+
+        client.assert(rewards[0].epoch >= 10, "Epoch should be greater than 10"); //As Preprod current epch > 10
+        client.assert(rewards[0].pool_id != null, "Pool is set to null");
+        client.assert(rewards[0].amount > 0, "Reward amount is greater than 0");
+        client.assert(rewards[0].type == 'member' , "Type is member");
+    });
+%}
+
+### //TODO
+### Account Rewards Rest Endpoint
+### GET {{base_url}}/api/v1/account/stake_test1uzzd5vuumkaq2c3a95gyt7rf28pdna4zpza9vjxmp7w00yc2rp5he/rewards_rest
+
+###
+### Account Rewards by Epoch
+GET {{base_url}}/api/v1/accounts/stake_test1ur5uc537jdf953she62atqeh44yrt2vrlx4yrrlsmggutqs896rz7/epochs/35/rewards
+
+> {%
+    client.test("Get Account Reward", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        const rewards = response.body;
+
+        client.assert(rewards.length == 1, "Rewards length should be 1");
+
+        client.assert(rewards[0].epoch == 35, "Epoch should be 35");
+        client.assert(rewards[0].pool_id == 'pool1dzxc7pqsqfs7dru7xdrkvkdf9s3kd4y2tqsdv063d2lfcxw6zmg', "Pool should be pool1dzxc7pqsqfs7dru7xdrkvkdf9s3kd4y2tqsdv063d2lfcxw6zmg");
+        client.assert(rewards[0].amount == 413444885, "Reward amount should be 413444885");
+        client.assert(rewards[0].type == 'leader' , "Type is leader");
+    });
+%}
+
+### //TODO
+### Account Reward Rest by epoch
+### GET {{base_url}}/api/v1/account/stake_test1ur5uc537jdf953she62atqeh44yrt2vrlx4yrrlsmggutqs896rz7/epoch/35/rewards_rest

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ControllerPageUtil.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ControllerPageUtil.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.common.util;
+
+public class ControllerPageUtil {
+
+    /// Adjust page number for API requests. Convert 1-based page number to 0-based.
+    public static int adjustPage(int page) {
+        int p = page;
+        if (p > 0)
+            p = p - 1;
+        return p;
+    }
+}


### PR DESCRIPTION
- Updated Epoch Stake Controller
- New Apis
   - Network Info endpoints to provide supply and total stake info
   - AdaPot api to provide adapot info by epoch
   - Rewards api to provide pool rewards, rewards_rest, unclaimed rewards
- New indexes
- Http tests for new and modified apis