### PR TITLE
Upgrade yaci-store images to version 0.1.5-beta.

### DIFF
--- a/docker/yaci-store-aggregation.yml
+++ b/docker/yaci-store-aggregation.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-aggregation:
-    image: bloxbean/yaci-store-aggregation-app:0.1.3
+    image: bloxbean/yaci-store-aggregation-app:0.1.5-beta
     container_name: yaci-store-aggregation
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=aggregation}

--- a/docker/yaci-store-all.yml
+++ b/docker/yaci-store-all.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-all:
-    image: bloxbean/yaci-store-all:0.1.3
+    image: bloxbean/yaci-store-all:0.1.5-beta
     container_name: yaci-store-all
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=yaci_store}

--- a/docker/yaci-store-utxo-indexer.yml
+++ b/docker/yaci-store-utxo-indexer.yml
@@ -1,6 +1,6 @@
 services:
   yaci-store-utxo-indexer:
-    image: bloxbean/yaci-store-utxo-indexer:0.1.3
+    image: bloxbean/yaci-store-utxo-indexer:0.1.5-beta
     container_name: yaci-store-utxo-indexer
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=utxo_indexer}


### PR DESCRIPTION
Updated Docker configurations for yaci-store services to use the latest 0.1.5-beta images. 