### PR TITLE
chore(ledger-state-mismatches): update menu structure and simplify content

### DIFF
--- a/docs/pages/ledger-state-mismatches/2-0-0-beta1/_meta.json
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta1/_meta.json
@@ -1,3 +1,3 @@
 {
-  "2-0-0-beta1": "Beta1 Summary"
+  "2-0-0-beta1": "Overview"
 } 

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/2-0-0-beta3.mdx
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/2-0-0-beta3.mdx
@@ -54,11 +54,9 @@ We have conducted an extensive analysis of DRep stake distribution across epochs
 **📋 Raw Data Source:**
 - [📄 **Raw Mismatch Data**](https://gist.github.com/satran004/06eac89cffebe9aca856aeda810c0a2c) - Complete raw data file used for the analysis (10,036 lines)
 
-**📋 Detailed Analysis:**
-- [🔴 **Summary**](./mainnet/drep-distribution/summary) - Overview with key statistics and Top 10 critical DReps
-- [📊 **Full Analysis**](./mainnet/drep-distribution/drep-distribution-analysis) - Complete technical analysis with formulas and examples  
-- [📝 **Complete DRep List**](./mainnet/drep-distribution/drep-details) - All 143 DReps with detailed breakdown
+**📋 Detail:**
+- [📝 **Complete DRep List**](./mainnet/drep-distribution-detail) - All 143 DReps with detailed breakdown
 
 ### DRep active_until mismatches
 
-For detail, check the [DRep active_until mismatches](./mainnet/drep-active-until/detail.mdx) page.
+For detail, check the [DRep active_until mismatches](./mainnet/drep-active-until-detail) page.

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/_meta.json
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/_meta.json
@@ -1,4 +1,4 @@
 {
-  "2-0-0-beta3": "Beta3 Summary",
+  "2-0-0-beta3": "Overview",
   "mainnet": "Mainnet"
-} 
+}

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_hidden/drep-distribution-analysis.mdx
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_hidden/drep-distribution-analysis.mdx
@@ -108,7 +108,5 @@ Indexer Amount:  32,074,564,381,465 lovelace (~32,074,564 ADA)
 
 Deviation = |32,073,571,553,788 - 32,074,564,381,465| / 32,074,564,381,465 × 100 = 0.003%
 
-[View Complete 143 DRep Details →](./drep-details)
-
 ---
 

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_hidden/drep-distribution-summary.mdx
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_hidden/drep-distribution-summary.mdx
@@ -34,5 +34,3 @@
 | 8 | drep1y2dptycrks2ggae95leeh66m0l0svet98c44hl4rmaec7as6hgpp3 | 9a159303b414847725a7f39beb5b7fdf0665653e2b5bfea3df738f76 | **39.23%** | 48 | 8.50% |
 | 9 | drep1yfcdzuag647evc9tmr5rawpl4t3x4qxlagyy5taj6al7wwqr8qye5 | 70d173a8d57d9660abd8e83eb83faae26a80dfea084a2fb2d77fe738 | **22.25%** | 14 | 22.17% |
 | 10 | drep1yg8vjs7ute7z7vyd8yez5tgjey6043djjfh8d3n7sjev35g064xxc | 0ec943dc5e7c2f308d39322a2d12c934fac5b2926e76c67e84b2c8d1 | **10.41%** | 48 | 4.45% |
-
-[View Original Analysis →](./drep-distribution-analysis) | [Detailed DRep Breakdown →](./drep-details)

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_meta.json
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/_meta.json
@@ -1,4 +1,0 @@
-{
-  "drep-distribution": "DRep Distribution",
-  "drep-active-until": "DRep Active Until"
-}

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-active-until-detail.mdx
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-active-until-detail.mdx
@@ -73,3 +73,8 @@ The following table lists DRep Hashes with mismatches in `active_until` values b
 | **537** | 21 | All have +1 difference (DB Sync: 555/556, Yaci Store: 556/555) |
 | **565** | 12 | All have +1 difference (DB Sync: 583, Yaci Store: 584) |
 | **566** | 17 | Mixed differences (+1 and +2) |
+
+---
+
+
+*Data source: Yaci Store and Cardano DB Sync from epochs 506-569*

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-distribution-detail.mdx
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-distribution-detail.mdx
@@ -1,7 +1,5 @@
 # Complete DRep Details - All 143 DReps
 
-> **💡 Note**: All stake amounts in this analysis are measured in **lovelace** (1 ADA = 1,000,000 lovelace).
-
 
 ## Summary Statistics
 
@@ -11,7 +9,6 @@
 | **Total Mismatch Entries** | **4,800** | Individual discrepancies |
 | **Analysis Period** | **64 epochs** | Epochs 506-569 |
 | **Worst Case** | **99.61% deviation** | Near-total stake loss |
-| **Most Persistent** | **62/64 epochs** | Almost always affected |
 
 
 ### Severity Distribution
@@ -26,8 +23,9 @@
 
 ## Complete DRep Table (143 entries)
 
-*Note: Epochs shown as ranges (e.g., 513→518 = epochs 513,514,515,516,517,518)*
-
+> *Note:*
+> - Epochs shown as ranges (e.g., 513→518 = epochs 513,514,515,516,517,518)
+> - Deviation % = |DB_Sync_Amount - Indexer_Amount| / max(DB_Sync_Amount, Indexer_Amount) × 100
 
 | # | DRep ID | Hash | Max Dev% | Avg Dev% | Epochs Affected | Epoch Ranges |
 |---|---------|------|----------|----------|-----------------|--------------|
@@ -175,32 +173,7 @@
 | 142 | drep1yfeqm8wfd2h9pf2c9y934qskuw3z04selrpr7esf4gdsl2c5zvpgf | 720d9dc96aae50a558290b1a8216e3a227d619f8c23f6609aa1b0fab | 🟢 **0.000%** | 0.000% | 7 | 563→569 |
 | 143 | drep1yfr747pqr904utcw24puj9a9lx6t0x4xpjy38nvsux3rukskd7dj3 | 47eaf820195f5e2f0e5543c917a5f9b4b79aa60c8913cd90e1a23e5a | 🟢 **0.000%** | 0.000% | 6 | 564→569 |
 
-
-## Key Observations
-
-
-### Most Critical Cases
-
-1. **99.61% deviation**: Nearly complete stake loss detected
-
-2. **90%+ deviations**: 4 DReps with severe calculation errors
-
-3. **Persistent issues**: Some DReps affected across 60+ epochs
-
-
-### Pattern Analysis
-
-- **High severity** issues tend to be concentrated in epochs 508-521
-
-- **Most persistent** DRep has issues in 62/64 epochs
-
-- **Low severity** issues (130 DReps) suggest minor calculation differences
-
-
 ---
 
 
 *Data source: Yaci Store and Cardano DB Sync from epochs 506-569*
-
-
-[Back to Summary](./summary) | [Original Analysis](./drep-distribution-analysis)

--- a/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-distribution/_meta.json
+++ b/docs/pages/ledger-state-mismatches/2-0-0-beta3/mainnet/drep-distribution/_meta.json
@@ -1,5 +1,0 @@
-{
-  "summary": "Summary Overview",
-  "drep-distribution-analysis": "Detailed Analysis",
-  "drep-details": "Complete DRep List"
-} 

--- a/docs/pages/ledger-state-mismatches/_meta.json
+++ b/docs/pages/ledger-state-mismatches/_meta.json
@@ -1,4 +1,4 @@
 {
-  "2-0-0-beta1": "2.0.0-beta1 Issues",
-  "2-0-0-beta3": "2.0.0-beta3 Issues"
+  "2-0-0-beta1": "2.0.0-beta1",
+  "2-0-0-beta3": "2.0.0-beta3"
 } 


### PR DESCRIPTION
Simplified the Ledger State Mismatches section.
-  Removed the summary and detailed analysis from DRep Distribution.
-  Moved the sub-menu under "DRep Active Until" since it only has one page. Now there are just two direct pages under "Mainnet"