### PR TITLE
Fix: #263 Remove TipFinder bean. Create and destroy tip finder connection in find method

### DIFF
--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/EraService.java
@@ -138,7 +138,7 @@ public class EraService {
      */
     public synchronized Optional<Tuple<Tip, Integer>> getTipAndCurrentEpoch() {
         try {
-            var tip = tipFinderService.getTip().block(Duration.ofSeconds(5));
+            var tip = tipFinderService.getTip().block(Duration.ofSeconds(10));
 
             if (tip != null) {
                 int epoch = epochConfig.epochFromSlot(firstShelleySlot(), Era.Shelley, tip.getPoint().getSlot());

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/TipFinderService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/TipFinderService.java
@@ -1,22 +1,26 @@
 package com.bloxbean.cardano.yaci.store.core.service;
 
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
 import com.bloxbean.cardano.yaci.helper.TipFinder;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 @Component
+@RequiredArgsConstructor
 @ReadOnly(false)
 public class TipFinderService {
-    private TipFinder tipFinder;
-
-    public TipFinderService(TipFinder tipFinder) {
-        //tipFinder.start();
-        this.tipFinder = tipFinder;
-    }
+    private final StoreProperties properties;
 
     public Mono<Tip> getTip() {
-        return this.tipFinder.find();
+        TipFinder tipFinder = new TipFinder(properties.getCardanoHost(), properties.getCardanoPort(),
+            Point.ORIGIN, properties.getProtocolMagic());
+        tipFinder.start();
+
+        return tipFinder.find()
+                .doFinally(signalType -> tipFinder.shutdown());
     }
 }

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/TipFinderServiceTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/TipFinderServiceTest.java
@@ -1,0 +1,34 @@
+package com.bloxbean.cardano.yaci.store.core.service;
+
+import com.bloxbean.cardano.yaci.core.common.Constants;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TipFinderServiceTest {
+
+    @Test
+    @Disabled
+    void findTip() {
+        StoreProperties storeProperties = new StoreProperties();
+        storeProperties.setCardanoHost(Constants.PREPROD_PUBLIC_RELAY_ADDR);
+        storeProperties.setCardanoPort(Constants.PREPROD_PUBLIC_RELAY_PORT);
+        storeProperties.setProtocolMagic(Constants.PREPROD_PROTOCOL_MAGIC);
+
+        try {
+            TipFinderService tipFinderService = new TipFinderService(storeProperties);
+            var tip = tipFinderService.getTip().block(Duration.ofSeconds(5));
+            assertThat(tip).isNotNull();
+            System.out.println("Tip found: " + tip);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Failed to find tip: " + e.getMessage());
+        }
+    }
+
+}

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -56,15 +56,6 @@ public class YaciStoreAutoConfiguration {
 
     @Bean
     @ReadOnly(false)
-    public TipFinder tipFinder() {
-        TipFinder tipFinder = new TipFinder(properties.getCardano().getHost(), properties.getCardano().getPort(),
-                Point.ORIGIN, properties.getCardano().getProtocolMagic());
-        tipFinder.start();
-        return tipFinder;
-    }
-
-    @Bean
-    @ReadOnly(false)
     @Scope("prototype")
     public BlockRangeSync blockRangeSync() {
         log.info("Creating BlockRangeSync to fetch blocks");


### PR DESCRIPTION
#263

### Issue

To find the tip during startup, Yaci Store uses `TipFinderService`, which maintains a bean instance of `TipFinder`. This connection is kept alive solely for retrieving the tip, even though we only need it during startup or occasionally when reading local data directly from the node.

Since `TipFinder` does not have a KeepAlive agent configured, the connection gets reset over time, and `TipFinder` keeps trying to reconnect unnecessarily.

### Fix

Instead of keeping a persistent instance, we now create a new `TipFinder` instance for every `findTip` call and shut it down immediately after receiving the response. This avoids maintaining an unnecessary long-lived connection and simplifies resource usage.
