### PR TITLE
Add Byron epoch length support and fix slot duration calculations

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ByronGenesis.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ByronGenesis.java
@@ -38,6 +38,7 @@ public class ByronGenesis extends GenesisFile {
     private long startTime;
     private long byronSlotLength;
     private long protocolMagic;
+    private long k;
 
     public ByronGenesis(File byronGenesisFile) {
         super(byronGenesisFile);
@@ -58,10 +59,15 @@ public class ByronGenesis extends GenesisFile {
             return byronSlotLength / 1000;
     }
 
+    public long getEpochLength() {
+        return k * 10; //Hardcoded 10. Need to check why?
+    }
+
     protected void readGenesisData(JsonNode byronJsonNode) {
         startTime = byronJsonNode.get(ATTR_START_TIME).asLong();
         byronSlotLength = byronJsonNode.get(ATTR_BLOCK_VERSION_DATA).get(ATTR_SLOT_DURATION).asLong() / 1000; //in second
         protocolMagic = byronJsonNode.get(ATTR_PROTOCOL_CONSTS).get(ATTR_PROTOCOL_MAGIC).asLong();
+        k = byronJsonNode.get(ATTR_PROTOCOL_CONSTS).get("k").asLong();
 
         JsonNode avvmDistrMap = byronJsonNode.get(ATTR_AVVM_DISTR);
         if (avvmDistrMap != null && avvmDistrMap.fields().hasNext()) {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
@@ -43,6 +43,7 @@ public class GenesisConfig {
     private long startTime;
     private String shelleyStartTime;
     private long epochLength;
+    private long byronEpochLength;
 
     private long byronSlotLength;
     private double shelleySlotLength;
@@ -106,7 +107,10 @@ public class GenesisConfig {
     }
 
     public long slotsPerEpoch(Era era) {
-        return  (long)(getEpochLength() / slotDuration(era));
+        if (era == Era.Byron)
+            return byronEpochLength;
+        else
+            return getEpochLength();
     }
 
     public long getEpochLength() {
@@ -164,6 +168,7 @@ public class GenesisConfig {
 
         startTime = byronGenesis.getStartTime();
         byronSlotLength = byronGenesis.getByronSlotLength(); //in second
+        byronEpochLength = byronGenesis.getEpochLength();
         long protocolMagic = byronGenesis.getProtocolMagic();
 
         if (protocolMagic != storeProperties.getProtocolMagic())

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
@@ -104,7 +104,7 @@ public class EraService {
         firstShelleySlot();
 
         long startTime = genesisConfig.getStartTime(storeProperties.getProtocolMagic());
-        _shelleyStartTime = startTime + firstShelleySlot() * (long)genesisConfig.slotDuration(Era.Byron);
+        _shelleyStartTime = startTime + Math.round(firstShelleySlot() * genesisConfig.slotDuration(Era.Byron));
 
         return _shelleyStartTime;
     }
@@ -148,7 +148,7 @@ public class EraService {
             return byronBlockTime(slot);
         } else {
             long slotsFromShelleyStart = slot - firstShelleySlot();
-            return (shelleyEraStartTime() + slotsFromShelleyStart * (long) genesisConfig.slotDuration(Era.Shelley));
+            return (shelleyEraStartTime() + Math.round(slotsFromShelleyStart * genesisConfig.slotDuration(Era.Shelley)));
         }
     }
 
@@ -224,6 +224,6 @@ public class EraService {
      */
     private long byronBlockTime(long slot) {
         long startTime = genesisConfig.getStartTime(storeProperties.getProtocolMagic());
-        return startTime + slot * (long)genesisConfig.slotDuration(Era.Byron);
+        return startTime + Math.round(slot * genesisConfig.slotDuration(Era.Byron));
     }
 }


### PR DESCRIPTION
Introduced `byronEpochLength` to handle epoch length specific to the Byron era. Adjusted slot duration calculations in `EraService` to use `Math.round` for better precision. These changes ensure accurate timeline calculations across different eras and slot length below 1 second.