### PR TITLE
Introduce Content-Aware Rollback Events, Pre-Rollback Event, and Current Balance Tracking

### DIFF
--- a/aggregates/account/build.gradle
+++ b/aggregates/account/build.gradle
@@ -4,6 +4,12 @@ dependencies {
     implementation(libs.parallel.collector)
 
     api("org.springframework.boot:spring-boot-starter-batch")
+
+    testImplementation project(':starters:spring-boot-starter')
+    testImplementation project(':starters:account-spring-boot-starter')
+    testImplementation("org.springframework.boot:spring-boot-starter-jooq")
+
+    testImplementation("org.flywaydb:flyway-core")
 }
 
 publishing {

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/AccountStoreProperties.java
@@ -54,4 +54,10 @@ public class AccountStoreProperties {
 
     @Builder.Default
     private int pruningInterval = 86400;
+
+    @Builder.Default
+    private boolean contentAwareRollback = false;
+
+    @Builder.Default
+    private boolean currentBalanceEnabled = false;
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/domain/BalanceRollbackEvent.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/domain/BalanceRollbackEvent.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.yaci.store.account.domain;
+
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BalanceRollbackEvent {
+    private RollbackEvent rollbackEvent;
+
+    private List<AddressUnits> addressUnits;
+    private List<String> stakeAddresses;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddressUnits {
+        private String address;
+        private Set<String> units;
+    }
+}
+

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AccountBalanceProcessor.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AccountBalanceProcessor.java
@@ -709,6 +709,7 @@ public class AccountBalanceProcessor {
                     return addressBalance;
                 }).toList();
         accountBalanceStorage.saveAddressBalances(addressBalances);
+        accountBalanceStorage.saveCurrentAddressBalances(addressBalances);
 
         List<StakeAddressBalance> stakeAddrBalances = genesisBalanceList.stream()
                 .filter(genesisBalance -> {
@@ -734,6 +735,7 @@ public class AccountBalanceProcessor {
                     return stakeAddrBalance;
                 }).toList();
         accountBalanceStorage.saveStakeAddressBalances(stakeAddrBalances);
+        accountBalanceStorage.saveCurrentStakeAddressBalances(stakeAddrBalances);
     }
 
     @EventListener

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AccountBalanceRollbackProcessor.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/processor/AccountBalanceRollbackProcessor.java
@@ -1,14 +1,18 @@
 package com.bloxbean.cardano.yaci.store.account.processor;
 
-import com.bloxbean.cardano.yaci.store.account.service.AccountConfigService;
+import com.bloxbean.cardano.yaci.store.account.AccountStoreProperties;
+import com.bloxbean.cardano.yaci.store.account.domain.BalanceRollbackEvent;
 import com.bloxbean.cardano.yaci.store.account.storage.AccountBalanceStorage;
 import com.bloxbean.cardano.yaci.store.common.aspect.EnableIf;
 import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
 
 import static com.bloxbean.cardano.yaci.store.account.AccountStoreConfiguration.STORE_ACCOUNT_ENABLED;
 
@@ -18,16 +22,81 @@ import static com.bloxbean.cardano.yaci.store.account.AccountStoreConfiguration.
 @Slf4j
 public class AccountBalanceRollbackProcessor {
     private final AccountBalanceStorage accountBalanceStorage;
-    private final AccountConfigService accountConfigService;
+    private final AccountStoreProperties accountStoreProperties;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @EventListener
     @Transactional
     public void handleRollback(RollbackEvent rollbackEvent) {
+
+        if (accountStoreProperties.isContentAwareRollback()) {
+            handleContentAwareBalanceRollback(rollbackEvent);
+        }
+
         //Check rollbackTo slot
         int addressBalanceDeleted = accountBalanceStorage.deleteAddressBalanceBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
         int stakeBalanceDeleted = accountBalanceStorage.deleteStakeAddressBalanceBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
 
         log.info("Rollback -- {} address_balance records", addressBalanceDeleted);
         log.info("Rollback -- {} stake_balance records", stakeBalanceDeleted);
+    }
+
+    private void handleContentAwareBalanceRollback(RollbackEvent rollbackEvent) {
+        var rolledBackAddressBalances = accountBalanceStorage.getAddressBalanceBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
+        var rolledBackStakeAddressBalances = accountBalanceStorage.getStakeAddressBalanceBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
+
+        Map<String, Set<String>> addressUnitMap = new HashMap<>();
+
+        for (var addressBalance : rolledBackAddressBalances) {
+            String address = addressBalance.getAddress();
+            String unit = addressBalance.getUnit();
+
+            if (addressUnitMap.containsKey(address)) {
+                addressUnitMap.get(address).add(unit);
+            } else {
+                Set<String> units = new HashSet<>();
+                units.add(unit);
+                addressUnitMap.put(address, units);
+            }
+        }
+
+        //Address unit maps to AddressUnits record
+        List<BalanceRollbackEvent.AddressUnits> addressUnits = new ArrayList<>();
+        for (var entry : addressUnitMap.entrySet()) {
+            String address = entry.getKey();
+            Set<String> units = entry.getValue();
+
+            addressUnits.add(new BalanceRollbackEvent.AddressUnits(address, units));
+        }
+
+        var stakeAddresses = rolledBackStakeAddressBalances
+                .stream()
+                .map(stakeAddressBalance -> stakeAddressBalance.getAddress())
+                .distinct()
+                .toList();
+
+        var balanceRollbackEvent = new BalanceRollbackEvent(rollbackEvent, addressUnits, stakeAddresses);
+        applicationEventPublisher.publishEvent(balanceRollbackEvent);
+    }
+
+    @EventListener
+    @Transactional
+    public void handleCurrentAddressBalanceForRollback(BalanceRollbackEvent balanceRollbackEvent) {
+        if (!accountStoreProperties.isCurrentBalanceEnabled())
+            return;
+
+        for (BalanceRollbackEvent.AddressUnits addressUnits: balanceRollbackEvent.getAddressUnits()) {
+            accountBalanceStorage.refreshCurrentAddressBalance(addressUnits.getAddress(), addressUnits.getUnits(), balanceRollbackEvent.getRollbackEvent().getRollbackTo().getSlot());
+        }
+
+        accountBalanceStorage.refreshCurrentStakeAddressBalance(balanceRollbackEvent.getStakeAddresses(), balanceRollbackEvent.getRollbackEvent().getRollbackTo().getSlot());
+
+        log.info("Rollback -- Address balance adjusted for {} addresses", balanceRollbackEvent.getAddressUnits().size());
+        log.info("Rollback -- Stake address balance adjusted for {} addresses", balanceRollbackEvent.getStakeAddresses().size());
+
+        if (log.isDebugEnabled()) {
+            log.debug("Rollback -- Address balance adjusted for {}", balanceRollbackEvent.getAddressUnits());
+            log.debug("Rollback -- Stake address balance adjusted for {}", balanceRollbackEvent.getStakeAddresses());
+        }
     }
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/AccountBalanceStorage.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/AccountBalanceStorage.java
@@ -7,6 +7,7 @@ import org.springframework.data.util.Pair;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Storage for address balance and stake address balance
@@ -42,6 +43,14 @@ public interface AccountBalanceStorage {
      * @param addressBalances
      */
     void saveAddressBalances(List<AddressBalance> addressBalances);
+
+    /**
+     * Saves the current address balances to current address balance table.
+     *
+     * @param addressBalances a list of AddressBalance objects representing the current balances
+     *                        for various addresses and units.
+     */
+    void saveCurrentAddressBalances(List<AddressBalance> addressBalances);
 
     /**
      * Delete all address balances before the slot except the top one
@@ -122,6 +131,12 @@ public interface AccountBalanceStorage {
     void saveStakeAddressBalances(List<StakeAddressBalance> stakeBalances);
 
     /**
+     * Save current stake address balances to the current balance table
+     * @param stakeBalances
+     */
+    void saveCurrentStakeAddressBalances(List<StakeAddressBalance> stakeBalances);
+
+    /**
      * Delete all stake address balances before the slot except the top one
      * This is called to clean history data
      * <p></p>
@@ -162,4 +177,56 @@ public interface AccountBalanceStorage {
      */
     List<AddressBalance> getAddressesByAsset(String unit, int page, int count, Order sort);
 
+    /*******************************************************************************************
+     * The following methods are used for current address balance table refresh during rollback
+     *******************************************************************************************/
+
+    /**
+     * Retrieves a list of address balances where the slot is greater than the specified value. This is typically used
+     * to identify records that need to be deleted during a rollback operation.
+     *
+     * @param slot the slot value
+     * @return a list of AddressBalance objects that match the specified slot criteria.
+     */
+    List<AddressBalance> getAddressBalanceBySlotGreaterThan(Long slot);
+
+    /**
+     * Retrieves a list of stake address balances where the slot is greater than the specified value. This is typically used
+     * to identify records that need to be deleted during a rollback operation.
+     *
+     * @param slot the slot value
+     * @return a list of StakeAddressBalance objects that match the specified slot criteria.
+     */
+    List<StakeAddressBalance> getStakeAddressBalanceBySlotGreaterThan(Long slot);
+
+    /**
+     * Refreshes the current address balance for a given address and set of units at a specified slot.
+     * This is typically used during a rollback operation to ensure that the current balance is accurate.
+     * @param address
+     * @param units
+     * @param slot rollback slot
+     */
+    void refreshCurrentAddressBalance(String address, Set<String> units, Long slot);
+
+    /**
+     * Refreshes the current stake address balance for a given list of addresses at a specified slot.
+     * This is typically used during a rollback operation to ensure that the current balance is accurate.
+     * @param address
+     * @param slot rollback slot
+     */
+    void refreshCurrentStakeAddressBalance(List<String> address, Long slot);
+
+    /**
+     * Get current address balances for the given address from current balance table
+     * @param address
+     * @return List of AddressBalance
+     */
+    List<AddressBalance> getCurrentAddressBalance(String address);
+
+    /**
+     * Get current stake address balance for the given address from current balance table
+     * @param address
+     * @return StakeAddressBalance
+     */
+    Optional<StakeAddressBalance> getCurrentStakeAddressBalance(String address);
 }

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImpl.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImpl.java
@@ -162,6 +162,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                     addressBalanceRec.setUnit(addrBalance.getUnit());
                     addressBalanceRec.setQuantity(addrBalance.getQuantity());
                     addressBalanceRec.setAddrFull(addrBalance.getAddrFull());
+                    addressBalanceRec.setSlot(addrBalance.getSlot());
                     addressBalanceRec.setBlock(addrBalance.getBlockNumber());
                     addressBalanceRec.setBlockTime(addrBalance.getBlockTime());
                     addressBalanceRec.setEpoch(addrBalance.getEpoch());
@@ -180,6 +181,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                             ADDRESS_BALANCE_CURRENT.UNIT,
                             ADDRESS_BALANCE_CURRENT.QUANTITY,
                             ADDRESS_BALANCE_CURRENT.ADDR_FULL,
+                            ADDRESS_BALANCE_CURRENT.SLOT,
                             ADDRESS_BALANCE_CURRENT.BLOCK,
                             ADDRESS_BALANCE_CURRENT.BLOCK_TIME,
                             ADDRESS_BALANCE_CURRENT.EPOCH,
@@ -309,6 +311,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                     var stakeAddressBalanceRec = dsl.newRecord(STAKE_ADDRESS_BALANCE_CURRENT);
                     stakeAddressBalanceRec.setAddress(stakeAddrBalance.getAddress());
                     stakeAddressBalanceRec.setQuantity(stakeAddrBalance.getQuantity());
+                    stakeAddressBalanceRec.setSlot(stakeAddrBalance.getSlot());
                     stakeAddressBalanceRec.setBlock(stakeAddrBalance.getBlockNumber());
                     stakeAddressBalanceRec.setBlockTime(stakeAddrBalance.getBlockTime());
                     stakeAddressBalanceRec.setEpoch(stakeAddrBalance.getEpoch());
@@ -325,6 +328,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                     .loadRecords(stakeAddressBalanceRecords)
                     .fields(STAKE_ADDRESS_BALANCE_CURRENT.ADDRESS,
                             STAKE_ADDRESS_BALANCE_CURRENT.QUANTITY,
+                            STAKE_ADDRESS_BALANCE_CURRENT.SLOT,
                             STAKE_ADDRESS_BALANCE_CURRENT.BLOCK,
                             STAKE_ADDRESS_BALANCE_CURRENT.BLOCK_TIME,
                             STAKE_ADDRESS_BALANCE_CURRENT.EPOCH,
@@ -476,6 +480,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                         abc.UNIT,
                         abc.QUANTITY,
                         abc.ADDR_FULL,
+                        abc.SLOT,
                         abc.BLOCK,
                         abc.BLOCK_TIME,
                         abc.EPOCH,
@@ -487,6 +492,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                                 latestTable.field("unit", String.class),
                                 latestTable.field("quantity", BigInteger.class),
                                 latestTable.field("addr_full", String.class),
+                                latestTable.field("slot", Long.class),
                                 latestTable.field("block", Long.class),
                                 latestTable.field("block_time", Long.class),
                                 latestTable.field("epoch", Integer.class),
@@ -546,6 +552,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                 .columns(
                         sabc.ADDRESS,
                         sabc.QUANTITY,
+                        sabc.SLOT,
                         sabc.BLOCK,
                         sabc.BLOCK_TIME,
                         sabc.EPOCH,
@@ -555,6 +562,7 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                         select(
                                 latestTable.field("address", String.class),
                                 latestTable.field("quantity", BigInteger.class),
+                                latestTable.field("slot", Long.class),
                                 latestTable.field("block", Long.class),
                                 latestTable.field("block_time", Long.class),
                                 latestTable.field("epoch", Integer.class),

--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImpl.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImpl.java
@@ -15,7 +15,8 @@ import com.bloxbean.cardano.yaci.store.common.util.ListUtil;
 import com.bloxbean.cardano.yaci.store.events.internal.CommitEvent;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.DSLContext;
+import org.jooq.*;
+import org.jooq.Record;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
@@ -24,16 +25,16 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.math.BigInteger;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.ADDRESS_BALANCE;
-import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.STAKE_ADDRESS_BALANCE;
+import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.*;
+import static com.bloxbean.cardano.yaci.store.common.util.ListUtil.partition;
+import static org.jooq.impl.DSL.*;
 
 @Slf4j
 public class AccountBalanceStorageImpl implements AccountBalanceStorage {
@@ -146,6 +147,51 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
 
     @Transactional
     @Override
+    public void saveCurrentAddressBalances(List<AddressBalance> addressBalances) {
+        LocalDateTime localDateTime = LocalDateTime.now();
+
+        List<AddressBalanceEntity> entities = addressBalances.stream().map(mapper::toAddressBalanceEntity)
+                .toList();
+
+        int batchSize = storeProperties.getWriteThreadDefaultBatchSize();
+
+        var addressBalanceRecords = entities.stream()
+                .map(addrBalance -> {
+                    var addressBalanceRec = dsl.newRecord(ADDRESS_BALANCE_CURRENT);
+                    addressBalanceRec.setAddress(addrBalance.getAddress());
+                    addressBalanceRec.setUnit(addrBalance.getUnit());
+                    addressBalanceRec.setQuantity(addrBalance.getQuantity());
+                    addressBalanceRec.setAddrFull(addrBalance.getAddrFull());
+                    addressBalanceRec.setBlock(addrBalance.getBlockNumber());
+                    addressBalanceRec.setBlockTime(addrBalance.getBlockTime());
+                    addressBalanceRec.setEpoch(addrBalance.getEpoch());
+                    addressBalanceRec.setUpdateDatetime(localDateTime);
+                    return addressBalanceRec;
+                });
+
+        try {
+            dsl.loadInto(ADDRESS_BALANCE_CURRENT)
+                    .onDuplicateKeyUpdate()
+                    //.bulkAfter(batchSize)
+                    .batchAfter(batchSize)
+                    .commitAfter(batchSize)
+                    .loadRecords(addressBalanceRecords)
+                    .fields(ADDRESS_BALANCE_CURRENT.ADDRESS,
+                            ADDRESS_BALANCE_CURRENT.UNIT,
+                            ADDRESS_BALANCE_CURRENT.QUANTITY,
+                            ADDRESS_BALANCE_CURRENT.ADDR_FULL,
+                            ADDRESS_BALANCE_CURRENT.BLOCK,
+                            ADDRESS_BALANCE_CURRENT.BLOCK_TIME,
+                            ADDRESS_BALANCE_CURRENT.EPOCH,
+                            ADDRESS_BALANCE_CURRENT.UPDATE_DATETIME)
+                    .execute();
+        } catch (IOException e) {
+            log.error("Error while inserting address balance current records", e);
+        }
+    }
+
+    @Transactional
+    @Override
     public int deleteAddressBalanceBeforeSlotExceptTop(String address, String unit, long slot) {
         //Find the latest address balance before the slot and delete all address balances before that
         return addressBalanceRepository.findTopByAddressAndUnitAndSlotIsLessThanEqualOrderBySlotDesc(address, unit, slot)
@@ -231,7 +277,6 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
 
     private void saveStakeBalanceBatchJOOQ(List<StakeAddressBalanceEntity> stakeAddressBalances) {
         LocalDateTime localDateTime = LocalDateTime.now();
-
         var inserts = stakeAddressBalances.stream()
                         .map(stakeAddrBalance -> dsl.insertInto(STAKE_ADDRESS_BALANCE)
                                 .set(STAKE_ADDRESS_BALANCE.ADDRESS, stakeAddrBalance.getAddress())
@@ -250,6 +295,44 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
                         ).toList();
 
         dsl.batch(inserts).execute();
+    }
+
+    @Transactional
+    @Override
+    public void saveCurrentStakeAddressBalances(List<StakeAddressBalance> stakeBalances) {
+        LocalDateTime localDateTime = LocalDateTime.now();
+
+        int batchSize = storeProperties.getWriteThreadDefaultBatchSize();
+
+        var stakeAddressBalanceRecords = stakeBalances.stream()
+                .map(stakeAddrBalance -> {
+                    var stakeAddressBalanceRec = dsl.newRecord(STAKE_ADDRESS_BALANCE_CURRENT);
+                    stakeAddressBalanceRec.setAddress(stakeAddrBalance.getAddress());
+                    stakeAddressBalanceRec.setQuantity(stakeAddrBalance.getQuantity());
+                    stakeAddressBalanceRec.setBlock(stakeAddrBalance.getBlockNumber());
+                    stakeAddressBalanceRec.setBlockTime(stakeAddrBalance.getBlockTime());
+                    stakeAddressBalanceRec.setEpoch(stakeAddrBalance.getEpoch());
+                    stakeAddressBalanceRec.setUpdateDatetime(localDateTime);
+                    return stakeAddressBalanceRec;
+                });
+
+        try {
+            dsl.loadInto(STAKE_ADDRESS_BALANCE_CURRENT)
+                    .onDuplicateKeyUpdate()
+                    //.bulkAfter(batchSize)
+                    .batchAfter(batchSize)
+                    .commitAfter(batchSize)
+                    .loadRecords(stakeAddressBalanceRecords)
+                    .fields(STAKE_ADDRESS_BALANCE_CURRENT.ADDRESS,
+                            STAKE_ADDRESS_BALANCE_CURRENT.QUANTITY,
+                            STAKE_ADDRESS_BALANCE_CURRENT.BLOCK,
+                            STAKE_ADDRESS_BALANCE_CURRENT.BLOCK_TIME,
+                            STAKE_ADDRESS_BALANCE_CURRENT.EPOCH,
+                            STAKE_ADDRESS_BALANCE_CURRENT.UPDATE_DATETIME)
+                    .execute();
+        } catch (IOException e) {
+            log.error("Error while inserting stake address balance current records", e);
+        }
     }
 
     @Transactional
@@ -331,6 +414,188 @@ public class AccountBalanceStorageImpl implements AccountBalanceStorage {
         stakeBalanceKeysToDeleteCache.clear();
 
         return totalCount;
+    }
+
+    @Transactional
+    @Override
+    public void refreshCurrentAddressBalance(String address, Set<String> units, Long slot) {
+        if (units == null || units.isEmpty()) {
+            log.warn("No units found for address: {}", address);
+            return;
+        }
+
+        List<String> unitList = new ArrayList<>(units);
+
+        List<List<String>> unitChunks = partition(unitList, 20);
+
+        for (List<String> unitChunk : unitChunks) {
+            rollbackForAddressUnits(address, unitChunk, slot);
+        }
+
+    }
+
+    private void rollbackForAddressUnits(String address, List<String> units, Long slot) {
+        // Table aliases
+        var ab = ADDRESS_BALANCE.as("ab");
+        var abc = ADDRESS_BALANCE_CURRENT;
+        var ranked = name("ranked");
+        var latest = name("latest_balances");
+
+        // Step 1: CTE for latest balances with row_number()
+        var latestBalancesQuery = dsl
+                .select()
+                .from(
+                        select(ab.fields())
+                                .select(rowNumber().over()
+                                        .partitionBy(ab.ADDRESS, ab.UNIT)
+                                        .orderBy(ab.SLOT.desc())
+                                        .as("rn"))
+                                .from(ab)
+                                .where(ab.ADDRESS.eq(address))
+                                .and(ab.UNIT.in(units))
+                                .and(ab.SLOT.le(slot))
+                                .asTable(ranked)
+                )
+                .where(field("rn", Integer.class).eq(1));
+                //.asTable(latest);
+
+        Table<Record> latestTable = latestBalancesQuery.asTable(latest);
+        CommonTableExpression<?> latestBalancesCte = name("latest_balances").as(latestBalancesQuery);
+
+        // Step 2: Delete existing entries
+        dsl.deleteFrom(abc)
+                .where(abc.ADDRESS.eq(address))
+                .and(abc.UNIT.in(units))
+                .execute();
+
+        // Step 3: Upsert back into current balance table
+        dsl.with(latestBalancesCte)
+                .insertInto(abc)
+                .columns(
+                        abc.ADDRESS,
+                        abc.UNIT,
+                        abc.QUANTITY,
+                        abc.ADDR_FULL,
+                        abc.BLOCK,
+                        abc.BLOCK_TIME,
+                        abc.EPOCH,
+                        abc.UPDATE_DATETIME
+                )
+                .select(
+                        select(
+                                latestTable.field("address", String.class),
+                                latestTable.field("unit", String.class),
+                                latestTable.field("quantity", BigInteger.class),
+                                latestTable.field("addr_full", String.class),
+                                latestTable.field("block", Long.class),
+                                latestTable.field("block_time", Long.class),
+                                latestTable.field("epoch", Integer.class),
+                                latestTable.field("update_datetime", LocalDateTime.class)
+                        ).from(latest)
+                )
+                .execute();
+    }
+
+    @Transactional
+    @Override
+    public void refreshCurrentStakeAddressBalance(List<String> stakeAddresses, Long slot) {
+        List<List<String>> addressChunks = partition(stakeAddresses, 20);
+
+        for (List<String> chunk : addressChunks) {
+            rollbackForStakeAddresses(chunk, slot);
+        }
+    }
+
+    private void rollbackForStakeAddresses(List<String> addresses, Long slot) {
+        var sab = STAKE_ADDRESS_BALANCE.as("sab");
+        var sabc = STAKE_ADDRESS_BALANCE_CURRENT;
+        var ranked = name("ranked");
+        var latest = name("latest_balances");
+
+        // Step 1: Build CTE for latest balances
+        var latestBalancesQuery = dsl
+                .select()
+                .from(
+                        select(sab.fields())
+                                .select(
+                                        rowNumber().over()
+                                                .partitionBy(sab.ADDRESS)
+                                                .orderBy(sab.SLOT.desc())
+                                                .as("rn")
+                                )
+                                .from(sab)
+                                .where(sab.ADDRESS.in(addresses))
+                                .and(sab.SLOT.le(slot))
+                                .asTable(ranked)
+                )
+                .where(field("rn", Integer.class).eq(1));
+                //.asTable(latest);
+
+        Table<Record> latestTable = latestBalancesQuery.asTable(latest);
+        CommonTableExpression<?> latestBalancesCte = name("latest_balances").as(latestBalancesQuery);
+
+
+        // Step 2: Delete old current records for addresses
+        dsl.deleteFrom(sabc)
+                .where(sabc.ADDRESS.in(addresses))
+                .execute();
+
+        // Step 3: Insert or update latest balance
+        dsl.with(latestBalancesCte)
+                .insertInto(sabc)
+                .columns(
+                        sabc.ADDRESS,
+                        sabc.QUANTITY,
+                        sabc.BLOCK,
+                        sabc.BLOCK_TIME,
+                        sabc.EPOCH,
+                        sabc.UPDATE_DATETIME
+                )
+                .select(
+                        select(
+                                latestTable.field("address", String.class),
+                                latestTable.field("quantity", BigInteger.class),
+                                latestTable.field("block", Long.class),
+                                latestTable.field("block_time", Long.class),
+                                latestTable.field("epoch", Integer.class),
+                                latestTable.field("update_datetime", LocalDateTime.class)
+                        ).from(latest)
+                )
+                .execute();
+    }
+
+    @Override
+    public List<AddressBalance> getAddressBalanceBySlotGreaterThan(Long slot) {
+        return dsl.select()
+                .from(ADDRESS_BALANCE)
+                .where(ADDRESS_BALANCE.SLOT.gt(slot))
+                .orderBy(ADDRESS_BALANCE.SLOT.asc())
+                .fetchInto(AddressBalance.class);
+    }
+
+    @Override
+    public List<StakeAddressBalance> getStakeAddressBalanceBySlotGreaterThan(Long slot) {
+        return dsl.select()
+                .from(STAKE_ADDRESS_BALANCE)
+                .where(STAKE_ADDRESS_BALANCE.SLOT.gt(slot))
+                .orderBy(STAKE_ADDRESS_BALANCE.SLOT.asc())
+                .fetchInto(StakeAddressBalance.class);
+    }
+
+    @Override
+    public List<AddressBalance> getCurrentAddressBalance(String address) {
+        return dsl.select()
+                .from(ADDRESS_BALANCE_CURRENT)
+                .where(ADDRESS_BALANCE_CURRENT.ADDRESS.eq(address))
+                .fetchInto(AddressBalance.class);
+    }
+
+    @Override
+    public Optional<StakeAddressBalance> getCurrentStakeAddressBalance(String address) {
+        return dsl.select()
+                .from(STAKE_ADDRESS_BALANCE_CURRENT)
+                .where(STAKE_ADDRESS_BALANCE_CURRENT.ADDRESS.eq(address))
+                .fetchOptionalInto(StakeAddressBalance.class);
     }
 
     private int getPartitionSize(int totalSize) {

--- a/aggregates/account/src/main/resources/META-INF/native-image/yaci-store-account/reflect-config.json
+++ b/aggregates/account/src/main/resources/META-INF/native-image/yaci-store-account/reflect-config.json
@@ -30,6 +30,26 @@
     "unsafeAllocated": true
   },
   {
+    "name": "com.bloxbean.cardano.yaci.store.account.jooq.tables.pojos.StakeAddressBalanceCurrent",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "[Lcom.bloxbean.cardano.yaci.store.account.jooq.tables.pojos.StakeAddressBalanceCurrent;",
+    "unsafeAllocated": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.account.jooq.tables.pojos.AddressBalanceCurrent",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "[Lcom.bloxbean.cardano.yaci.store.account.jooq.tables.pojos.AddressBalanceCurrent;",
+    "unsafeAllocated": true
+  },
+  {
     "name": "com.bloxbean.cardano.yaci.store.account.jooq.tables.pojos.AccountConfig",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,

--- a/aggregates/account/src/main/resources/META-INF/native-image/yaci-store-account/reflect-config.json
+++ b/aggregates/account/src/main/resources/META-INF/native-image/yaci-store-account/reflect-config.json
@@ -82,5 +82,17 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.account.jooq.tables.records.AddressBalanceCurrentRecord",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.account.jooq.tables.records.StakeAddressBalanceCurrentRecord",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/aggregates/account/src/main/resources/db/store/h2/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/h2/V0_900_6__current_tables.sql
@@ -1,0 +1,26 @@
+drop table if exists address_balance_current;
+create table address_balance_current
+(
+    address            varchar(500),
+    unit               varchar(255),
+    quantity           numeric(38)  null,
+    addr_full          clob null,
+    block              bigint,
+    block_time         bigint,
+    epoch              integer,
+    update_datetime    timestamp,
+    primary key (address, unit)
+);
+
+-- stake_balance
+drop table if exists stake_address_balance_current;
+create table stake_address_balance_current
+(
+    address          varchar(255),
+    quantity         numeric(38)  null,
+    block            bigint,
+    block_time       bigint,
+    epoch            integer,
+    update_datetime  timestamp,
+    primary key (address)
+);

--- a/aggregates/account/src/main/resources/db/store/h2/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/h2/V0_900_6__current_tables.sql
@@ -5,6 +5,7 @@ create table address_balance_current
     unit               varchar(255),
     quantity           numeric(38)  null,
     addr_full          clob null,
+    slot               bigint,
     block              bigint,
     block_time         bigint,
     epoch              integer,
@@ -18,6 +19,7 @@ create table stake_address_balance_current
 (
     address          varchar(255),
     quantity         numeric(38)  null,
+    slot             bigint,
     block            bigint,
     block_time       bigint,
     epoch            integer,

--- a/aggregates/account/src/main/resources/db/store/mysql/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/mysql/V0_900_6__current_tables.sql
@@ -5,6 +5,7 @@ create table address_balance_current
     unit               varchar(255),
     quantity           numeric(38)  null,
     addr_full          longtext null,
+    slot               bigint,
     block              bigint,
     block_time         bigint,
     epoch              integer,
@@ -18,6 +19,7 @@ create table stake_address_balance_current
 (
     address          varchar(255),
     quantity         numeric(38)  null,
+    slot             bigint,
     block            bigint,
     block_time       bigint,
     epoch            integer,

--- a/aggregates/account/src/main/resources/db/store/mysql/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/mysql/V0_900_6__current_tables.sql
@@ -1,0 +1,26 @@
+drop table if exists address_balance_current;
+create table address_balance_current
+(
+    address            varchar(500),
+    unit               varchar(255),
+    quantity           numeric(38)  null,
+    addr_full          longtext null,
+    block              bigint,
+    block_time         bigint,
+    epoch              integer,
+    update_datetime    timestamp,
+    primary key (address, unit)
+);
+
+-- stake_balance
+drop table if exists stake_address_balance_current;
+create table stake_address_balance_current
+(
+    address          varchar(255),
+    quantity         numeric(38)  null,
+    block            bigint,
+    block_time       bigint,
+    epoch            integer,
+    update_datetime  timestamp,
+    primary key (address)
+);

--- a/aggregates/account/src/main/resources/db/store/postgresql/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/postgresql/V0_900_6__current_tables.sql
@@ -5,6 +5,7 @@ create table address_balance_current
     unit               varchar(255),
     quantity           numeric(38)  null,
     addr_full          text,
+    slot               bigint,
     block              bigint,
     block_time         bigint,
     epoch              integer,
@@ -18,6 +19,7 @@ create table stake_address_balance_current
 (
     address          varchar(255),
     quantity         numeric(38)  null,
+    slot             bigint,
     block            bigint,
     block_time       bigint,
     epoch            integer,

--- a/aggregates/account/src/main/resources/db/store/postgresql/V0_900_6__current_tables.sql
+++ b/aggregates/account/src/main/resources/db/store/postgresql/V0_900_6__current_tables.sql
@@ -1,0 +1,26 @@
+drop table if exists address_balance_current;
+create table address_balance_current
+(
+    address            varchar(500),
+    unit               varchar(255),
+    quantity           numeric(38)  null,
+    addr_full          text,
+    block              bigint,
+    block_time         bigint,
+    epoch              integer,
+    update_datetime    timestamp,
+    primary key (address, unit)
+);
+
+-- stake_balance
+drop table if exists stake_address_balance_current;
+create table stake_address_balance_current
+(
+    address          varchar(255),
+    quantity         numeric(38)  null,
+    block            bigint,
+    block_time       bigint,
+    epoch            integer,
+    update_datetime  timestamp,
+    primary key (address)
+);

--- a/aggregates/account/src/test/java/com/bloxbean/cardano/yaci/store/account/config/JooqTestConfig.java
+++ b/aggregates/account/src/test/java/com/bloxbean/cardano/yaci/store/account/config/JooqTestConfig.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.account.config;
+
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.RenderQuotedNames;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+public class JooqTestConfig {
+
+    @Bean
+    public DSLContext dslContext(DataSource dataSource) {
+        return DSL.using(dataSource, SQLDialect.H2,
+                new Settings().withRenderQuotedNames(RenderQuotedNames.NEVER));
+    }
+}
+

--- a/aggregates/account/src/test/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImplTest.java
+++ b/aggregates/account/src/test/java/com/bloxbean/cardano/yaci/store/account/storage/impl/AccountBalanceStorageImplTest.java
@@ -1,0 +1,324 @@
+package com.bloxbean.cardano.yaci.store.account.storage.impl;
+
+import com.bloxbean.cardano.yaci.store.account.AccountStoreProperties;
+import com.bloxbean.cardano.yaci.store.account.config.JooqTestConfig;
+import com.bloxbean.cardano.yaci.store.account.domain.AddressBalance;
+import com.bloxbean.cardano.yaci.store.account.storage.AccountBalanceStorage;
+import com.bloxbean.cardano.yaci.store.account.storage.impl.repository.AddressBalanceRepository;
+import com.bloxbean.cardano.yaci.store.account.storage.impl.repository.StakeBalanceRepository;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.bloxbean.cardano.yaci.store.account.domain.StakeAddressBalance;
+
+import java.util.Optional;
+
+@DataJpaTest
+@Import({JooqTestConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=true",
+        "spring.flyway.locations=classpath:db/store/h2",
+        "spring.flyway.out-of-order=true",
+        "spring.datasource.url=jdbc:h2:mem:mydb",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=password"
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AccountBalanceStorageImplTest {
+
+    @Autowired
+    private AddressBalanceRepository addressBalanceRepository;
+
+    @Autowired
+    private StakeBalanceRepository stakeBalanceRepository;
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private Flyway flyway;
+
+    private StoreProperties storeProperties;
+    private AccountStoreProperties accountStoreProperties;
+
+    private AccountBalanceStorage accountBalanceStorage;
+
+    @BeforeAll
+    void migrate() {
+        flyway.migrate();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        storeProperties = new StoreProperties();
+        accountStoreProperties = new AccountStoreProperties();
+
+        accountBalanceStorage = new AccountBalanceStorageImpl(
+                addressBalanceRepository,
+                stakeBalanceRepository,
+                dsl,
+                storeProperties,
+                accountStoreProperties
+        );
+    }
+
+    @Test
+    void testRefreshCurrentAddressBalance() {
+        AddressBalance addressBalance11 = new AddressBalance();
+        addressBalance11.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance11.setUnit("lovelace");
+        addressBalance11.setQuantity(new BigInteger("2000000"));
+        addressBalance11.setSlot(1L);
+
+        AddressBalance addressBalance21 = new AddressBalance();
+        addressBalance21.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance21.setUnit("a5968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        addressBalance21.setQuantity(new BigInteger("1"));
+        addressBalance21.setSlot(1L);
+
+        AddressBalance addressBalance31 = new AddressBalance();
+        addressBalance31.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance31.setUnit("b6968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        addressBalance31.setQuantity(new BigInteger("5"));
+        addressBalance31.setSlot(1L);
+
+        AddressBalance addressBalance12= new AddressBalance();
+        addressBalance12.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance12.setUnit("lovelace");
+        addressBalance12.setQuantity(new BigInteger("3000000"));
+        addressBalance12.setSlot(2L);
+
+        AddressBalance addressBalance16= new AddressBalance();
+        addressBalance16.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance16.setUnit("lovelace");
+        addressBalance16.setQuantity(new BigInteger("8000000"));
+        addressBalance16.setSlot(6L);
+
+        AddressBalance addressBalance26 = new AddressBalance();
+        addressBalance26.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance26.setUnit("b6968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        addressBalance26.setQuantity(new BigInteger("56"));
+        addressBalance26.setSlot(6L);
+
+        AddressBalance addressBalance32 = new AddressBalance();
+        addressBalance32.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance32.setUnit("c8968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624c595f4e46545f31");
+        addressBalance32.setQuantity(new BigInteger("10"));
+        addressBalance32.setSlot(3L);
+
+        AddressBalance addressBalance41 = new AddressBalance();
+        addressBalance41.setAddress("addr_test1vqvhvxjz4q7g5gw64jacxevgmzzlfju87ma0q4wcgv656vsvm7k08");
+        addressBalance41.setUnit("d9968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        addressBalance41.setQuantity(new BigInteger("20"));
+        addressBalance41.setSlot(4L);
+
+        AddressBalance newAddressBalance1 = new AddressBalance();
+        newAddressBalance1.setAddress("addr_test1rpqmcdy3pklfwlptkzef77yj8sfvrlgqtdtvvhz989g3kkg6a2kwp");
+        newAddressBalance1.setUnit("e0968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        newAddressBalance1.setQuantity(new BigInteger("15"));
+        newAddressBalance1.setSlot(3L);
+
+        AddressBalance newAddressBalance2 = new AddressBalance();
+        newAddressBalance2.setAddress("addr_test1qqpptk7uumhx3ppcwka362xycjyn23qkzd6w5y6pl3c7lg05u7sl4");
+        newAddressBalance2.setUnit("f1968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31");
+        newAddressBalance2.setQuantity(new BigInteger("25"));
+        newAddressBalance2.setSlot(7L);
+
+        accountBalanceStorage.saveAddressBalances(List.of(
+                addressBalance11,
+                addressBalance21,
+                addressBalance31,
+                addressBalance12,
+                addressBalance16,
+                addressBalance26,
+                addressBalance32,
+                addressBalance41,
+                newAddressBalance1,
+                newAddressBalance2
+        ));
+        accountBalanceStorage.saveCurrentAddressBalances(List.of(addressBalance21, addressBalance16, addressBalance26, addressBalance32, addressBalance41, newAddressBalance1, newAddressBalance2));
+
+        accountBalanceStorage.refreshCurrentAddressBalance(addressBalance11.getAddress(), Set.of("lovelace", "b6968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31"), 4L);
+
+        List<AddressBalance> addressBalances = accountBalanceStorage.getCurrentAddressBalance(addressBalance11.getAddress());
+        assertEquals(5, addressBalances.size());
+        assertEquals(new BigInteger("3000000"), addressBalances.stream().filter(ab -> ab.getUnit().equals("lovelace")).findFirst().get().getQuantity());
+        assertEquals(new BigInteger("5"), addressBalances.stream().filter(ab -> ab.getUnit().equals("b6968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31"))
+                .findFirst().get().getQuantity());
+        assertEquals(new BigInteger("1"), addressBalances.stream().filter(ab -> ab.getUnit().equals("a5968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31"))
+                .findFirst().get().getQuantity());
+        assertEquals(new BigInteger("10"), addressBalances.stream().filter(ab -> ab.getUnit().equals("c8968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624c595f4e46545f31"))
+                .findFirst().get().getQuantity());
+        assertEquals(new BigInteger("20"), addressBalances.stream().filter(ab -> ab.getUnit().equals("d9968700149c46e87e13bd15e9a69dc5ef06d80b72dfad41523c78624d595f4e46545f31"))
+                .findFirst().get().getQuantity());
+    }
+
+    private static java.util.Map.Entry<String, String> generateRandomAddressAndUnit() {
+        String randomAddress = "addr_test" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 32);
+        String randomUnit = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 32);
+        return java.util.Map.entry(randomAddress, randomUnit);
+    }
+
+    @Test
+    void testRefreshCurrentAddressBalanceWithNewAddressOne() {
+        var randomData = generateRandomAddressAndUnit();
+        String newAddress = randomData.getKey();
+        String newUnit = randomData.getValue();
+
+        AddressBalance addressBalance = new AddressBalance();
+        addressBalance.setAddress(newAddress);
+        addressBalance.setUnit(newUnit);
+        addressBalance.setQuantity(new BigInteger("1000000"));
+        addressBalance.setSlot(10L);
+
+        accountBalanceStorage.saveAddressBalances(List.of(addressBalance));
+        accountBalanceStorage.saveCurrentAddressBalances(List.of(addressBalance));
+
+        accountBalanceStorage.refreshCurrentAddressBalance(newAddress, Set.of(newUnit), 10L);
+
+        List<AddressBalance> addressBalances = accountBalanceStorage.getCurrentAddressBalance(newAddress);
+        assertEquals(1, addressBalances.size());
+        assertEquals(new BigInteger("1000000"), addressBalances.stream().filter(ab -> ab.getUnit().equals(newUnit)).findFirst().get().getQuantity());
+    }
+
+    @Test
+    void testRefreshCurrentAddressBalanceWithNewAddressOne_noBalanceAfterRollback() {
+        var randomData = generateRandomAddressAndUnit();
+        String newAddress = randomData.getKey();
+        String newUnit = randomData.getValue();
+
+        AddressBalance addressBalance = new AddressBalance();
+        addressBalance.setAddress(newAddress);
+        addressBalance.setUnit(newUnit);
+        addressBalance.setQuantity(new BigInteger("1000000"));
+        addressBalance.setSlot(10L);
+
+        accountBalanceStorage.saveAddressBalances(List.of(addressBalance));
+        accountBalanceStorage.saveCurrentAddressBalances(List.of(addressBalance));
+
+        accountBalanceStorage.refreshCurrentAddressBalance(newAddress, Set.of(newUnit), 5L);
+
+        List<AddressBalance> addressBalances = accountBalanceStorage.getCurrentAddressBalance(newAddress);
+        assertEquals(0, addressBalances.size());
+    }
+
+    @Test
+    void testRefreshCurrentAddressBalanceWithNewAddressTwo() {
+        var randomData = generateRandomAddressAndUnit();
+        String newAddress = randomData.getKey();
+        String newUnit = randomData.getValue();
+
+        AddressBalance addressBalance1 = new AddressBalance();
+        addressBalance1.setAddress(newAddress);
+        addressBalance1.setUnit(newUnit);
+        addressBalance1.setQuantity(new BigInteger("2000000"));
+        addressBalance1.setSlot(5L);
+
+        AddressBalance addressBalance2 = new AddressBalance();
+        addressBalance2.setAddress(newAddress);
+        addressBalance2.setUnit(newUnit);
+        addressBalance2.setQuantity(new BigInteger("3000000"));
+        addressBalance2.setSlot(8L);
+
+        accountBalanceStorage.saveAddressBalances(List.of(addressBalance1, addressBalance2));
+        accountBalanceStorage.saveCurrentAddressBalances(List.of(addressBalance2));
+
+        accountBalanceStorage.refreshCurrentAddressBalance(newAddress, Set.of(newUnit), 7L);
+
+        List<AddressBalance> addressBalances = accountBalanceStorage.getCurrentAddressBalance(newAddress);
+        assertEquals(1, addressBalances.size());
+        assertEquals(new BigInteger("2000000"), addressBalances.stream().filter(ab -> ab.getUnit().equals(newUnit)).findFirst().get().getQuantity());
+    }
+
+
+    @Test
+    void testRefreshCurrentStakeAddressBalanceWithStakeAddresses() {
+        String stakeAddress1 = "stake_test1uqfu602nvxp7j5wkr2ngeq3pzusengw6anv9el6z4hqweuc4pvuq5";
+        String stakeAddress2 = "stake_test1zp6cmg4vl8qkv6nvmcxyd7nvlj8q2htyj6nzemxadfqj8vspy8cck";
+
+        StakeAddressBalance stakeBalance1 = new StakeAddressBalance();
+        stakeBalance1.setAddress(stakeAddress1);
+        stakeBalance1.setQuantity(new BigInteger("1000000"));
+        stakeBalance1.setSlot(3L);
+
+        StakeAddressBalance stakeBalance2 = new StakeAddressBalance();
+        stakeBalance2.setAddress(stakeAddress2);
+        stakeBalance2.setQuantity(new BigInteger("1500000"));
+        stakeBalance2.setSlot(5L);
+
+        accountBalanceStorage.saveStakeAddressBalances(List.of(stakeBalance1, stakeBalance2));
+        accountBalanceStorage.saveCurrentStakeAddressBalances(List.of(stakeBalance1, stakeBalance2));
+
+        accountBalanceStorage.refreshCurrentStakeAddressBalance(List.of(stakeAddress1, stakeAddress2), 4L);
+
+        Optional<StakeAddressBalance> updatedBalance1 = accountBalanceStorage.getCurrentStakeAddressBalance(stakeAddress1);
+        assertTrue(updatedBalance1.isPresent());
+        assertEquals(new BigInteger("1000000"), updatedBalance1.get().getQuantity());
+
+        Optional<StakeAddressBalance> updatedBalance2 = accountBalanceStorage.getCurrentStakeAddressBalance(stakeAddress2);
+        assertFalse(updatedBalance2.isPresent());
+    }
+
+    @Test
+    void testRefreshCurrentStakeAddressBalanceWithRollback() {
+        String stakeAddress = "stake_test1zq5hdjkk9e6jxk6nlc4d57vnzej60eyzegn3fy0qcq7nm8slyp7qj";
+
+        StakeAddressBalance stakeBalance = new StakeAddressBalance();
+        stakeBalance.setAddress(stakeAddress);
+        stakeBalance.setQuantity(new BigInteger("2000000"));
+        stakeBalance.setSlot(6L);
+
+        accountBalanceStorage.saveStakeAddressBalances(List.of(stakeBalance));
+        accountBalanceStorage.saveCurrentStakeAddressBalances(List.of(stakeBalance));
+
+        accountBalanceStorage.refreshCurrentStakeAddressBalance(List.of(stakeAddress), 3L);
+
+        Optional<StakeAddressBalance> updatedBalance = accountBalanceStorage.getCurrentStakeAddressBalance(stakeAddress);
+        assertTrue(updatedBalance.isEmpty());
+    }
+
+    @Test
+    void testRefreshCurrentStakeAddressBalanceWithMultipleEntries() {
+        String stakeAddress = "stake_test1uqfu602nvxp7j5wkr2ngeq3pzusengw6anv9el6z4hqweuc4pvuq5";
+        String stakeAddress2 = "stake_test1zp6cmg4vl8qkv6nvmcxyd7nvlj8q2htyj6nzemxadfqj8vspy8cck";
+
+        StakeAddressBalance stakeBalance1 = new StakeAddressBalance();
+        stakeBalance1.setAddress(stakeAddress);
+        stakeBalance1.setQuantity(new BigInteger("1000000"));
+        stakeBalance1.setSlot(4L);
+
+        StakeAddressBalance stakeBalance2 = new StakeAddressBalance();
+        stakeBalance2.setAddress(stakeAddress2);
+        stakeBalance2.setQuantity(new BigInteger("1500000"));
+        stakeBalance2.setSlot(5L);
+
+        StakeAddressBalance stakeBalance3 = new StakeAddressBalance();
+        stakeBalance3.setAddress(stakeAddress);
+        stakeBalance3.setQuantity(new BigInteger("3000000"));
+        stakeBalance3.setSlot(6L);
+
+        accountBalanceStorage.saveStakeAddressBalances(List.of(stakeBalance1, stakeBalance2, stakeBalance3));
+        accountBalanceStorage.saveCurrentStakeAddressBalances(List.of(stakeBalance2, stakeBalance3));
+
+        accountBalanceStorage.refreshCurrentStakeAddressBalance(List.of(stakeAddress, stakeAddress2), 5L);
+
+        Optional<StakeAddressBalance> updatedBalance = accountBalanceStorage.getCurrentStakeAddressBalance(stakeAddress);
+        assertTrue(updatedBalance.isPresent());
+        assertEquals(new BigInteger("1000000"), updatedBalance.get().getQuantity());
+    }
+}

--- a/aggregates/account/src/test/resources/application.properties
+++ b/aggregates/account/src/test/resources/application.properties
@@ -1,0 +1,17 @@
+#spring.flyway.locations=classpath:db/store/{vendor}
+#spring.flyway.out-of-order=true
+#
+#apiPrefix=/api/v1
+#store.sync-auto-start=false
+#
+#store.cardano.host==preprod-node.world.dev.cardano.org
+#store.cardano.port=30000
+#store.cardano.protocol-magic=1
+#
+#spring.datasource.url=jdbc:h2:mem:mydb
+#spring.datasource.username=sa
+#spring.datasource.password=password
+#spring.h2.console.enabled=true
+#
+#store.account.enabled=true
+

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -297,6 +297,16 @@ public class BlockFetchService implements BlockChainDataListener {
 
         cursorService.rollback(point.getSlot());
 
+        //Publish Pre-rollback event
+        PreRollbackEvent preRollbackEvent = PreRollbackEvent
+                .builder()
+                .rollbackTo(point)
+                .currentPoint(currentPoint)
+                .currentBlock(currentBlockNum)
+                .build();
+        log.info("Publishing pre-rollback event : " + preRollbackEvent);
+        publisher.publishEvent(preRollbackEvent);
+
         //Publish rollback event
         RollbackEvent rollbackEvent = RollbackEvent
                 .builder()

--- a/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/PreRollbackEvent.java
+++ b/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/PreRollbackEvent.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.store.events;
+
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import lombok.*;
+
+/**
+ * Represents an event that occurs prior to the rollback event.
+ * This event contains details about the point to which the rollback will occur,
+ * the current point in the chain, and the block number at the current point.
+ *
+ * This can be used to do pre-rollback operations, such as saving the current state.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+@ToString
+public class PreRollbackEvent {
+    private Point rollbackTo;
+    private Point currentPoint;
+    private long currentBlock;
+
+    private boolean remotePublish; //Is published by a remote publisher
+}

--- a/extensions/account-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/account/rocksdb/RocksDBAccountBalanceStorageImpl.java
+++ b/extensions/account-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/account/rocksdb/RocksDBAccountBalanceStorageImpl.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
@@ -106,6 +107,11 @@ public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
         } else {
             ListUtil.partitionAndApply(addressBalances, batchSize, this::saveAddressBalancesToDB);
         }
+    }
+
+    @Override
+    public void saveCurrentAddressBalances(List<AddressBalance> addressBalances) {
+        //TODO
     }
 
     @SneakyThrows
@@ -209,6 +215,12 @@ public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
         }
     }
 
+    @Override
+    public void saveCurrentStakeAddressBalances(List<StakeAddressBalance> stakeBalances) {
+        //TODO
+    }
+
+
     @SneakyThrows
     private void saveStakeAddressBalancesToDB(List<StakeAddressBalance> stakeBalances) {
         try (var writeBatch = new WriteBatch();
@@ -275,6 +287,41 @@ public class RocksDBAccountBalanceStorageImpl implements AccountBalanceStorage {
     public List<AddressBalance> getAddressesByAsset(String unit, int page, int count, Order sort) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
+
+    @Override
+    public List<AddressBalance> getAddressBalanceBySlotGreaterThan(Long slot) {
+        //TODO
+        return List.of();
+    }
+
+    @Override
+    public List<StakeAddressBalance> getStakeAddressBalanceBySlotGreaterThan(Long slot) {
+        //TODO
+        return List.of();
+    }
+
+    @Override
+    public void refreshCurrentAddressBalance(String address, Set<String> units, Long slot) {
+        //TODO
+    }
+
+    @Override
+    public void refreshCurrentStakeAddressBalance(List<String> address, Long slot) {
+        //TODO
+    }
+
+    @Override
+    public List<AddressBalance> getCurrentAddressBalance(String address) {
+        //TODO
+        return List.of();
+    }
+
+    @Override
+    public Optional<StakeAddressBalance> getCurrentStakeAddressBalance(String address) {
+        //TODO
+        return Optional.empty();
+    }
+
 
     private byte[] getAddressAssetKey(String address, String unit) {
         return (address + "_" + unit).getBytes(StandardCharsets.UTF_8);

--- a/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorage.java
+++ b/extensions/utxo-rocksdb/src/main/java/com/bloxbean/cardano/yaci/store/extensions/utxo/rocksdb/RocksDBUtxoStorage.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.event.EventListener;
 
 import java.util.*;
 
@@ -202,6 +201,18 @@ public class RocksDBUtxoStorage implements UtxoStorage {
             utxoCache.clear();
             spentUtxoCache.clear();
         }
+    }
+
+    @Override
+    public List<AddressUtxo> getUnspentBySlotGreaterThan(Long slot) {
+        //TODO
+        return List.of();
+    }
+
+    @Override
+    public List<TxInput> getSpentBySlotGreaterThan(Long slot) {
+        //TODO
+        return List.of();
     }
 
     private void handleCommitForSpentUtxos() {

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfigProperties.java
@@ -49,6 +49,17 @@ public class AccountStoreAutoConfigProperties {
          * Pruning interval in seconds
          */
         private int pruningInterval = 86400;
+
+        /**
+         * Enable content aware rollback
+         */
+        private boolean contentAwareRollback = false;
+
+        /**
+         * Enable current address balance and stake address balance in the current balance table.
+         * This should be enabled with contentAwareRollback option to calculate the current balance correctly during rollback.
+         */
+        private boolean currentBalanceEnabled = false;
     }
 
 }

--- a/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
+++ b/starters/account-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/account/AccountStoreAutoConfiguration.java
@@ -45,6 +45,9 @@ public class AccountStoreAutoConfiguration {
         accountStoreProperties.setPruningBatchSize(properties.getAccount().getPruningBatchSize());
         accountStoreProperties.setPruningInterval(properties.getAccount().getPruningInterval());
 
+        accountStoreProperties.setContentAwareRollback(properties.getAccount().isContentAwareRollback());
+        accountStoreProperties.setCurrentBalanceEnabled(properties.getAccount().isCurrentBalanceEnabled());
+
         return accountStoreProperties;
     }
 }

--- a/starters/utxo-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/utxo/UtxoStoreAutoConfigProperties.java
+++ b/starters/utxo-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/utxo/UtxoStoreAutoConfigProperties.java
@@ -33,6 +33,11 @@ public class UtxoStoreAutoConfigProperties {
          * No of safe blocks to keep before pruning the UTXO
          */
         private int pruningSafeBlocks = 2160;
+
+        /**
+         * Enable content aware rollback
+         */
+        private boolean contentAwareRollback = false;
     }
 
     @Getter

--- a/starters/utxo-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/utxo/UtxoStoreAutoConfiguration.java
+++ b/starters/utxo-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/utxo/UtxoStoreAutoConfiguration.java
@@ -31,6 +31,7 @@ public class UtxoStoreAutoConfiguration {
         utxoStoreProperties.setPruningEnabled(properties.getUtxo().isPruningEnabled());
         utxoStoreProperties.setPruningInterval(properties.getUtxo().getPruningInterval());
         utxoStoreProperties.setPruningSafeBlocks(properties.getUtxo().getPruningSafeBlocks());
+        utxoStoreProperties.setContentAwareRollback(properties.getUtxo().isContentAwareRollback());
 
         return utxoStoreProperties;
     }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreProperties.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/UtxoStoreProperties.java
@@ -30,4 +30,7 @@ public class UtxoStoreProperties {
 
     @Builder.Default
     private int pruningSafeBlocks = 2160;
+
+    @Builder.Default
+    private boolean contentAwareRollback = false;
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/domain/UtxoRollbackEvent.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/domain/UtxoRollbackEvent.java
@@ -1,0 +1,25 @@
+package com.bloxbean.cardano.yaci.store.utxo.domain;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.TxInput;
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UtxoRollbackEvent {
+    private RollbackEvent rollbackEvent;
+
+    private List<AddressUtxo> addressUtxos;
+    private List<TxInput> txInputs;
+}

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoRollbackProcessor.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoRollbackProcessor.java
@@ -2,9 +2,12 @@ package com.bloxbean.cardano.yaci.store.utxo.processor;
 
 import com.bloxbean.cardano.yaci.store.common.aspect.EnableIf;
 import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.bloxbean.cardano.yaci.store.utxo.UtxoStoreProperties;
+import com.bloxbean.cardano.yaci.store.utxo.domain.UtxoRollbackEvent;
 import com.bloxbean.cardano.yaci.store.utxo.storage.UtxoStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +20,26 @@ import static com.bloxbean.cardano.yaci.store.utxo.UtxoStoreConfiguration.STORE_
 @Slf4j
 public class UtxoRollbackProcessor {
     private final UtxoStorage utxoStorage;
+    private final UtxoStoreProperties utxoStoreProperties;
+    private final ApplicationEventPublisher publisher;
 
     @EventListener
     @Transactional
     public void handleRollbackEvent(RollbackEvent rollbackEvent) {
         long rollBackToSlot = rollbackEvent.getRollbackTo().getSlot();
+
+        if (utxoStoreProperties.isContentAwareRollback()) {
+            log.info("Rollback -- content aware rollback is enabled. Publishing UtxoRollbackEvent");
+            //Find all addressUtxo records which are greater than rollBackToSlot
+            //Find all txInputs which are greater than rollBackToSlot
+            var addressUtxos = utxoStorage.getUnspentBySlotGreaterThan(rollBackToSlot);
+            var txInputs = utxoStorage.getSpentBySlotGreaterThan(rollBackToSlot);
+
+            log.info("Rollback -- {} address_utxos records", addressUtxos);
+            log.info("Rollback -- {} spent output records", txInputs);
+            var utxoRollbackEvent = new UtxoRollbackEvent(rollbackEvent, addressUtxos, txInputs);
+            publisher.publishEvent(utxoRollbackEvent);
+        }
 
         int deletedUnspent = utxoStorage.deleteUnspentBySlotGreaterThan(rollBackToSlot);
         int deletedSpent = utxoStorage.deleteSpentBySlotGreaterThan(rollBackToSlot);

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorage.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/UtxoStorage.java
@@ -19,4 +19,7 @@ public interface UtxoStorage {
     int deleteBySpentAndBlockLessThan(Long block);
 
     void handleCommit(CommitEvent commitEvent);
+
+    List<AddressUtxo> getUnspentBySlotGreaterThan(Long slot);
+    List<TxInput> getSpentBySlotGreaterThan(Long slot);
 }

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageImpl.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageImpl.java
@@ -236,6 +236,28 @@ public class UtxoStorageImpl implements UtxoStorage {
         utxoCache.clear();
     }
 
+    @Override
+    public List<AddressUtxo> getUnspentBySlotGreaterThan(Long slot) {
+        var query = dsl
+                .select()
+                .from(ADDRESS_UTXO)
+                .where(ADDRESS_UTXO.SLOT.gt(slot))
+                .orderBy(ADDRESS_UTXO.SLOT.asc());
+
+        return query.fetch().into(AddressUtxo.class);
+    }
+
+    @Override
+    public List<TxInput> getSpentBySlotGreaterThan(Long slot) {
+        var query = dsl
+                .select()
+                .from(TX_INPUT)
+                .where(TX_INPUT.SPENT_AT_SLOT.gt(slot))
+                .orderBy(TX_INPUT.SPENT_AT_SLOT.asc());
+
+        return query.fetch().into(TxInput.class);
+    }
+
 /**   Remove this method after testing
     @EventListener
     @Transactional


### PR DESCRIPTION
This PR introduces the following new features:

1. **Content-Aware Rollback Events**
2. **Pre-Rollback Event**
3. **Current Balance Tables for `address_balance` and `stake_address_balance`**

---

### 1. Content-Aware Rollback Events

Currently, our rollback strategy is based solely on the `slot` value. This works well for most tables, which are append-only and include a `slot` column.
However, this approach can cause issues for applications that maintain derived values using in-place updates.

To address this, we are introducing a new optional event type that informs applications of the specific data (e.g., addresses, UTxOs) that will be rolled back—*before* the rollback is applied.
This enables applications to adjust derived values or perform cleanup based on rollback impact.

#### In this PR, we introduce two content-aware rollback events:

* `UtxoRollbackEvent` in the UTXO store
* `BalanceRollbackEvent` in the Account store

`UtxoRollbackEvent` provides information about which `address_utxo` or `tx_input` entries will be deleted. Applications can use this to update application-specific values.

`BalanceRollbackEvent` is used in the Account store to handle rollback for the newly introduced "current" tables. These tables—`address_balance_current` and `stake_address_balance_current`—store the latest balances. See section 3 for details.

---

### 2. `PreRollbackEvent`

This is a new event that is published **just before** every `RollbackEvent`.
It provides applications an opportunity to inspect the current data before the actual rollback is applied to the core tables.
This allows applications to capture state, make adjustments, or log relevant data as needed.

---

### 3. New "Current" Balance Tables

Two new tables are introduced:

* `address_balance_current`
* `stake_address_balance_current`

These tables maintain the latest balance information for addresses and stake addresses. They are updated in sync with the main `address_balance` and `stake_address_balance` tables.

During a rollback, the system uses `BalanceRollbackEvent` to determine the affected address/unit pairs and update the corresponding rows in these current tables.

These current tables are especially useful for analytics queries, such as retrieving the top 100 addresses by balance.

---

### New Configuration Flags

These features are **optional**. Only `PreRollbackEvent` is always published by default.
The **Content-Aware Rollback Events** and **Current Balance Tables** are disabled by default and can be enabled using the following configuration flags:

#### For Account Store:

```properties
store.account.content-aware-rollback=true
store.account.current-balance-enabled=true
```

#### For UTXO Store:

```properties
store.utxo.content-aware-rollback=true
```
