### PR TITLE
 Add Auto-Restart Feature for IntersectionNotFound Errors

### DIFF
--- a/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/service/AutoRecoveryStartService.java
+++ b/components/admin/src/main/java/com/bloxbean/cardano/yaci/store/admin/service/AutoRecoveryStartService.java
@@ -1,15 +1,16 @@
 package com.bloxbean.cardano.yaci.store.admin.service;
 
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
-import com.bloxbean.cardano.yaci.store.core.service.StartService;
+import com.bloxbean.cardano.yaci.store.core.service.HealthService;
+import com.bloxbean.cardano.yaci.store.events.internal.RequiredSyncRestartEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 @ReadOnly(false)
@@ -18,10 +19,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Slf4j
 public class AutoRecoveryStartService {
     private final HealthService healthService;
-    private final StartService startService;
-    private AtomicBoolean waitingToStart = new AtomicBoolean(false);
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Scheduled(fixedRateString = "${store.admin.health-check-interval}", initialDelay = 120, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedRateString = "${store.admin.health-check-interval:120}", initialDelay = 120, timeUnit = TimeUnit.SECONDS)
     public void checkHealthAndStart() {
         var healthStatus = healthService.getHealthStatus();
 
@@ -34,29 +34,17 @@ public class AutoRecoveryStartService {
             return;
         }
 
-        if(waitingToStart.get()) { //Already waiting to start
-            return;
-        }
+        // Publish restart event - let RequiredRestartProcessor handle the restart
+        RequiredSyncRestartEvent restartEvent = RequiredSyncRestartEvent.builder()
+                .reason("HealthCheckFailed")
+                .errorCode("HEALTH_CHECK_FAILED")
+                .timestamp(System.currentTimeMillis())
+                .source("AutoRecoveryStartService")
+                .details("Connection not alive or sync error detected")
+                .build();
 
-        //Schedule to start the service
-        Thread.startVirtualThread(() -> {
-            waitingToStart.set(true);
-            log.info("Waiting for 10 seconds before restarting the sync process ...");
-            try {
-                TimeUnit.SECONDS.sleep(10); //TODO -- Configurable
-            } catch (InterruptedException e) {
-            }
-            synchronized (this) {
-                try {
-                    startService.stop();
-                    startService.start();
-                } catch (Exception e) {
-                    log.error("Error starting the service", e);
-                }
-            }
-
-            waitingToStart.set(false);
-        });
+        eventPublisher.publishEvent(restartEvent);
+        log.info("Published restart event due to health check failure");
     }
 
 }

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -137,4 +137,10 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
 
     @Builder.Default
     private boolean continueOnParseError = false;
+
+    //Auto-restart properties
+    private boolean autoRestartEnabled = true;
+    private long autoRestartDebounceWindowMs = 30000;
+    private int autoRestartMaxAttempts = 5;
+    private long autoRestartBackoffBaseMs = 5000;
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
@@ -1,0 +1,185 @@
+package com.bloxbean.cardano.yaci.store.core.processor;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
+import com.bloxbean.cardano.yaci.store.core.service.HealthService;
+import com.bloxbean.cardano.yaci.store.core.service.StartService;
+import com.bloxbean.cardano.yaci.store.events.internal.RequiredSyncRestartEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+@ReadOnly(false)
+@RequiredArgsConstructor
+@Slf4j
+public class RequiredRestartProcessor {
+    private final StartService startService;
+    private final HealthService healthService;
+    private final StoreProperties storeProperties;
+
+    private final AtomicLong lastRestartAttempt = new AtomicLong(0);
+    private final AtomicInteger restartCount = new AtomicInteger(0);
+    private final Lock restartLock = new ReentrantLock();
+    private final AtomicBoolean monitoringHealth = new AtomicBoolean(false);
+
+    // Track successful sync period
+    private static final long SUCCESS_THRESHOLD_MS = 300000; // 5 minutes
+    private static final long HEALTH_CHECK_INTERVAL_MS = 30000; // 30 seconds
+
+    @EventListener
+    public void handleRequiredRestart(RequiredSyncRestartEvent event) {
+
+        Thread.startVirtualThread(() -> handleRestartInterval(event));
+    }
+
+    private void handleRestartInterval(RequiredSyncRestartEvent event) {
+        if (!storeProperties.isAutoRestartEnabled()) {
+            log.warn("Auto-restart is disabled. Ignoring event: {}", event.getReason());
+            return;
+        }
+
+        if (!restartLock.tryLock()) {
+            log.info("Restart already in progress. Ignoring event: {}", event.getReason());
+            return;
+        }
+
+        try {
+            // Check debounce window
+            long now = System.currentTimeMillis();
+            long lastAttempt = lastRestartAttempt.get();
+            if (now - lastAttempt < storeProperties.getAutoRestartDebounceWindowMs()) {
+                log.info("Within debounce window. Ignoring restart event: {}", event.getReason());
+                return;
+            }
+
+            // Check retry limit
+            if (restartCount.get() >= storeProperties.getAutoRestartMaxAttempts()) {
+                log.error("Max restart attempts reached. Manual intervention required.");
+                return;
+            }
+
+            // Calculate backoff
+            int attemptNumber = restartCount.incrementAndGet();
+            long backoffMs = calculateBackoff(attemptNumber);
+
+            log.info("Scheduling sync restart. Reason: {}, Attempt: {}, Backoff: {}ms",
+                     event.getReason(), attemptNumber, backoffMs);
+
+            // Wait for backoff
+            Thread.sleep(backoffMs);
+
+            // Perform restart
+            performRestart(event);
+
+            lastRestartAttempt.set(System.currentTimeMillis());
+
+        } catch (Exception e) {
+            log.error("Error during sync restart", e);
+        } finally {
+            restartLock.unlock();
+        }
+    }
+
+    private void performRestart(RequiredSyncRestartEvent event) {
+        log.info("Stopping sync service...");
+        startService.stop();
+
+        // Wait for clean shutdown
+        try {
+            TimeUnit.SECONDS.sleep(5);
+            log.debug("Waited 5 seconds for clean shutdown");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting for shutdown");
+        }
+
+        log.info("Starting sync service...");
+        startService.start();
+
+        log.info("Sync restart completed for reason: {}", event.getReason());
+
+        // Start health monitoring thread only if we have restart attempts
+        if (restartCount.get() > 0) {
+            startHealthMonitoring();
+        }
+    }
+
+    private long calculateBackoff(int attemptNumber) {
+        return Math.min(
+            storeProperties.getAutoRestartBackoffBaseMs() * (long)Math.pow(2, attemptNumber - 1),
+            60000L // Max 1 minute
+        );
+    }
+
+    private void startHealthMonitoring() {
+        // Only start monitoring if not already running
+        if (!monitoringHealth.compareAndSet(false, true)) {
+            log.debug("Health monitoring already in progress");
+            return;
+        }
+
+        Thread.startVirtualThread(() -> {
+            log.info("Starting health monitoring to reset restart counter after stable sync");
+            long monitoringStartTime = System.currentTimeMillis();
+            long lastSuccessfulSyncTime = 0;
+
+            try {
+                while (monitoringHealth.get() && restartCount.get() > 0) {
+                    // Check sync health using HealthService
+                    var healthStatus = healthService.getHealthStatus();
+                    
+                    if (healthStatus.isConnectionAlive() && !healthStatus.isError()) {
+                        long lastBlockTime = healthStatus.getLastReceivedBlockTime();
+                        long currentTime = System.currentTimeMillis();
+
+                        // Check if we're receiving blocks (within last minute)
+                        if (lastBlockTime > 0 && (currentTime - lastBlockTime) < 60000) {
+                            // We're successfully syncing
+                            if (lastSuccessfulSyncTime == 0) {
+                                lastSuccessfulSyncTime = currentTime;
+                                log.debug("Started tracking successful sync period");
+                            } else if (currentTime - lastSuccessfulSyncTime > SUCCESS_THRESHOLD_MS) {
+                                // 5 minutes of stable sync, reset counter
+                                log.info("Sync has been stable for 5 minutes. Resetting restart counter.");
+                                restartCount.set(0);
+                                break; // Exit monitoring
+                            }
+                        } else {
+                            // Not receiving blocks, reset success tracking
+                            lastSuccessfulSyncTime = 0;
+                        }
+                    } else {
+                        // Not running or in error state, reset success tracking
+                        lastSuccessfulSyncTime = 0;
+                    }
+
+                    // Stop monitoring after 10 minutes regardless
+                    if (System.currentTimeMillis() - monitoringStartTime > 600000) {
+                        log.info("Health monitoring timeout reached (10 minutes). Stopping monitoring.");
+                        break;
+                    }
+
+                    // Sleep for check interval
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(HEALTH_CHECK_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            } finally {
+                monitoringHealth.set(false);
+                log.info("Health monitoring stopped. Restart counter: {}", restartCount.get());
+            }
+        });
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
@@ -1,8 +1,7 @@
-package com.bloxbean.cardano.yaci.store.admin.service;
+package com.bloxbean.cardano.yaci.store.core.service;
 
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
-import com.bloxbean.cardano.yaci.store.core.service.BlockFetchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/docs/pages/other-configurations.mdx
+++ b/docs/pages/other-configurations.mdx
@@ -90,6 +90,82 @@ By default, saving of transaction witness data is disabled.
 ```properties
 store.transaction.save-witness=false
 ```
+## Auto-Restart Configuration
+
+Yaci-store includes an auto-restart feature that automatically handles recoverable sync errors, such as IntersectionNotFound errors that can occur after network disconnections and node rollbacks.
+
+The auto-restart system uses an event-driven architecture to detect sync issues and restart the sync process with proper backpressure controls.
+
+```properties
+# Auto-restart configuration (enabled by default)
+store.auto-restart.enabled=true
+store.auto-restart.debounce-window-ms=30000
+store.auto-restart.max-attempts=5
+store.auto-restart.backoff-base-ms=5000
+```
+
+### Configuration Options
+
+- **`store.auto-restart.enabled`** (default: `true`): Enable or disable the auto-restart feature
+- **`store.auto-restart.debounce-window-ms`** (default: `30000`): Time window in milliseconds to prevent multiple restart attempts. If multiple restart events occur within this window, only the first one will be processed
+- **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts before giving up and requiring manual intervention
+- **`store.auto-restart.backoff-base-ms`** (default: `5000`): Base delay in milliseconds for exponential backoff between restart attempts
+
+### How It Works
+
+The auto-restart system automatically handles:
+- **IntersectionNotFound errors**: When the node can't find a common intersection point after network issues
+- **Health check failures**: When the auto-recovery service detects sync problems
+
+The system includes safeguards to prevent restart storms:
+- **Debouncing**: Ignores rapid restart requests within the configured window
+- **Exponential backoff**: Increases delay between retry attempts (5s, 10s, 20s, 40s, 60s max)
+- **Retry limits**: Stops trying after the maximum attempts are reached
+- **Success tracking**: Resets the retry counter after 5 minutes of stable sync
+
+<Callout>
+The auto-restart feature is enabled by default since IntersectionNotFound is a valid scenario that should be handled automatically, especially in production environments.
+</Callout>
+
+## Auto-Recovery Service
+
+In addition to the auto-restart feature, yaci-store provides an auto-recovery service that monitors the overall health of the sync process and triggers restarts when health issues are detected.
+
+The auto-recovery service performs periodic health checks and publishes restart events when:
+- Connection to the Cardano node is not alive
+- Sync process is in an error state
+- General sync health problems are detected
+
+```properties
+# Auto-recovery service configuration (disabled by default)
+store.admin.auto-recovery-enabled=false
+store.admin.health-check-interval=120
+```
+
+### Configuration Options
+
+- **`store.admin.auto-recovery-enabled`** (default: `false`): Enable or disable the auto-recovery service
+- **`store.admin.health-check-interval`** (default: `120`): Health check interval in seconds
+
+### How Auto-Recovery Works
+
+The auto-recovery service:
+1. **Periodic Health Monitoring**: Runs health checks at the configured interval
+2. **Connection Monitoring**: Checks if the connection to the Cardano node is alive
+3. **Error Detection**: Monitors for sync errors and problematic states
+4. **Event Publishing**: Publishes restart events that are handled by the auto-restart system
+
+<Callout>
+The auto-recovery service is disabled by default. It should only be enabled in environments where you want comprehensive health monitoring beyond just IntersectionNotFound errors. When enabled, it works together with the auto-restart system to provide robust sync reliability.
+</Callout>
+
+### Relationship Between Auto-Restart and Auto-Recovery
+
+- **Auto-Restart**: Always enabled by default, handles specific recoverable errors like IntersectionNotFound
+- **Auto-Recovery**: Disabled by default, provides broader health monitoring and triggers restarts for general health issues
+- Both systems work together through the same event-driven architecture
+- Auto-recovery publishes events that are processed by the auto-restart system's backpressure controls
+
 ## Auto Sync off
 
 Ideally, you should only have one write instance of yaci-store. However, if you want to set up multiple read-only yaci-store instances alongside one write instance,

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -250,6 +250,12 @@ public class YaciStoreAutoConfiguration {
 
         storeProperties.setContinueOnParseError(properties.isContinueOnParseError());
 
+        //Auto-restart properties
+        storeProperties.setAutoRestartEnabled(properties.getAutoRestart().isEnabled());
+        storeProperties.setAutoRestartDebounceWindowMs(properties.getAutoRestart().getDebounceWindowMs());
+        storeProperties.setAutoRestartMaxAttempts(properties.getAutoRestart().getMaxAttempts());
+        storeProperties.setAutoRestartBackoffBaseMs(properties.getAutoRestart().getBackoffBaseMs());
+
         return storeProperties;
     }
 

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -29,6 +29,7 @@ public class YaciStoreProperties {
 
     private Plugins plugins = new Plugins();
     private Metrics metrics = new Metrics();
+    private AutoRestart autoRestart = new AutoRestart();
 
     @Getter
     @Setter
@@ -143,4 +144,14 @@ public class YaciStoreProperties {
     public static final class Metrics {
         boolean enabled = true;
     }
+
+    @Getter
+    @Setter
+    public static final class AutoRestart {
+        private boolean enabled = true;
+        private long debounceWindowMs = 30000;
+        private int maxAttempts = 5;
+        private long backoffBaseMs = 5000;
+    }
+
 }


### PR DESCRIPTION
 ### Summary

  Implements an event-driven auto-restart system to handle `IntersectionNotFound` errors that occur after network disconnections and node rollbacks. This fixes an edge case where yaci-store sync would stop and require manual intervention.

  ### Changes

  - **RequiredSyncRestartEvent**: New internal event for triggering sync restarts
  - **RequiredRestartProcessor**: Event-driven processor with debouncing, retry limits, and exponential backoff
  - **BlockFetchService**: Added intersactNotFound callback to publish restart events
  - **AutoRecoveryStartService**: Updated to use event-driven approach instead of direct restarts
  - **Configuration**: Added auto-restart properties with sensible defaults
  - **Documentation**: Updated configuration docs with both auto-restart and auto-recovery sections

  ### Configuration

```
  # Auto-restart (enabled by default)
  store.auto-restart.enabled=true
  store.auto-restart.debounce-window-ms=30000
  store.auto-restart.max-attempts=5
  store.auto-restart.backoff-base-ms=5000

  # Auto-recovery (disabled by default)
  store.admin.auto-recovery-enabled=false
  store.admin.health-check-interval=120
  ```

  ### Testing

  - Manual testing performed with Yaci DevKit devnet where network rollbacks and disconnections were simulated to trigger **IntersectionNotFound** errors
  - Verified auto-restart successfully handles the edge case scenario
  - Confirmed restart counter resets after stable sync periods
