### PR TITLE
Update file path configuration and Docker volume mapping

### DIFF
--- a/docker/compose/yaci-store.yml
+++ b/docker/compose/yaci-store.yml
@@ -13,6 +13,7 @@ services:
       - ../config/application-plugins.yml:/app/config/application-plugins.yml
       - ../plugins/scripts:/app/plugins/scripts/
       - ../plugins/ext-jars:/app/plugins/ext-jars/
+      - ../plugins/files:/app/plugins/files/
     logging:
       driver: "json-file"
       options:

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -148,7 +148,7 @@ public class YaciStoreProperties {
     @Getter
     @Setter
     public static final class FileSettings {
-        private String rootPath = "./plugin-files";
+        private String rootPath = "./plugins/files";
         private boolean enableLocks = true;
     }
 }


### PR DESCRIPTION
Modified the default `rootPath` in `YaciStoreProperties` to align with the updated folder structure. Additionally, added a volume mapping in the Docker Compose file for the `plugins/files` directory to ensure proper file handling.