### PR TITLE
Feat/merge connection metrics and update restart condition, shutdown unused BlockRangeSync when we move to BlockSync

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -64,6 +64,10 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
 
     private int keepAliveInterval = 10000;
 
+    //Block receive delay threshold in seconds
+    @Builder.Default
+    private int blockReceiveDelaySeconds = 120;
+
     //Only required if the genesis hash can't be fetched
     private String defaultGenesisHash = "Genesis";
 

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/HealthStatus.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/HealthStatus.java
@@ -21,4 +21,19 @@ public class HealthStatus {
     private int lastKeepAliveResponseCookie;
     private long lastKeepAliveResponseTime;
     private long lastReceivedBlockTime;
+
+    /**
+     * Time since last block was received in milliseconds
+     */
+    private long timeSinceLastBlock;
+
+    /**
+     * Indicates if blocks are being received within the configured threshold
+     */
+    private boolean isReceivingBlocks;
+
+    /**
+     * The configured block receive delay threshold in milliseconds
+     */
+    private long blockReceiveDelayThreshold;
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
@@ -18,7 +18,6 @@ public class MetricsService {
     public static final String YACI_STORE_SYNC_MODE = "yaci.store.sync_mode";
     public static final String YACI_STORE_PROTOCOL_MAGIC = "yaci.store.protocol_magic";
     public static final String YACI_STORE_CURRENT_SLOT = "yaci.store.current.slot";
-    public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.node.connection.status";
     public static final String YACI_STORE_LAST_RECEIVED_BLOCK_TIME = "yaci.store.last_received_block_time";
 
     private AtomicLong currentBlockNo = new AtomicLong(0);
@@ -28,7 +27,6 @@ public class MetricsService {
     private AtomicInteger isSyncMode = new AtomicInteger(0);
     private AtomicLong protocolMagic = new AtomicLong(0);
     private AtomicLong currentSlot = new AtomicLong(0);
-    private AtomicInteger connectionStatus = new AtomicInteger(0);
     private AtomicLong lastReceivedBlockTime = new AtomicLong(0);
 
     public MetricsService(MeterRegistry meterRegistry, StoreProperties storeProperties) {
@@ -64,10 +62,6 @@ public class MetricsService {
                 .description("Current slot being processed")
                 .register(meterRegistry);
 
-        Gauge.builder(YACI_STORE_CONNECTION_STATUS, connectionStatus, AtomicInteger::get)
-                .description("Connection status to the node. 1 for up, 0 for down")
-                .register(meterRegistry);
-
         Gauge.builder(YACI_STORE_LAST_RECEIVED_BLOCK_TIME, lastReceivedBlockTime, AtomicLong::get)
                 .description("Timestamp of the last received block in milliseconds")
                 .register(meterRegistry);
@@ -82,10 +76,6 @@ public class MetricsService {
         isSyncMode.set(metadata.isSyncMode()? 1 : 0);
         protocolMagic.set(metadata.getProtocolMagic());
         currentSlot.set(metadata.getSlot());
-    }
-
-    public void updateConnectionStatus(boolean isConnected) {
-        connectionStatus.set(isConnected ? 1 : 0);
     }
 
     public void updateLastReceivedBlockTime(long timestamp) {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/metrics/MetricsService.java
@@ -17,6 +17,9 @@ public class MetricsService {
     public static final String YACI_STORE_CURRENT_ERA = "yaci.store.current.era";
     public static final String YACI_STORE_SYNC_MODE = "yaci.store.sync_mode";
     public static final String YACI_STORE_PROTOCOL_MAGIC = "yaci.store.protocol_magic";
+    public static final String YACI_STORE_CURRENT_SLOT = "yaci.store.current.slot";
+    public static final String YACI_STORE_CONNECTION_STATUS = "yaci.store.node.connection.status";
+    public static final String YACI_STORE_LAST_RECEIVED_BLOCK_TIME = "yaci.store.last_received_block_time";
 
     private AtomicLong currentBlockNo = new AtomicLong(0);
     private AtomicLong currentEpochNo = new AtomicLong(0);
@@ -24,6 +27,9 @@ public class MetricsService {
     private AtomicLong currentBlockTime = new AtomicLong(0);
     private AtomicInteger isSyncMode = new AtomicInteger(0);
     private AtomicLong protocolMagic = new AtomicLong(0);
+    private AtomicLong currentSlot = new AtomicLong(0);
+    private AtomicInteger connectionStatus = new AtomicInteger(0);
+    private AtomicLong lastReceivedBlockTime = new AtomicLong(0);
 
     public MetricsService(MeterRegistry meterRegistry, StoreProperties storeProperties) {
 
@@ -53,6 +59,18 @@ public class MetricsService {
         Gauge.builder(YACI_STORE_PROTOCOL_MAGIC, protocolMagic, AtomicLong::get)
                 .description("Protocol magic of the current chain")
                 .register(meterRegistry);
+
+        Gauge.builder(YACI_STORE_CURRENT_SLOT, currentSlot, AtomicLong::get)
+                .description("Current slot being processed")
+                .register(meterRegistry);
+
+        Gauge.builder(YACI_STORE_CONNECTION_STATUS, connectionStatus, AtomicInteger::get)
+                .description("Connection status to the node. 1 for up, 0 for down")
+                .register(meterRegistry);
+
+        Gauge.builder(YACI_STORE_LAST_RECEIVED_BLOCK_TIME, lastReceivedBlockTime, AtomicLong::get)
+                .description("Timestamp of the last received block in milliseconds")
+                .register(meterRegistry);
     }
 
     public void updateMetrics(EventMetadata metadata) {
@@ -63,5 +81,14 @@ public class MetricsService {
         currentEraNo.set(metadata.getEra().getValue());
         isSyncMode.set(metadata.isSyncMode()? 1 : 0);
         protocolMagic.set(metadata.getProtocolMagic());
+        currentSlot.set(metadata.getSlot());
+    }
+
+    public void updateConnectionStatus(boolean isConnected) {
+        connectionStatus.set(isConnected ? 1 : 0);
+    }
+
+    public void updateLastReceivedBlockTime(long timestamp) {
+        lastReceivedBlockTime.set(timestamp);
     }
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -535,16 +535,6 @@ public class BlockFetchService implements BlockChainDataListener {
     }
 
     @Override
-    public void onDisconnect() {
-        metricsService.updateConnectionStatus(false);
-    }
-
-    @Override
-    public void intersactFound(Tip tip, Point point) {
-        metricsService.updateConnectionStatus(true);
-    }
-
-    @Override
     public void intersactNotFound(Tip tip) {
         log.error("Intersection not found. Current tip: {}", tip);
         

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -146,6 +146,7 @@ public class BlockFetchService implements BlockChainDataListener {
         //Update metrics
         try {
             metricsService.updateMetrics(eventMetadata);
+            metricsService.updateLastReceivedBlockTime(lastReceivedBlockTime);
         } catch (Exception e) {
             log.warn("Error updating metrics for block: " + block.getHeader().getHeaderBody().getBlockNumber(), e);
         }
@@ -531,6 +532,16 @@ public class BlockFetchService implements BlockChainDataListener {
                 .era(eventMetadata.getEra())
                 .build();
         publisher.publishEvent(epochChangeEvent);
+    }
+
+    @Override
+    public void onDisconnect() {
+        metricsService.updateConnectionStatus(false);
+    }
+
+    @Override
+    public void intersactFound(Tip tip, Point point) {
+        metricsService.updateConnectionStatus(true);
     }
 
     @Override

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -338,6 +338,9 @@ public class BlockFetchService implements BlockChainDataListener {
             log.info("Batch Done >>>");
 
             if (storeProperties.isPrimaryInstance()) {
+                //Stop BlockRange Sync before starting BlockSync
+                shutdownRangeSync();
+
                 //If primary instance, start sync
                 //start sync
                 cursorService.getCursor()
@@ -409,6 +412,14 @@ public class BlockFetchService implements BlockChainDataListener {
         blockRangeSync.stop();
     }
 
+    public synchronized void shutdownRangeSync() {
+        try {
+            blockRangeSync.stop();
+        } catch (Exception e) {
+            log.error("Error stopping blockRangeSync", e);
+        }
+    }
+
     public synchronized void shutdownSync() {
         blockSync.stop();
     }
@@ -477,13 +488,19 @@ public class BlockFetchService implements BlockChainDataListener {
                     Thread.sleep(interval);
                     int randomNo = getRandomNumber(0, 60000);
 
-                    if (log.isDebugEnabled())
+                    if (log.isDebugEnabled()) {
                         log.debug("Sending keep alive : " + randomNo);
+                    }
 
-                    if (syncMode)
+                    if (syncMode) {
                         blockSync.sendKeepAliveMessage(randomNo);
-                    else
+                        if (log.isDebugEnabled())
+                            log.debug("Response from keep alive : " + blockSync.getLastKeepAliveResponseCookie());
+                    } else {
                         blockRangeSync.sendKeepAliveMessage(randomNo);
+                        if (log.isDebugEnabled())
+                            log.debug("Response from keep alive : " + blockRangeSync.getLastKeepAliveResponseCookie());
+                    }
 
                 } catch (InterruptedException e) {
                     log.info("Keep alive thread interrupted");

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -277,18 +277,14 @@ public class BlockFetchService implements BlockChainDataListener {
 
     private void stopSyncOnError() {
         setError();
-        if (blockRangeSync != null)
-            blockRangeSync.stop();
-        if (blockSync != null)
-            blockSync.stop();
+        shutdownRangeSync();
+        shutdownSync();
     }
 
     public void stop() {
         scheduledToStop.set(true);
-        if (blockRangeSync != null)
-            blockRangeSync.stop();
-        if (blockSync != null)
-            blockSync.stop();
+        shutdownRangeSync();
+        shutdownSync();
     }
 
     @Transactional
@@ -414,14 +410,20 @@ public class BlockFetchService implements BlockChainDataListener {
 
     public synchronized void shutdownRangeSync() {
         try {
-            blockRangeSync.stop();
+            if (blockRangeSync != null)
+                blockRangeSync.stop();
         } catch (Exception e) {
             log.error("Error stopping blockRangeSync", e);
         }
     }
 
     public synchronized void shutdownSync() {
-        blockSync.stop();
+        try {
+            if (blockSync != null)
+                blockSync.stop();
+        } catch (Exception e) {
+            log.error("Error stopping blockSync", e);
+        }
     }
 
     public boolean isRunning() {

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/HealthService.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.core.service;
 
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import lombok.RequiredArgsConstructor;
@@ -12,16 +13,36 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class HealthService {
     private final BlockFetchService blockFetchService;
+    private final StoreProperties storeProperties;
 
     public HealthStatus getHealthStatus() {
+        long currentTime = System.currentTimeMillis();
+        long lastReceivedBlockTime = blockFetchService.getLastReceivedBlockTime();
+        long blockReceiveDelayThreshold = getBlockReceiveDelayThreshold();
+        long timeSinceLastReceivedBlock = (lastReceivedBlockTime == 0) ? 0 : (currentTime - lastReceivedBlockTime);
+
+        // Consider blocks are being received if:
+        // - No blocks received yet (lastReceivedBlockTime == 0) OR
+        // - Time since last block is within threshold
+        boolean isReceivingBlocks = (lastReceivedBlockTime == 0) || (timeSinceLastReceivedBlock <= blockReceiveDelayThreshold);
+
+        boolean isConnectionAlive = blockFetchService.isRunning();
 
         return HealthStatus.builder()
-                .isConnectionAlive(blockFetchService.isRunning())
+                .isConnectionAlive(isConnectionAlive)
                 .isScheduleToStop(blockFetchService.isScheduledToStop())
                 .isError(blockFetchService.isError())
                 .lastKeepAliveResponseCookie(blockFetchService.getLastKeepAliveResponseCookie())
                 .lastKeepAliveResponseTime(blockFetchService.getLastKeepAliveResponseTime())
-                .lastReceivedBlockTime(blockFetchService.getLastReceivedBlockTime())
+                .lastReceivedBlockTime(lastReceivedBlockTime)
+                .timeSinceLastBlock(timeSinceLastReceivedBlock)
+                .isReceivingBlocks(isReceivingBlocks)
+                .blockReceiveDelayThreshold(blockReceiveDelayThreshold)
                 .build();
+    }
+
+    private long getBlockReceiveDelayThreshold() {
+        // Convert seconds to milliseconds
+        return storeProperties.getBlockReceiveDelaySeconds() * 1000L;
     }
 }

--- a/config/application.properties
+++ b/config/application.properties
@@ -181,6 +181,10 @@ store.auto-index-management=true
 ## Ping the node at regular intervals to maintain the connection. The default interval is 10 seconds.
 #store.cardano.keep-alive-interval=10000
 
+## Block receive delay threshold in seconds for health check. If no blocks are received within this time,
+## the connection is considered unhealthy, default is 120 seconds.
+#store.block-receive-delay-seconds=120
+
 ############################################################
 # Flags to enable/disable a store.
 # Default value = "true", To disable a store, set the flag to "false"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.4.0-beta4"
+yaci = "com.bloxbean.cardano:yaci:0.4.0-beta5"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.0-beta4"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.0-beta4"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.0-beta4"

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -200,7 +200,7 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setCursorCleanupInterval(properties.getCardano().getCursorCleanupInterval());
 
         storeProperties.setKeepAliveInterval(properties.getCardano().getKeepAliveInterval());
-
+        storeProperties.setBlockReceiveDelaySeconds(properties.getBlockReceiveDelaySeconds());
         storeProperties.setDefaultGenesisHash(properties.getCardano().getDefaultGenesisHash());
 
         //executor properties

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -31,6 +31,9 @@ public class YaciStoreProperties {
     private Metrics metrics = new Metrics();
     private AutoRestart autoRestart = new AutoRestart();
 
+    //Block receive delay threshold in seconds for health check
+    private int blockReceiveDelaySeconds = 120;
+
     @Getter
     @Setter
     public static final class Cardano {


### PR DESCRIPTION
- Merge the changes in https://github.com/bloxbean/yaci-store/pull/630 to main
- Upgrade yaci library to 0.4.0-beta5
- Fix: Connection reset issue. Shutdown unused BlockRangeSync when we move to BlockSync. Check detail: https://github.com/bloxbean/yaci-store/pull/638
- Fix: remove connection status metric and update new Cardano node host, port. Check detail: https://github.com/bloxbean/yaci-store/pull/639
- Refactor sync stopping logic to handle null checks and exceptions. Check : https://github.com/bloxbean/yaci-store/pull/640 