### PR TITLE
chore: add metrics tracking for connection status and resets

### DIFF
--- a/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/api/AdminController.java
+++ b/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/api/AdminController.java
@@ -2,7 +2,6 @@ package com.bloxbean.cardano.yaci.store.admin.api;
 
 import com.bloxbean.cardano.yaci.store.account.service.AddressBalanceSnapshotService;
 import com.bloxbean.cardano.yaci.store.account.service.BalanceSnapshotService;
-import com.bloxbean.cardano.yaci.store.core.metrics.MetricsService;
 import com.bloxbean.cardano.yaci.store.core.service.StartService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,16 +24,13 @@ public class AdminController {
     private final StartService startService;
     private final BalanceSnapshotService balanceSnapshotService;
     private final AddressBalanceSnapshotService addressBalanceSnapshotService;
-    private final MetricsService metricsService;
 
     public AdminController(@Autowired(required = true) StartService startService,
                            @Autowired(required = false) BalanceSnapshotService balanceSnapshotService,
-                           @Autowired(required = false) AddressBalanceSnapshotService addressBalanceSnapshotService,
-                           @Autowired(required = true) MetricsService metricsService) {
+                           @Autowired(required = false) AddressBalanceSnapshotService addressBalanceSnapshotService) {
         this.startService = startService;
         this.balanceSnapshotService = balanceSnapshotService;
         this.addressBalanceSnapshotService = addressBalanceSnapshotService;
-        this.metricsService = metricsService;
     }
 
     @PostMapping(value = "/admin/calculate-address-balance", consumes = {MediaType.APPLICATION_JSON_VALUE})
@@ -82,8 +78,6 @@ public class AdminController {
             startService.stop();
             TimeUnit.SECONDS.sleep(2);
             startService.start();
-
-            metricsService.incrementConnectionResets();
 
             return "Sync restarted";
         } else {

--- a/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/api/AdminController.java
+++ b/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/api/AdminController.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.admin.api;
 
 import com.bloxbean.cardano.yaci.store.account.service.AddressBalanceSnapshotService;
 import com.bloxbean.cardano.yaci.store.account.service.BalanceSnapshotService;
+import com.bloxbean.cardano.yaci.store.core.metrics.MetricsService;
 import com.bloxbean.cardano.yaci.store.core.service.StartService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,13 +25,16 @@ public class AdminController {
     private final StartService startService;
     private final BalanceSnapshotService balanceSnapshotService;
     private final AddressBalanceSnapshotService addressBalanceSnapshotService;
+    private final MetricsService metricsService;
 
     public AdminController(@Autowired(required = true) StartService startService,
                            @Autowired(required = false) BalanceSnapshotService balanceSnapshotService,
-                           @Autowired(required = false) AddressBalanceSnapshotService addressBalanceSnapshotService) {
+                           @Autowired(required = false) AddressBalanceSnapshotService addressBalanceSnapshotService,
+                           @Autowired(required = true) MetricsService metricsService) {
         this.startService = startService;
         this.balanceSnapshotService = balanceSnapshotService;
         this.addressBalanceSnapshotService = addressBalanceSnapshotService;
+        this.metricsService = metricsService;
     }
 
     @PostMapping(value = "/admin/calculate-address-balance", consumes = {MediaType.APPLICATION_JSON_VALUE})
@@ -78,6 +82,8 @@ public class AdminController {
             startService.stop();
             TimeUnit.SECONDS.sleep(2);
             startService.start();
+
+            metricsService.incrementConnectionResets();
 
             return "Sync restarted";
         } else {

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -54,6 +54,10 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
 
     private int keepAliveInterval = 10000;
 
+    //Block receive delay threshold in seconds
+    @Builder.Default
+    private int blockReceiveDelaySeconds = 120;
+
     //Only required if the genesis hash can't be fetched
     private String defaultGenesisHash = "Genesis";
 

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/HealthStatus.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/HealthStatus.java
@@ -21,4 +21,19 @@ public class HealthStatus {
     private int lastKeepAliveResponseCookie;
     private long lastKeepAliveResponseTime;
     private long lastReceivedBlockTime;
+
+    /**
+     * Time since last block was received in milliseconds
+     */
+    private long timeSinceLastBlock;
+
+    /**
+     * Indicates if blocks are being received within the configured threshold
+     */
+    private boolean isReceivingBlocks;
+
+    /**
+     * The configured block receive delay threshold in milliseconds
+     */
+    private long blockReceiveDelayThreshold;
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
@@ -2,7 +2,6 @@ package com.bloxbean.cardano.yaci.store.core.metrics;
 
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
@@ -20,7 +19,7 @@ public class MetricsService {
     public static final String YACI_STORE_PROTOCOL_MAGIC = "yaci.store.protocol_magic";
     public static final String YACI_STORE_CURRENT_SLOT = "yaci.store.current.slot";
     public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.node.connection.status";
-    public static final String YACI_STORE_CONNECTION_RESETS = "yaci.store.node.connection.resets";
+    public static final String YACI_STORE_LAST_RECEIVED_BLOCK_TIME = "yaci.store.last_received_block_time";
 
     private AtomicLong currentBlockNo = new AtomicLong(0);
     private AtomicLong currentEpochNo = new AtomicLong(0);
@@ -30,7 +29,7 @@ public class MetricsService {
     private AtomicLong protocolMagic = new AtomicLong(0);
     private AtomicLong currentSlot = new AtomicLong(0);
     private AtomicInteger connectionStatus = new AtomicInteger(0);
-    private Counter connectionResetCounter;
+    private AtomicLong lastReceivedBlockTime = new AtomicLong(0);
 
     public MetricsService(MeterRegistry meterRegistry, StoreProperties storeProperties) {
 
@@ -69,8 +68,8 @@ public class MetricsService {
                 .description("Connection status to the node. 1 for up, 0 for down")
                 .register(meterRegistry);
 
-        connectionResetCounter = Counter.builder(YACI_STORE_CONNECTION_RESETS)
-                .description("Number of connection resets to the node")
+        Gauge.builder(YACI_STORE_LAST_RECEIVED_BLOCK_TIME, lastReceivedBlockTime, AtomicLong::get)
+                .description("Timestamp of the last received block in milliseconds")
                 .register(meterRegistry);
     }
 
@@ -89,9 +88,7 @@ public class MetricsService {
         connectionStatus.set(isConnected ? 1 : 0);
     }
 
-    public void incrementConnectionResets() {
-        if (connectionResetCounter != null) {
-            connectionResetCounter.increment();
-        }
+    public void updateLastReceivedBlockTime(long timestamp) {
+        lastReceivedBlockTime.set(timestamp);
     }
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.core.metrics;
 
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,9 @@ public class MetricsService {
     public static final String YACI_STORE_CURRENT_ERA = "yaci.store.current.era";
     public static final String YACI_STORE_SYNC_MODE = "yaci.store.sync_mode";
     public static final String YACI_STORE_PROTOCOL_MAGIC = "yaci.store.protocol_magic";
+    public static final String YACI_STORE_CURRENT_SLOT = "yaci.store.current.slot";
+    public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.connection.status";
+    public static final String YACI_STORE_CONNECTION_RESETS = "yaci.store.connection.resets";
 
     private AtomicLong currentBlockNo = new AtomicLong(0);
     private AtomicLong currentEpochNo = new AtomicLong(0);
@@ -24,6 +28,9 @@ public class MetricsService {
     private AtomicLong currentBlockTime = new AtomicLong(0);
     private AtomicInteger isSyncMode = new AtomicInteger(0);
     private AtomicLong protocolMagic = new AtomicLong(0);
+    private AtomicLong currentSlot = new AtomicLong(0);
+    private AtomicInteger connectionStatus = new AtomicInteger(0);
+    private Counter connectionResetCounter;
 
     public MetricsService(MeterRegistry meterRegistry, StoreProperties storeProperties) {
 
@@ -53,6 +60,18 @@ public class MetricsService {
         Gauge.builder(YACI_STORE_PROTOCOL_MAGIC, protocolMagic, AtomicLong::get)
                 .description("Protocol magic of the current chain")
                 .register(meterRegistry);
+
+        Gauge.builder(YACI_STORE_CURRENT_SLOT, currentSlot, AtomicLong::get)
+                .description("Current slot being processed")
+                .register(meterRegistry);
+
+        Gauge.builder(YACI_STORE_CONNECTION_STATUS, connectionStatus, AtomicInteger::get)
+                .description("Connection status to the node. 1 for up, 0 for down")
+                .register(meterRegistry);
+
+        connectionResetCounter = Counter.builder(YACI_STORE_CONNECTION_RESETS)
+                .description("Number of connection resets to the node")
+                .register(meterRegistry);
     }
 
     public void updateMetrics(EventMetadata metadata) {
@@ -63,5 +82,16 @@ public class MetricsService {
         currentEraNo.set(metadata.getEra().getValue());
         isSyncMode.set(metadata.isSyncMode()? 1 : 0);
         protocolMagic.set(metadata.getProtocolMagic());
+        currentSlot.set(metadata.getSlot());
+    }
+
+    public void updateConnectionStatus(boolean isConnected) {
+        connectionStatus.set(isConnected ? 1 : 0);
+    }
+
+    public void incrementConnectionResets() {
+        if (connectionResetCounter != null) {
+            connectionResetCounter.increment();
+        }
     }
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
@@ -19,8 +19,8 @@ public class MetricsService {
     public static final String YACI_STORE_SYNC_MODE = "yaci.store.sync_mode";
     public static final String YACI_STORE_PROTOCOL_MAGIC = "yaci.store.protocol_magic";
     public static final String YACI_STORE_CURRENT_SLOT = "yaci.store.current.slot";
-    public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.connection.status";
-    public static final String YACI_STORE_CONNECTION_RESETS = "yaci.store.connection.resets";
+    public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.node.connection.status";
+    public static final String YACI_STORE_CONNECTION_RESETS = "yaci.store.node.connection.resets";
 
     private AtomicLong currentBlockNo = new AtomicLong(0);
     private AtomicLong currentEpochNo = new AtomicLong(0);

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -380,6 +380,8 @@ public class BlockFetchService implements BlockChainDataListener {
         syncMode = false;
         cursorService.setSyncMode(syncMode);
 
+        metricsService.updateConnectionStatus(true);
+
         startKeepAliveThread(syncMode);
     }
 
@@ -392,6 +394,8 @@ public class BlockFetchService implements BlockChainDataListener {
         syncMode = true;
         cursorService.setSyncMode(syncMode);
         startKeepAliveThread(syncMode);
+
+        metricsService.updateConnectionStatus(true);
     }
 
     public synchronized void shutdown() {
@@ -424,6 +428,11 @@ public class BlockFetchService implements BlockChainDataListener {
         }
 
         return blockRangeSync.getLastKeepAliveResponseTime();
+    }
+
+    @Override
+    public void onDisconnect() {
+        metricsService.updateConnectionStatus(false);
     }
 
     public boolean isScheduledToStop() {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.core.service;
 
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import lombok.RequiredArgsConstructor;
@@ -12,16 +13,36 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class HealthService {
     private final BlockFetchService blockFetchService;
+    private final StoreProperties storeProperties;
 
     public HealthStatus getHealthStatus() {
+        long currentTime = System.currentTimeMillis();
+        long lastReceivedBlockTime = blockFetchService.getLastReceivedBlockTime();
+        long blockReceiveDelayThreshold = getBlockReceiveDelayThreshold();
+        long timeSinceLastReceivedBlock = (lastReceivedBlockTime == 0) ? 0 : (currentTime - lastReceivedBlockTime);
+
+        // Consider blocks are being received if:
+        // - No blocks received yet (lastReceivedBlockTime == 0) OR
+        // - Time since last block is within threshold
+        boolean isReceivingBlocks = (lastReceivedBlockTime == 0) || (timeSinceLastReceivedBlock <= blockReceiveDelayThreshold);
+
+        boolean isConnectionAlive = blockFetchService.isRunning();
 
         return HealthStatus.builder()
-                .isConnectionAlive(blockFetchService.isRunning())
+                .isConnectionAlive(isConnectionAlive)
                 .isScheduleToStop(blockFetchService.isScheduledToStop())
                 .isError(blockFetchService.isError())
                 .lastKeepAliveResponseCookie(blockFetchService.getLastKeepAliveResponseCookie())
                 .lastKeepAliveResponseTime(blockFetchService.getLastKeepAliveResponseTime())
-                .lastReceivedBlockTime(blockFetchService.getLastReceivedBlockTime())
+                .lastReceivedBlockTime(lastReceivedBlockTime)
+                .timeSinceLastBlock(timeSinceLastReceivedBlock)
+                .isReceivingBlocks(isReceivingBlocks)
+                .blockReceiveDelayThreshold(blockReceiveDelayThreshold)
                 .build();
+    }
+
+    private long getBlockReceiveDelayThreshold() {
+        // Convert seconds to milliseconds
+        return storeProperties.getBlockReceiveDelaySeconds() * 1000L;
     }
 }

--- a/config/application.properties
+++ b/config/application.properties
@@ -173,6 +173,10 @@ store.auto-index-management=true
 ## Ping the node at regular intervals to maintain the connection. The default interval is 10 seconds.
 #store.cardano.keep-alive-interval=10000
 
+## Block receive delay threshold in seconds for health check. If no blocks are received within this time,
+## the connection is considered unhealthy, default is 120 seconds.
+#store.block-receive-delay-seconds=120
+
 ############################################################
 # Flags to enable/disable a store.
 # Default value = "true", To disable a store, set the flag to "false"

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -209,6 +209,7 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setCursorCleanupInterval(properties.getCardano().getCursorCleanupInterval());
 
         storeProperties.setKeepAliveInterval(properties.getCardano().getKeepAliveInterval());
+        storeProperties.setBlockReceiveDelaySeconds(properties.getBlockReceiveDelaySeconds());
 
         storeProperties.setDefaultGenesisHash(properties.getCardano().getDefaultGenesisHash());
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -23,6 +23,9 @@ public class YaciStoreProperties {
     private boolean continueOnParseError = false;
     private AutoRestart autoRestart = new AutoRestart();
 
+    //Block receive delay threshold in seconds for health check (default: 120 seconds)
+    private int blockReceiveDelaySeconds = 120;
+
     @Getter
     @Setter
     public static final class Cardano {

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -23,7 +23,7 @@ public class YaciStoreProperties {
     private boolean continueOnParseError = false;
     private AutoRestart autoRestart = new AutoRestart();
 
-    //Block receive delay threshold in seconds for health check (default: 120 seconds)
+    //Block receive delay threshold in seconds for health check
     private int blockReceiveDelaySeconds = 120;
 
     @Getter


### PR DESCRIPTION
#621 

3 new metrics:
- `yaci.store.connection.status`  : connection status (1: up, 0: down)
- `yaci.store.last_received_block_time` :Timestamp of the last received block in milliseconds
- `yaci.store.current.slot`: current slot being processed

Improvements:
- Enhance HealthService  by providing additional isReceivingBlocks status for enhanced monitoring
