### PR TITLE
feat: Continue Sync on Parse Error

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -108,4 +108,7 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
     private int n2cPoolMaxIdle = 5;
     @Builder.Default
     private int n2cPoolMaxWaitInMillis = 10000;
+
+    @Builder.Default
+    private boolean continueOnParseError = false;
 }

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ErrorCode.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ErrorCode.java
@@ -1,0 +1,5 @@
+package com.bloxbean.cardano.yaci.store.common.util;
+
+public enum ErrorCode {
+    BLOCK_PARSE_ERROR
+}

--- a/components/core/build.gradle
+++ b/components/core/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation libs.apache.commons.pool
 
     testImplementation libs.assertj.core
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 }
 
 publishing {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreConfiguration.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/StoreConfiguration.java
@@ -3,8 +3,10 @@ package com.bloxbean.cardano.yaci.store.core;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.core.service.CursorCleanupScheduler;
+import com.bloxbean.cardano.yaci.store.core.storage.ErrorStorageImpl;
 import com.bloxbean.cardano.yaci.store.core.storage.api.CursorStorage;
 import com.bloxbean.cardano.yaci.store.core.storage.api.EraStorage;
+import com.bloxbean.cardano.yaci.store.core.storage.api.ErrorStorage;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -52,5 +54,10 @@ public class StoreConfiguration {
         log.info("CursorCleanupScheduler will run every {} sec", storeProperties.getCursorCleanupInterval());
         log.info("CursorCleanupScheduler will keep {} blocks in cursor", storeProperties.getCursorNoOfBlocksToKeep());
         return new CursorCleanupScheduler(cursorStorage, storeProperties);
+    }
+
+    @Bean
+    public ErrorStorage errorStorage(ErrorRepository errorRepository) {
+        return new ErrorStorageImpl(errorRepository);
     }
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/ErrorEventProcessor.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/ErrorEventProcessor.java
@@ -1,0 +1,26 @@
+package com.bloxbean.cardano.yaci.store.core.processor;
+
+import com.bloxbean.cardano.yaci.store.core.storage.api.ErrorStorage;
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ErrorEventProcessor {
+    private final ErrorStorage errorStorage;
+
+    @EventListener
+    @Transactional
+    public void handleErrorEvent(ErrorEvent errorEvent) {
+        try {
+            errorStorage.save(errorEvent);
+        } catch (Exception e) {
+            log.error("Error while processing ErrorEvent: {}", errorEvent, e);
+        }
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -1,11 +1,13 @@
 package com.bloxbean.cardano.yaci.store.core.service;
 
+import com.bloxbean.cardano.yaci.core.exception.BlockParseRuntimeException;
 import com.bloxbean.cardano.yaci.core.model.Block;
 import com.bloxbean.cardano.yaci.core.model.BlockHeader;
 import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.helper.BlockRangeSync;
 import com.bloxbean.cardano.yaci.helper.BlockSync;
 import com.bloxbean.cardano.yaci.helper.listener.BlockChainDataListener;
@@ -13,6 +15,7 @@ import com.bloxbean.cardano.yaci.helper.model.Transaction;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.Cursor;
 import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.common.util.ErrorCode;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
 import com.bloxbean.cardano.yaci.store.core.service.publisher.ByronBlockEventPublisher;
@@ -333,10 +336,29 @@ public class BlockFetchService implements BlockChainDataListener {
     }
 
     @Override
-    public void onParsingError(Exception e) {
+    public void onParsingError(BlockParseRuntimeException e) {
         log.error("Block parsing error", e);
-        stopSyncOnError();
-        throw new RuntimeException(e);
+        if (storeProperties.isContinueOnParseError()) {
+            log.info("Continue on parse error is enabled. Continuing sync ...");
+            String cbor = null;
+            if (e.getBlockCbor() != null) {
+                try {
+                    cbor = HexUtil.encodeHexString(e.getBlockCbor());
+                } catch (Exception ex) {
+                    log.error("Error encoding block cbor to hex string", ex);
+                }
+            }
+            ErrorEvent errorEvent = ErrorEvent.builder()
+                    .block(e.getBlockNumber())
+                    .errorCode(ErrorCode.BLOCK_PARSE_ERROR.name())
+                    .reason(e.getMessage())
+                    .details(cbor)
+                    .build();
+            publisher.publishEvent(errorEvent);
+        } else {
+            stopSyncOnError();
+            throw new RuntimeException(e);
+        }
     }
 
     public synchronized void startFetch(Point from, Point to) {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorStorageImpl.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorStorageImpl.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.store.core.storage;
+
+import com.bloxbean.cardano.yaci.store.core.storage.api.ErrorStorage;
+import com.bloxbean.cardano.yaci.store.core.storage.impl.ErrorRepository;
+import com.bloxbean.cardano.yaci.store.core.storage.impl.model.ErrorEntity;
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ErrorStorageImpl implements ErrorStorage {
+    private final ErrorRepository errorRepository;
+
+    @Override
+    public void save(ErrorEvent error) {
+        if (error == null) return;
+
+        ErrorEntity errorEntity = ErrorEntity.builder()
+                .block(error.getBlock())
+                .errorCode(error.getErrorCode())
+                .reason(error.getReason())
+                .details(error.getDetails())
+                .build();
+
+        errorRepository.save(errorEntity);
+    }
+
+    @Override
+    public ErrorEvent findById(Integer id) {
+        return errorRepository.findById(id)
+                .map(errorEntity -> ErrorEvent.builder()
+                        .id(errorEntity.getId())
+                        .block(errorEntity.getBlock())
+                        .errorCode(errorEntity.getErrorCode())
+                        .reason(errorEntity.getReason())
+                        .details(errorEntity.getDetails())
+                        .build())
+                .orElse(null);
+    }
+
+    @Override
+    public List<ErrorEvent> findAll() {
+        return errorRepository.findAllOrderById()
+                .stream()
+                .map(errorEntity -> ErrorEvent.builder()
+                        .id(errorEntity.getId())
+                        .block(errorEntity.getBlock())
+                        .errorCode(errorEntity.getErrorCode())
+                        .reason(errorEntity.getReason())
+                        .details(errorEntity.getDetails())
+                        .build())
+                .toList();
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/api/ErrorStorage.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/api/ErrorStorage.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.core.storage.api;
+
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+
+import java.util.List;
+
+public interface ErrorStorage {
+    void save(ErrorEvent error);
+
+    ErrorEvent findById(Integer id);
+    List<ErrorEvent> findAll();
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/ErrorRepository.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/ErrorRepository.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yaci.store.core.storage.impl;
+
+import com.bloxbean.cardano.yaci.store.core.storage.impl.model.ErrorEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ErrorRepository extends JpaRepository<ErrorEntity, Integer> {
+
+    @Query("select e from ErrorEntity e order by e.id desc")
+    List<ErrorEntity> findAllOrderById();
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/ErrorEntity.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/model/ErrorEntity.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.yaci.store.core.storage.impl.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "error")
+public class ErrorEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "block")
+    private Long block;
+
+    @Column(name = "error_code")
+    private String errorCode;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "details")
+    private String details;
+
+    @UpdateTimestamp
+    @Column(name = "update_datetime")
+    private LocalDateTime updateDateTime;
+
+}

--- a/components/core/src/main/resources/db/store/h2/V0_000_2__error_table.sql
+++ b/components/core/src/main/resources/db/store/h2/V0_000_2__error_table.sql
@@ -1,0 +1,11 @@
+drop table if exists error;
+create table error
+(
+    id                  int not null auto_increment,
+    block               bigint,
+    error_code          varchar(64) not null,
+    reason              text not null,
+    details             text,
+    update_datetime     timestamp,
+    primary key (id)
+);

--- a/components/core/src/main/resources/db/store/mysql/V0_000_2__error_table.sql
+++ b/components/core/src/main/resources/db/store/mysql/V0_000_2__error_table.sql
@@ -1,0 +1,11 @@
+drop table if exists error;
+create table error
+(
+    id                  int not null auto_increment,
+    block               bigint,
+    error_code          varchar(64) not null,
+    reason              text not null,
+    details             mediumtext,
+    update_datetime     timestamp,
+    primary key (id)
+);

--- a/components/core/src/main/resources/db/store/postgresql/V0_000_2__error_table.sql
+++ b/components/core/src/main/resources/db/store/postgresql/V0_000_2__error_table.sql
@@ -1,0 +1,11 @@
+drop table if exists error;
+create table error
+(
+    id                  serial,
+    block               bigint,
+    error_code          varchar(64) not null,
+    reason              text not null,
+    details             text,
+    update_datetime     timestamp,
+    primary key (id)
+);

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/YaciIndexerApplicationTests.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/YaciIndexerApplicationTests.java
@@ -1,12 +1,9 @@
 package com.bloxbean.cardano.yaci.store;
 
-import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-//@SpringBootTest
-class YaciIndexerApplicationTests {
+@SpringBootApplication
+public class YaciIndexerApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
 
 }

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorRepositoryTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.bloxbean.cardano.yaci.store.core.storage;
+
+import com.bloxbean.cardano.yaci.store.core.storage.impl.ErrorRepository;
+import com.bloxbean.cardano.yaci.store.core.storage.impl.model.ErrorEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+public class ErrorRepositoryTest {
+    @Autowired
+    private ErrorRepository errorRepository;
+
+    @Test
+    void save_shouldPersistErrorEntity() {
+        ErrorEntity errorEntity = new ErrorEntity();
+        errorEntity.setBlock(12345L);
+        errorEntity.setErrorCode("errorCode123");
+        errorEntity.setReason("Test reason");
+        errorEntity.setDetails("Test details");
+
+        ErrorEntity savedErrorEntity = errorRepository.save(errorEntity);
+
+        assertNotNull(savedErrorEntity.getId());
+        assertEquals(12345, savedErrorEntity.getBlock());
+        assertEquals("errorCode123", savedErrorEntity.getErrorCode());
+        assertEquals("Test reason", savedErrorEntity.getReason());
+        assertEquals("Test details", savedErrorEntity.getDetails());
+    }
+
+    @Test
+    void findAllOrderById_shouldReturnErrorsInDescendingOrder() {
+        ErrorEntity errorEntity1 = new ErrorEntity(null, 12345L, "errorCode1", "reason1", "details1", LocalDateTime.now());
+        ErrorEntity errorEntity2 = new ErrorEntity(null, 23456L, "errorCode2", "reason2", "details2", LocalDateTime.now());
+        errorRepository.save(errorEntity1);
+        errorRepository.save(errorEntity2);
+
+        List<ErrorEntity> errors = errorRepository.findAllOrderById();
+
+        assertEquals(2, errors.size());
+
+        assertNotNull(errors.get(1).getId());
+        assertEquals("errorCode2", errors.get(0).getErrorCode());
+        assertEquals("reason2", errors.get(0).getReason());
+        assertEquals("details2", errors.get(0).getDetails());
+
+        assertNotNull(errors.get(1).getId());
+        assertEquals("errorCode1", errors.get(1).getErrorCode());
+        assertEquals("reason1", errors.get(1).getReason());
+        assertEquals("details1", errors.get(1).getDetails());
+    }
+
+    @Test
+    void findById_shouldReturnErrorEntityById() {
+        ErrorEntity errorEntity = new ErrorEntity(null, 23456L, "errorCode2", "reason2", "details2", LocalDateTime.now());
+        ErrorEntity savedErrorEntity = errorRepository.save(errorEntity);
+
+        Optional<ErrorEntity> foundErrorEntity = errorRepository.findById(savedErrorEntity.getId());
+
+        assertTrue(foundErrorEntity.isPresent());
+        assertEquals("errorCode2", foundErrorEntity.get().getErrorCode());
+    }
+}

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorStorageImplTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/storage/ErrorStorageImplTest.java
@@ -1,0 +1,99 @@
+package com.bloxbean.cardano.yaci.store.core.storage;
+
+import com.bloxbean.cardano.yaci.store.core.storage.impl.ErrorRepository;
+import com.bloxbean.cardano.yaci.store.core.storage.impl.model.ErrorEntity;
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DataJpaTest
+class ErrorStorageImplTest {
+    private ErrorRepository errorRepository;
+    private ErrorStorageImpl errorStorage;
+
+    @BeforeEach
+    void setUp() {
+        errorRepository = mock(ErrorRepository.class);
+        errorStorage = new ErrorStorageImpl(errorRepository);
+    }
+
+    @Test
+    void save() {
+        ErrorEvent errorEvent = ErrorEvent.builder()
+                .block(123L)
+                .errorCode("404")
+                .reason("Not Found")
+                .details("Details about the error")
+                .build();
+
+        errorStorage.save(errorEvent);
+
+        verify(errorRepository, times(1)).save(argThat(errorEntity ->
+                errorEntity.getBlock().equals(123L)
+                        && errorEntity.getErrorCode().equals("404")
+                        && errorEntity.getReason().equals("Not Found")
+                        && errorEntity.getDetails().equals("Details about the error")
+        ));
+    }
+
+    @Test
+    void findById() {
+        ErrorEntity errorEntity = ErrorEntity.builder()
+                .id(1)
+                .block(123L)
+                .errorCode("404")
+                .reason("Not Found")
+                .details("Details about the error")
+                .build();
+
+        when(errorRepository.findById(1)).thenReturn(java.util.Optional.of(errorEntity));
+
+        ErrorEvent result = errorStorage.findById(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.getId());
+        assertEquals(123L, result.getBlock());
+        assertEquals("404", result.getErrorCode());
+        assertEquals("Not Found", result.getReason());
+        assertEquals("Details about the error", result.getDetails());
+    }
+
+    @Test
+    void findAll() {
+        ErrorEntity errorEntity1 = ErrorEntity.builder()
+                .id(1)
+                .block(123L)
+                .errorCode("404")
+                .reason("Not Found")
+                .details("Details 1")
+                .build();
+        ErrorEntity errorEntity2 = ErrorEntity.builder()
+                .id(2)
+                .block(456L)
+                .errorCode("500")
+                .reason("Internal Server Error")
+                .details("Details 2")
+                .build();
+
+        when(errorRepository.findAllOrderById()).thenReturn(List.of(errorEntity1, errorEntity2));
+
+        List<ErrorEvent> result = errorStorage.findAll();
+
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getId());
+        assertEquals(123L, result.get(0).getBlock());
+        assertEquals("404", result.get(0).getErrorCode());
+        assertEquals("Details 1", result.get(0).getDetails());
+
+        assertEquals(2, result.get(1).getId());
+        assertEquals(456L, result.get(1).getBlock());
+        assertEquals("500", result.get(1).getErrorCode());
+        assertEquals("Details 2", result.get(1).getDetails());
+    }
+}

--- a/components/core/src/test/resources/application.yml
+++ b/components/core/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:mydb
+    username: sa
+    password: password
+  flyway:
+    locations: classpath:db/store/{vendor}
+    out-of-order: true
+
+apiPrefix: /api/v1
+
+#LOGGING CONFIGURATION
+logging:
+  level:
+    org:
+      hibernate:
+        sql: info
+
+store:
+  cardano:
+    protocol-magic: 764824073
+
+

--- a/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/ErrorEvent.java
+++ b/components/events/src/main/java/com/bloxbean/cardano/yaci/store/events/ErrorEvent.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.store.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorEvent {
+    private Integer id; // Null if not persisted
+    private Long block;
+    private String errorCode;
+    private String reason;
+    private String details;
+}

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -252,6 +252,8 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setN2cPoolMaxIdle(properties.getCardano().getN2cPoolMaxIdle());
         storeProperties.setN2cPoolMaxWaitInMillis(properties.getCardano().getN2cPoolMaxWaitInMillis());
 
+        storeProperties.setContinueOnParseError(properties.isContinueOnParseError());
+
         return storeProperties;
     }
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -18,6 +18,7 @@ public class YaciStoreProperties {
     private String utxoClientUrl;
     private boolean mvstoreEnabled = false;
     private String mvstorePath = "./.mvstore";
+    private boolean continueOnParseError = false;
 
     @Getter
     @Setter


### PR DESCRIPTION
### New Feature: Continue Sync on Parse Error

* Introduced a new optional flag: `store.continue-on-parse-error` (default: `false`).

  When set to `true`, the sync process will continue even if a parsing error occurs. By default, this flag is `false` to preserve current behavior. This option is intended for critical applications where uninterrupted syncing is preferred, even in the presence of rare parsing errors.

* If this flag is enabled and a parsing error occurs:

  * The error details will be saved in the `ERROR` table.
  * Sync will continue after logging the error, allowing users to investigate later while maintaining sync continuity.
