### PR TITLE
Optimize VariableProvider implementations by caching variable maps

### DIFF
--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/variables/DefaultVariableProvider.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/variables/DefaultVariableProvider.java
@@ -3,20 +3,23 @@ package com.bloxbean.cardano.yaci.store.plugin.variables;
 import com.bloxbean.cardano.yaci.store.plugin.api.VariableProvider;
 import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateService;
 import com.bloxbean.cardano.yaci.store.plugin.util.PluginContextUtil;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 @Component
-@RequiredArgsConstructor
 public class DefaultVariableProvider implements VariableProvider {
+
     private final PluginContextUtil pluginContextUtil;
     private final PluginStateService stateService;
 
-    @Override
-    public Map<String, Object> getVariables() {
-        return Map.of(
+    private final Map<String, Object> cachedVariables;
+
+    public DefaultVariableProvider(PluginContextUtil pluginContextUtil, PluginStateService stateService) {
+        this.pluginContextUtil = pluginContextUtil;
+        this.stateService = stateService;
+
+        this.cachedVariables = Map.of(
                 "jdbc", pluginContextUtil.getJdbc(),
                 "named_jdbc", pluginContextUtil.getNamedJdbc(),
                 "rest", pluginContextUtil.getRest(),
@@ -26,4 +29,10 @@ public class DefaultVariableProvider implements VariableProvider {
                 "global_state", stateService
         );
     }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        return cachedVariables;
+    }
 }
+

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/variables/NamedBeansVariableProvider.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/variables/NamedBeansVariableProvider.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,101 +18,55 @@ import java.util.Map;
 public class NamedBeansVariableProvider implements VariableProvider {
 
     private final ApplicationContext applicationContext;
+    private volatile Map<String, Object> cachedVariables;
 
     @Override
     public Map<String, Object> getVariables() {
+        if (cachedVariables == null) {
+            synchronized (this) {
+                if (cachedVariables == null) {
+                    cachedVariables = initVariables();
+                }
+            }
+        }
+        return cachedVariables;
+    }
+
+    private Map<String, Object> initVariables() {
         Map<String, Object> variables = new HashMap<>();
 
-        try {
-            variables.put("asset_reader", applicationContext.getBean("assetStorageReader"));
-        } catch (Exception ignored) {}
+        addBean(variables, "asset_reader", "assetStorageReader");
+        addBean(variables, "block_reader", "blockStorageReader");
+        addBean(variables, "epoch_param_reader", "epochParamStorage");
+        addBean(variables, "voting_procedure_reader", "votingProcedureStorageReader");
+        addBean(variables, "delegation_vote_reader", "delegationVoteStorageReader");
+        addBean(variables, "committee_reader", "committeeStorageReader");
+        addBean(variables, "gov_action_reader", "govActionProposalStorageReader");
+        addBean(variables, "constitution_reader", "constitutionStorageReader");
+        addBean(variables, "metadata_reader", "txMetadataStorageReader");
+        addBean(variables, "mir_reader", "mirStorageReader");
+        addBean(variables, "datum_reader", "datumStorageReader");
+        addBean(variables, "script_reader", "scriptStorageReader");
+        addBean(variables, "tx_script_reader", "txScriptStorageReader");
+        addBean(variables, "pool_cert_reader", "poolCertificateStorageReader");
+        addBean(variables, "pool_reader", "poolStorageReader");
+        addBean(variables, "staking_cert_reader", "stakingStorageReader");
+        addBean(variables, "txn_reader", "transactionStorageReader");
+        addBean(variables, "txn_witness_reader", "transactionWitnessStorageReader");
+        addBean(variables, "withdrawal_reader", "withdrawalStorageReader");
+        addBean(variables, "utxo_reader", "utxoStorageReader");
+        addBean(variables, "drep_reader", "dRepStorageReader");
+        addBean(variables, "proposal_status_reader", "govActionProposalStatusStorageReader");
 
-        try {
-            variables.put("block_reader", applicationContext.getBean("blockStorageReader"));
-        } catch (Exception ignored) {}
+        return Collections.unmodifiableMap(variables);
+    }
 
+    private void addBean(Map<String, Object> variables, String key, String beanName) {
         try {
-            variables.put("epoch_param_reader", applicationContext.getBean("epochParamStorage"));
-        } catch (Exception ignored) {}
-
-        //governance
-        try {
-            variables.put("voting_procedure_reader", applicationContext.getBean("votingProcedureStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("delegation_vote_reader", applicationContext.getBean("delegationVoteStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("committee_reader", applicationContext.getBean("committeeStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("gov_action_reader", applicationContext.getBean("govActionProposalStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("constitution_reader", applicationContext.getBean("constitutionStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("metadata_reader", applicationContext.getBean("txMetadataStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("mir_reader", applicationContext.getBean("mirStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("datum_reader", applicationContext.getBean("datumStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("script_reader", applicationContext.getBean("scriptStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("tx_script_reader", applicationContext.getBean("txScriptStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("pool_cert_reader", applicationContext.getBean("poolCertificateStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("pool_reader", applicationContext.getBean("poolStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("staking_cert_reader", applicationContext.getBean("stakingCertificateStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("txn_reader", applicationContext.getBean("transactionStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("txn_witness_reader", applicationContext.getBean("transactionWitnessStorageReader"));
-        } catch (NoSuchBeanDefinitionException ignored) {}
-
-        try {
-            variables.put("withdrawal_reader", applicationContext.getBean("withdrawalStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("utxo_reader", applicationContext.getBean("utxoStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("drep_reader", applicationContext.getBean("dRepStorageReader"));
-        } catch (Exception ignored) {}
-
-        try {
-            variables.put("proposal_status_reader", applicationContext.getBean("govActionProposalStatusStorageReader"));
-        } catch (Exception ignored) {}
-
-        return variables;
+            variables.put(key, applicationContext.getBean(beanName));
+        } catch (NoSuchBeanDefinitionException ignored) {
+            // Bean not available — skip
+        }
     }
 }
 


### PR DESCRIPTION
- Modified DefaultVariableProvider to cache the variable map in the constructor to avoid repeated object creation during sync.
- Updated NamedBeansVariableProvider to use lazy initialization.