### PR TITLE
Fix: Correct proposal dropping logic for ratified/expired proposals

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessor.java
@@ -75,7 +75,7 @@ public class ProposalRefundProcessor {
         );
 
         ratifiedProposalsInThisEpoch.forEach(proposal ->
-                ProposalUtils.findDescendantsAndSiblings(proposal, proposalListInThisEpoch)
+                ProposalUtils.findSiblingsAndTheirDescendants(proposal, proposalListInThisEpoch)
                         .forEach(p -> siblingsOrDescendantsBePrunedInNextEpoch.putIfAbsent(p.getGovActionId(), p))
         );
 

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessor.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.bloxbean.cardano.yaci.store.governanceaggr.GovernanceAggrConfiguration.STORE_GOVERNANCEAGGR_ENABLED;
 
@@ -62,10 +63,13 @@ public class ProposalRefundProcessor {
         rewardStorage.deleteRewardRest(epoch, RewardRestType.proposal_refund);
         rewardStorage.deleteUnclaimedRewardRest(epoch, RewardRestType.proposal_refund);
 
+        List<Proposal> newProposalsCreatedInPrevEpoch = getNewProposalsCreatedInPrevEpoch(epoch);
         List<Proposal> expiredProposalsInThisEpoch = getProposalsByStatusAndEpoch(GovActionStatus.EXPIRED, epoch);
         List<Proposal> ratifiedProposalsInThisEpoch = getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, epoch);
-        List<Proposal> proposalListInThisEpoch = getProposalsByStatusListAndEpoch(
-                List.of(GovActionStatus.ACTIVE, GovActionStatus.RATIFIED, GovActionStatus.EXPIRED), epoch);
+        List<Proposal> proposalListInThisEpoch = Stream.concat(
+                getProposalsByStatusListAndEpoch(List.of(GovActionStatus.ACTIVE, GovActionStatus.RATIFIED, GovActionStatus.EXPIRED), epoch).stream(),
+                newProposalsCreatedInPrevEpoch.stream())
+                .toList();
 
         Map<GovActionId, Proposal> siblingsOrDescendantsBePrunedInNextEpoch = new HashMap<>();
 
@@ -156,6 +160,15 @@ public class ProposalRefundProcessor {
                 .map(this::mapToProposal)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+                .toList();
+    }
+
+    private List<Proposal> getNewProposalsCreatedInPrevEpoch(int epoch) {
+        return govActionProposalStorage.findByEpoch(epoch)
+                .stream()
+                .map(proposalMapper::toGovActionProposal)
+                .filter(Optional::isPresent)
+                .map(govActionProposal -> proposalMapper.toProposal(govActionProposal.get()))
                 .toList();
     }
 

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
@@ -749,7 +749,8 @@ public class ProposalStatusProcessor {
             proposalsToPrune.forEach(p -> proposalsBeDroppedInCurrentEpoch.put(p.getGovActionId(), p));
         }
 
-        List<GovActionProposal> filteredActiveProposals = activeProposalsInPrevSnapshot.stream()
+        List<GovActionProposal> filteredActiveProposals =
+                Stream.concat(activeProposalsInPrevSnapshot.stream(), newProposalsCreatedInPrevEpoch.stream())
                 .filter(govActionProposal -> !proposalsBeDroppedInCurrentEpoch.containsKey(
                         GovActionId.builder()
                                 .gov_action_index(govActionProposal.getIndex())
@@ -757,8 +758,7 @@ public class ProposalStatusProcessor {
                                 .build()))
                 .toList();
 
-        return Stream.concat(filteredActiveProposals.stream(), newProposalsCreatedInPrevEpoch.stream())
-                .toList();
+        return filteredActiveProposals;
     }
 
     private boolean isEpochInConwayBootstrapPhase(int epoch) {

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalStatusProcessor.java
@@ -728,7 +728,13 @@ public class ProposalStatusProcessor {
                 .map(proposalMapper::toProposal)
                 .toList();
 
-        List<Proposal> allProposals = Stream.concat(expiredProposals.stream(), Stream.concat(ratifiedProposals.stream(), activeProposals.stream())).toList();
+        List<Proposal> newProposals = newProposalsCreatedInPrevEpoch.stream()
+                .map(proposalMapper::toProposal)
+                .toList();
+
+        List<Proposal> allProposals = Stream.concat(expiredProposals.stream(),
+                Stream.concat(ratifiedProposals.stream(),
+                Stream.concat(activeProposals.stream(), newProposals.stream()))).toList();
         Map<GovActionId, Proposal> proposalsBeDroppedInCurrentEpoch = new HashMap<>();
 
         for (Proposal proposal : expiredProposals) {

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepDistService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepDistService.java
@@ -2,10 +2,12 @@ package com.bloxbean.cardano.yaci.store.governanceaggr.service;
 
 import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobExtraInfo;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
 import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
+import com.bloxbean.cardano.yaci.store.client.governance.ProposalStateClient;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
 import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
@@ -14,8 +16,12 @@ import com.bloxbean.cardano.yaci.store.dbutils.index.util.DatabaseUtils;
 import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
 import com.bloxbean.cardano.yaci.store.epoch.processor.EraGenesisProtocolParamsUtil;
 import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import com.bloxbean.cardano.yaci.store.governance.storage.GovActionProposalStorage;
 import com.bloxbean.cardano.yaci.store.governanceaggr.domain.GovActionProposalStatus;
+import com.bloxbean.cardano.yaci.store.governanceaggr.domain.Proposal;
 import com.bloxbean.cardano.yaci.store.governanceaggr.storage.GovActionProposalStatusStorage;
+import com.bloxbean.cardano.yaci.store.governanceaggr.storage.impl.mapper.ProposalMapper;
+import com.bloxbean.cardano.yaci.store.governanceaggr.util.ProposalUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -26,10 +32,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
@@ -39,6 +44,9 @@ public class DRepDistService {
     private final EraService eraService;
     private final EpochParamStorage epochParamStorage;
     private final GovActionProposalStatusStorage govActionProposalStatusStorage;
+    private final GovActionProposalStorage govActionProposalStorage;
+    private final ProposalStateClient proposalStateClient;
+    private final ProposalMapper proposalMapper;
     private final StoreProperties storeProperties;
     private final EraGenesisProtocolParamsUtil eraGenesisProtocolParamsUtil;
     private final DRepExpiryService dRepExpiryService;
@@ -102,6 +110,7 @@ public class DRepDistService {
             "DROP TABLE IF EXISTS ss_drep_ranked_delegations",
             "DROP TABLE IF EXISTS ss_drep_status",
             "DROP TABLE IF EXISTS ss_gov_active_proposal_deposits",
+            "DROP TABLE IF EXISTS ss_gov_scheduled_to_drop_proposal_deposits",
             "DROP TABLE IF EXISTS ss_gov_spendable_reward_rest",
             "DROP TABLE IF EXISTS ss_gov_pool_refund_rewards"
         );
@@ -110,6 +119,9 @@ public class DRepDistService {
             jdbcTemplate.update(query, Map.of());
         }
         log.info("Dropped existing temp tables for DRep distribution !!!");
+
+        // Get proposals that will be dropped in current epoch
+        Set<GovActionId> proposalsToBeDropped = getActiveProposalsScheduledToDrop(currentEpoch);
 
         String rankedDelegationsQuery = String.format("""
                 CREATE %s TABLE ss_drep_ranked_delegations AS
@@ -249,6 +261,42 @@ public class DRepDistService {
                       g.return_address
                 """, tableType);
 
+        String droppedProposalDepositsQuery;
+        if (!proposalsToBeDropped.isEmpty()) {
+            String droppedProposals = proposalsToBeDropped.stream()
+                    .map(govActionId -> String.format("('%s', %d)",
+                            govActionId.getTransactionId(), govActionId.getGov_action_index()))
+                    .collect(Collectors.joining(", "));
+
+            droppedProposalDepositsQuery = String.format("""
+                    CREATE %s TABLE ss_gov_scheduled_to_drop_proposal_deposits AS
+                    select
+                          g.return_address,
+                          SUM(g.deposit) as deposit
+                        from
+                          gov_action_proposal g
+                          left join gov_action_proposal_status s on g.tx_hash = s.gov_action_tx_hash
+                          and g.idx = s.gov_action_index
+                        where
+                         ((s.status = 'ACTIVE'
+                         		and g.epoch < :epoch
+                         		and s.epoch = :epoch)
+                         	or (s.status is null
+                         		and g.epoch = :epoch))
+                         and (g.tx_hash, g.idx) IN (%s)
+                        group by
+                          g.return_address
+                    """, tableType, droppedProposals);
+        } else {
+            // Create empty table if no proposals scheduled to be drop
+            droppedProposalDepositsQuery = String.format("""
+                    CREATE %s TABLE ss_gov_scheduled_to_drop_proposal_deposits (
+                        return_address varchar(255),
+                        deposit bigint
+                    )
+                    """, tableType);
+        }
+
         String spendableRewardRestQuery = String.format("""
                 CREATE %s TABLE ss_gov_spendable_reward_rest AS
                 select
@@ -262,7 +310,7 @@ public class DRepDistService {
                 where
                     (lw.max_slot is null
                         or r.slot > lw.max_slot)
-                    and r.spendable_epoch <= :snapshot_epoch 
+                    and r.spendable_epoch <= :snapshot_epoch
                 group by
                     r.address
                 """, tableType);
@@ -281,6 +329,7 @@ public class DRepDistService {
                 rankedDelegationsQuery,
                 drepStatusQuery,
                 activeProposalDepositsQuery,
+                droppedProposalDepositsQuery,
                 spendableRewardRestQuery,
                 poolRefundRewardsQuery
         );
@@ -307,7 +356,8 @@ public class DRepDistService {
                 "CREATE INDEX idx_ss_gov_pool_refund_rewards_address ON ss_gov_pool_refund_rewards(address)",
                 "CREATE INDEX idx_ss_drep_status_drep_hash ON ss_drep_status(drep_hash)",
                 "CREATE INDEX idx_ss_drep_status_drep_type ON ss_drep_status(type)",
-                "CREATE INDEX idx_ss_gov_active_proposal_deposits_ret_address ON ss_gov_active_proposal_deposits(return_address)"
+                "CREATE INDEX idx_ss_gov_active_proposal_deposits_ret_address ON ss_gov_active_proposal_deposits(return_address)",
+                "CREATE INDEX idx_ss_gov_scheduled_to_drop_proposal_deposits_ret_address ON ss_gov_scheduled_to_drop_proposal_deposits(return_address)"
         );
 
         start = System.currentTimeMillis();
@@ -379,7 +429,8 @@ public class DRepDistService {
                       COALESCE(sab.quantity, 0) 
                           + COALESCE(r.withdrawable_reward, 0) 
                           + COALESCE(pr.pool_refund_withdrawable_reward, 0) 
-                          + coalesce(apd.deposit, 0) 
+                          + COALESCE(apd.deposit, 0)
+                          - COALESCE(dpd.deposit, 0)
                           + COALESCE(rr.withdrawable_reward_rest, 0)
                     ),
                     :snapshot_epoch,
@@ -391,6 +442,7 @@ public class DRepDistService {
                     left join ss_pool_rewards r on rd.address = r.address
                     left join ss_gov_pool_refund_rewards pr on rd.address = pr.address
                     left join ss_gov_active_proposal_deposits  apd on apd.return_address = rd.address
+                    left join ss_gov_scheduled_to_drop_proposal_deposits dpd on dpd.return_address = rd.address
                     left join ss_max_slot_balances msb on msb.address = rd.address
                     left join stake_address_balance sab on msb.address = sab.address and msb.max_slot = sab.slot
                     left join ss_gov_spendable_reward_rest rr ON rd.address = rr.address
@@ -422,7 +474,8 @@ public class DRepDistService {
                       COALESCE(sab.quantity, 0)
                           + COALESCE(r.withdrawable_reward, 0) 
                           + COALESCE(pr.pool_refund_withdrawable_reward, 0) 
-                          + coalesce(apd.deposit, 0)
+                          + COALESCE(apd.deposit, 0)
+                          - COALESCE(dpd.deposit, 0)
                           + COALESCE(rr.withdrawable_reward_rest, 0)
                     ),
                     :snapshot_epoch,
@@ -430,10 +483,11 @@ public class DRepDistService {
                     null,
                     NOW()
                   from
-                    ss_drep_ranked_delegations rd                      
+                    ss_drep_ranked_delegations rd
                     left join ss_pool_rewards r on rd.address = r.address
                     left join ss_gov_pool_refund_rewards pr on rd.address = pr.address
                     left join ss_gov_active_proposal_deposits  apd on apd.return_address = rd.address
+                    left join ss_gov_scheduled_to_drop_proposal_deposits dpd on dpd.return_address = rd.address
                     left join ss_max_slot_balances msb on msb.address = rd.address
                     left join stake_address_balance sab on msb.address = sab.address and msb.max_slot = sab.slot
                     left join ss_gov_spendable_reward_rest rr ON rd.address = rr.address
@@ -497,5 +551,46 @@ public class DRepDistService {
         return storeProperties.getProtocolMagic() == Networks.mainnet().getProtocolMagic()
                 || storeProperties.getProtocolMagic() == Networks.preprod().getProtocolMagic()
                 || storeProperties.getProtocolMagic() == Networks.preview().getProtocolMagic();
+    }
+
+    private Set<GovActionId> getActiveProposalsScheduledToDrop(int currentEpoch) {
+        int prevEpoch = currentEpoch - 1;
+        
+        List<Proposal> newProposals = govActionProposalStorage.findByEpoch(prevEpoch)
+                .stream()
+                .map(proposalMapper::toGovActionProposal)
+                .flatMap(Optional::stream)
+                .map(proposalMapper::toProposal)
+                .toList();
+
+        List<Proposal> ratifiedProposals = proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, prevEpoch).stream()
+                .map(proposalMapper::toProposal)
+                .toList();
+        List<Proposal> activeProposals = proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.ACTIVE, prevEpoch).stream()
+                .map(proposalMapper::toProposal)
+                .toList();
+        List<Proposal> expiredProposals = proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.EXPIRED, prevEpoch).stream()
+                .map(proposalMapper::toProposal)
+                .toList();
+
+        List<Proposal> activeOrNewCreatedProposals = Stream.concat(activeProposals.stream(), newProposals.stream()).toList();
+
+        Set<GovActionId> proposalsToBeDropped = new HashSet<>();
+
+        for (Proposal proposal : expiredProposals) {
+            List<Proposal> proposalsToPrune = ProposalUtils.findDescendants(proposal, activeOrNewCreatedProposals);
+            proposalsToPrune.forEach(p -> proposalsToBeDropped.add(p.getGovActionId()));
+        }
+
+        for (Proposal proposal : ratifiedProposals) {
+            List<Proposal> proposalsToPrune = ProposalUtils.findSiblingsAndTheirDescendants(proposal, activeOrNewCreatedProposals);
+            proposalsToPrune.forEach(p -> {
+                if (activeProposals.contains(p) || newProposals.contains(p)) {
+                    proposalsToBeDropped.add(p.getGovActionId());
+                }
+            });
+        }
+
+        return proposalsToBeDropped;
     }
 }

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepDistService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepDistService.java
@@ -584,11 +584,7 @@ public class DRepDistService {
 
         for (Proposal proposal : ratifiedProposals) {
             List<Proposal> proposalsToPrune = ProposalUtils.findSiblingsAndTheirDescendants(proposal, activeOrNewCreatedProposals);
-            proposalsToPrune.forEach(p -> {
-                if (activeProposals.contains(p) || newProposals.contains(p)) {
-                    proposalsToBeDropped.add(p.getGovActionId());
-                }
-            });
+            proposalsToPrune.forEach(p -> {proposalsToBeDropped.add(p.getGovActionId());});
         }
 
         return proposalsToBeDropped;

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
@@ -188,7 +188,7 @@ public class VotingAggrService {
                         selectOne()
                                 .from(DREP_DIST)
                                 .where(DREP_DIST.DREP_HASH.eq(VOTING_PROCEDURE.VOTER_HASH))
-                                .and(DREP_DIST.EPOCH.eq(epoch))
+                                .and(DREP_DIST.EPOCH.eq(epoch + 1))
                 )
                 .fetch();
 

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
@@ -16,7 +16,6 @@ public class ProposalUtils {
      * @return A list of proposals that are descendants and siblings of the given proposal.
      */
     public static List<Proposal> findDescendantsAndSiblings(Proposal proposal, List<Proposal> allProposals) {
-        // Handle types that don't belong to any purpose tree
         if (proposal.getType() == GovActionType.INFO_ACTION || proposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
@@ -12,10 +12,10 @@ public class ProposalUtils {
      * Finds all descendants and siblings of a specific proposal.
      *
      * @param proposal     The proposal for which descendants and/or siblings are to be found.
-     * @param allProposals The list of all proposals.
+     * @param proposalList The list of proposals.
      * @return A list of proposals that are descendants and siblings of the given proposal.
      */
-    public static List<Proposal> findDescendantsAndSiblings(Proposal proposal, List<Proposal> allProposals) {
+    public static List<Proposal> findDescendantsAndSiblings(Proposal proposal, List<Proposal> proposalList) {
         if (proposal.getType() == GovActionType.INFO_ACTION || proposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
@@ -24,13 +24,13 @@ public class ProposalUtils {
         GovActionType type = proposal.getType();
 
         // Add descendants
-        result.addAll(findDescendants(proposal, allProposals, type));
+        result.addAll(findDescendants(proposal, proposalList, type));
 
         GovActionId parentId = proposal.getPreviousGovActionId();
         if (parentId != null) {
             // Find siblings with the same parent and type
             result.addAll(
-                    allProposals.stream()
+                    proposalList.stream()
                             .filter(p -> parentId.equals(p.getPreviousGovActionId()) && !p.equals(proposal)
                                     && isSamePurpose(p.getType(), type))
                             .toList()
@@ -38,7 +38,7 @@ public class ProposalUtils {
         } else {
             // If no parent, find siblings among root nodes
             result.addAll(
-                    allProposals.stream()
+                    proposalList.stream()
                             .filter(p -> p.getPreviousGovActionId() == null && !p.equals(proposal) && isSamePurpose(p.getType(), type))
                             .toList()
             );
@@ -49,11 +49,11 @@ public class ProposalUtils {
 
     /**
      * Find siblings of a proposal
-     * @param proposal
-     * @param allProposals
-     * @return
+     * @param proposal The proposal for which siblings are to be found.
+     * @param proposalList The list of proposals.
+     * @return A list of proposals that are descendants and siblings of the given proposal.
      */
-    public static List<Proposal> findSiblings(Proposal proposal, List<Proposal> allProposals) {
+    public static List<Proposal> findSiblings(Proposal proposal, List<Proposal> proposalList) {
         GovActionType type = proposal.getType();
 
         if (type == GovActionType.INFO_ACTION || type == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
@@ -63,11 +63,11 @@ public class ProposalUtils {
         GovActionId parentId = proposal.getPreviousGovActionId();
 
         if (parentId == null) {
-            return allProposals.stream()
+            return proposalList.stream()
                     .filter(p -> p.getPreviousGovActionId() == null && !p.equals(proposal) && isSamePurpose(p.getType(), type))
                     .toList();
         } else {
-            return allProposals.stream()
+            return proposalList.stream()
                     .filter(p -> parentId.equals(p.getPreviousGovActionId()) && !p.equals(proposal) && isSamePurpose(p.getType(), type))
                     .toList();
         }
@@ -75,14 +75,14 @@ public class ProposalUtils {
 
     /**
      * Find descendants of a proposal
-     * @param proposal
-     * @param allProposals
-     * @return
+     * @param proposal The proposal for which siblings are to be found.
+     * @param proposalList The list of proposals.
+     * @return A list of proposals that are descendants of the given proposal.
      */
-    public static List<Proposal> findDescendants(Proposal proposal, List<Proposal> allProposals) {
+    public static List<Proposal> findDescendants(Proposal proposal, List<Proposal> proposalList) {
         GovActionType type = proposal.getType();
 
-        return new ArrayList<>(findDescendants(proposal, allProposals, type));
+        return new ArrayList<>(findDescendants(proposal, proposalList, type));
     }
 
     private static List<Proposal> findDescendants(Proposal rootProposal, List<Proposal> allProposals, GovActionType type) {
@@ -108,26 +108,26 @@ public class ProposalUtils {
     }
 
     /**
-     * Finds siblings and their descendants of a ratified proposal.
+     * Finds siblings and their descendants of a proposal.
      *
-     * @param ratifiedProposal The ratified proposal for which siblings and their descendants are to be found.
-     * @param allProposals     The list of all proposals.
-     * @return A list of proposals that are siblings and descendants of siblings of the ratified proposal.
+     * @param proposal         The proposal for which siblings and their descendants are to be found.
+     * @param proposalList     The list of proposals.
+     * @return A list of proposals that are siblings and descendants of siblings of the proposal.
      */
-    public static List<Proposal> findSiblingsAndTheirDescendants(Proposal ratifiedProposal, List<Proposal> allProposals) {
-        if (ratifiedProposal.getType() == GovActionType.INFO_ACTION || ratifiedProposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
+    public static List<Proposal> findSiblingsAndTheirDescendants(Proposal proposal, List<Proposal> proposalList) {
+        if (proposal.getType() == GovActionType.INFO_ACTION || proposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
 
         List<Proposal> result = new ArrayList<>();
 
-        // First, find all siblings of the ratified proposal
-        List<Proposal> siblings = findSiblings(ratifiedProposal, allProposals);
+        // First, find all siblings of the proposal
+        List<Proposal> siblings = findSiblings(proposal, proposalList);
 
         // For each sibling, find all its descendants and add both sibling and descendants to result
         for (Proposal sibling : siblings) {
             result.add(sibling);
-            result.addAll(findDescendants(sibling, allProposals));
+            result.addAll(findDescendants(sibling, proposalList));
         }
 
         return result;

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/ProposalUtils.java
@@ -17,7 +17,7 @@ public class ProposalUtils {
      */
     public static List<Proposal> findDescendantsAndSiblings(Proposal proposal, List<Proposal> allProposals) {
         // Handle types that don't belong to any purpose tree
-        if (!belongsToPurposeTree(proposal.getType())) {
+        if (proposal.getType() == GovActionType.INFO_ACTION || proposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
 
@@ -57,7 +57,7 @@ public class ProposalUtils {
     public static List<Proposal> findSiblings(Proposal proposal, List<Proposal> allProposals) {
         GovActionType type = proposal.getType();
 
-        if (!belongsToPurposeTree(type)) {
+        if (type == GovActionType.INFO_ACTION || type == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
 
@@ -87,7 +87,7 @@ public class ProposalUtils {
     }
 
     private static List<Proposal> findDescendants(Proposal rootProposal, List<Proposal> allProposals, GovActionType type) {
-        if (!belongsToPurposeTree(type)) {
+        if (type == GovActionType.INFO_ACTION || type == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
 
@@ -116,7 +116,7 @@ public class ProposalUtils {
      * @return A list of proposals that are siblings and descendants of siblings of the ratified proposal.
      */
     public static List<Proposal> findSiblingsAndTheirDescendants(Proposal ratifiedProposal, List<Proposal> allProposals) {
-        if (!belongsToPurposeTree(ratifiedProposal.getType())) {
+        if (ratifiedProposal.getType() == GovActionType.INFO_ACTION || ratifiedProposal.getType() == GovActionType.TREASURY_WITHDRAWALS_ACTION) {
             return Collections.emptyList();
         }
 
@@ -132,18 +132,6 @@ public class ProposalUtils {
         }
 
         return result;
-    }
-
-    /**
-     * Determines if a governance action type belongs to a purpose tree.
-     * Types that belong to purpose trees can have siblings and descendants.
-     * TREASURY_WITHDRAWALS_ACTION and INFO_ACTION don't belong to any purpose tree.
-     *
-     * @param type The governance action type to check
-     * @return true if the type belongs to a purpose tree
-     */
-    public static boolean belongsToPurposeTree(GovActionType type) {
-        return type != GovActionType.INFO_ACTION && type != GovActionType.TREASURY_WITHDRAWALS_ACTION;
     }
 
     /**
@@ -170,7 +158,6 @@ public class ProposalUtils {
             return true;
         }
 
-        // TREASURY_WITHDRAWALS_ACTION and INFO_ACTION don't belong to any purpose tree
         return false;
     }
 

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessorTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/ProposalRefundProcessorTest.java
@@ -133,9 +133,9 @@ class ProposalRefundProcessorTest {
         domainGovProposal5.setReturnAddress("stake_test1upnakjguet3zc7qzrw54p3nc3j8c7pd5v4w8x5evdzseygs9eeeee");
         domainGovProposal5.setDeposit(BigInteger.valueOf(5000));
 
-        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.EXPIRED, 1))
-                .thenReturn(List.of(govProposal1));
         when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.RATIFIED, 1))
+                .thenReturn(List.of(govProposal1));
+        when(proposalStateClient.getProposalsByStatusAndEpoch(GovActionStatus.EXPIRED, 1))
                 .thenReturn(List.of(govProposal3));
         when(proposalStateClient.getProposalsByStatusListAndEpoch(anyList(), eq(1)))
                 .thenReturn(List.of(govProposal1, govProposal2, govProposal3, govProposal4, govProposal5));
@@ -169,8 +169,8 @@ class ProposalRefundProcessorTest {
         verify(govActionProposalStorage).findByGovActionIds(govActionIdsCaptor.capture());
         List<GovActionId> capturedGovActionIds = govActionIdsCaptor.getValue();
 
-        assertEquals(3, capturedGovActionIds.size());
-        assertThat(capturedGovActionIds).containsExactlyInAnyOrder(proposal1.getGovActionId(),
+        assertEquals(4, capturedGovActionIds.size());
+        assertThat(capturedGovActionIds).containsExactlyInAnyOrder(proposal1.getGovActionId(), proposal2.getGovActionId(),
                 proposal3.getGovActionId(), proposal4.getGovActionId());
 
         ArgumentCaptor<RewardRestEvent> eventCaptor = ArgumentCaptor.forClass(RewardRestEvent.class);


### PR DESCRIPTION
## 📌 Purpose

This pull request aims to fix issues related to the calculation of DRep distribution and proposal dropping logic.

## 🔧 Changes
### Core Fix
- Updated the logic for dropping proposals: if a proposal is ratified, its sibling proposals and the descendants of those siblings will be dropped. 
- Added a temporary table `ss_gov_scheduled_to_drop_proposal_deposits` to store deposits of proposals scheduled to be dropped. These deposit values will be subtracted when calculating DRep voting power.

### Proposal Purpose-Based Dropping Logic
- **Purpose groups**: Proposals are grouped by purpose (PParamUpdatePurpose, HardForkPurpose, CommitteePurpose, ConstitutionPurpose)
- **Sibling identification**: Proposals with the same purpose and same parent are considered siblings
- **Dropping rules**: When a proposal is ratified, all its siblings and descendants of those siblings are dropped. When a proposal is expired, its descendants are dropped
- **Cross-purpose isolation**: Proposals of different purposes don't affect each other (e.g., ParameterChange doesn't drop HardFork proposals)
## 📎 Related Issues
#642, #618

