### PR TITLE
Update version and Yaci library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
       - develop
+      - release/*
+      - develop/*
   pull_request:
     branches:
       - main
       - develop
+      - release/*
+      - develop/*
 
 jobs:
   commit-build:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bloxbean.cardano
-version = 0.1.4
+version = 0.1.5-beta
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.3.7"
+yaci = "com.bloxbean.cardano:yaci:0.3.8"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.6.6"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.6.6"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.6.6"


### PR DESCRIPTION
Bump project version to 0.1.5-beta and upgrade YACI library to 0.3.8. These changes ensure compatibility with the latest updates and prepare for a beta release.