### PR TITLE
feat: #622 Add scheduler plugin support with interval-based scheduling

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.store.common.config;
 
 import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
 import com.bloxbean.cardano.yaci.store.plugin.api.config.ScriptRef;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -129,6 +130,7 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
     private Map<String, List<PluginDef>> preActions = new HashMap<>();
     private Map<String, List<PluginDef>> postActions = new HashMap<>();
     private Map<String, List<PluginDef>> eventHandlers = new HashMap<>();
+    private List<SchedulerPluginDef> schedulers = new ArrayList<>();
 
     private String pythonVenv;
     private List<ScriptRef> pluginGlobalScripts;

--- a/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/PluginFactory.java
+++ b/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/PluginFactory.java
@@ -19,5 +19,7 @@ public interface PluginFactory {
     <T> PreActionPlugin<T> createPreActionPlugin(PluginDef def);
 
     <T> EventHandlerPlugin<T> createEventHandlerPlugin(PluginDef def);
+
+    <T> SchedulerPlugin<T> createSchedulerPlugin(PluginDef def);
 }
 

--- a/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/PluginType.java
+++ b/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/PluginType.java
@@ -1,5 +1,5 @@
 package com.bloxbean.cardano.yaci.store.plugin.api;
 
 public enum PluginType {
-    INIT, FILTER, POST_ACTION, PRE_ACTION, EVENT_HANDLER;
+    INIT, FILTER, POST_ACTION, PRE_ACTION, EVENT_HANDLER, SCHEDULER;
 }

--- a/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/SchedulerPlugin.java
+++ b/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/SchedulerPlugin.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.store.plugin.api;
+
+/**
+ * Interface for scheduler plugins that can execute scheduled tasks.
+ * Variables are directly accessible in the plugin execution context without parameters.
+ *
+ * @param <T>
+ */
+public interface SchedulerPlugin<T> extends IPlugin<T> {
+    void execute();
+}

--- a/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/config/SchedulerPluginDef.java
+++ b/components/plugin-api/src/main/java/com/bloxbean/cardano/yaci/store/plugin/api/config/SchedulerPluginDef.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.store.plugin.api.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class SchedulerPluginDef extends PluginDef {
+    private ScheduleConfig schedule;
+    private Map<String, Object> customVariables;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ScheduleConfig {
+        private ScheduleType type;
+        private String value;
+    }
+
+    public enum ScheduleType {
+        INTERVAL,
+        CRON,
+        BLOCK
+    }
+}

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/PolyglotConverter.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/PolyglotConverter.java
@@ -1,0 +1,88 @@
+package com.bloxbean.cardano.yaci.store.plugin.polyglot.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class for polyglot plugin developers to convert complex objects
+ * before storing them in global state. This prevents "Context is already closed"
+ * exceptions when other plugins try to access these objects after the GraalVM
+ * context is closed.
+ * 
+ * Usage in Python plugins:
+ * <pre>
+ * from com.bloxbean.cardano.yaci.store.plugin.polyglot.common import PolyglotConverter
+ * 
+ * # Convert before storing in global state
+ * my_dict = {"key": "value", "nested": {"data": 123}}
+ * global_state.put("shared_data", PolyglotConverter.unwrap(my_dict))
+ * </pre>
+ * 
+ * Usage in JavaScript plugins:
+ * <pre>
+ * const PolyglotConverter = Java.type('com.bloxbean.cardano.yaci.store.plugin.polyglot.common.PolyglotConverter');
+ * 
+ * // Convert before storing in global state
+ * const myObj = {key: "value", nested: {data: 123}};
+ * global_state.put("shared_data", PolyglotConverter.unwrap(myObj));
+ * </pre>
+ */
+@Slf4j
+public class PolyglotConverter {
+    
+    /**
+     * Unwraps a polyglot value (Python dict, JavaScript object, etc.) to a 
+     * native Java object that can be safely stored in global state and accessed
+     * by other plugins after the original context is closed.
+     * 
+     * @param value The value to unwrap (can be a GraalVM Value, proxy object, or regular Java object)
+     * @return A native Java object (HashMap for dicts/objects, ArrayList for lists/arrays, etc.)
+     */
+    public static Object unwrap(Object value) {
+        Object converted = ValueConverter.convertToJava(value);
+        
+        if (log.isDebugEnabled()) {
+            log.debug("Unwrapped {} to {}", 
+                value != null ? value.getClass().getSimpleName() : "null",
+                converted != null ? converted.getClass().getSimpleName() : "null");
+        }
+        
+        return converted;
+    }
+    
+    /**
+     * Checks if a value needs to be unwrapped before storing in global state.
+     * Returns true if the value is a GraalVM proxy object that will fail
+     * when accessed after context closure.
+     * 
+     * @param value The value to check
+     * @return true if unwrapping is needed, false otherwise
+     */
+    public static boolean needsUnwrap(Object value) {
+        if (value == null) {
+            return false;
+        }
+        
+        String className = value.getClass().getName();
+        
+        // Check for GraalVM proxy objects
+        if (className.contains("com.oracle.truffle") || 
+            className.contains("org.graalvm.polyglot")) {
+            return true;
+        }
+        
+        // Check for proxy Maps/Lists that aren't standard Java collections
+        if (value instanceof java.util.Map && 
+            !(value instanceof java.util.HashMap) && 
+            !(value instanceof java.util.concurrent.ConcurrentHashMap)) {
+            return true;
+        }
+        
+        if (value instanceof java.util.List && 
+            !(value instanceof java.util.ArrayList) && 
+            !(value instanceof java.util.LinkedList)) {
+            return true;
+        }
+        
+        return false;
+    }
+}

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/Unwrapper.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/Unwrapper.java
@@ -1,0 +1,37 @@
+package com.bloxbean.cardano.yaci.store.plugin.polyglot.common;
+
+/**
+ * A simple wrapper to provide the unwrap functionality to polyglot scripts.
+ * This allows scripts to call unwrap(value) directly without needing to reference
+ * the PolyglotConverter class.
+ * 
+ * Usage in Python:
+ * <pre>
+ * my_dict = {"key": "value", "nested": {"data": 123}}
+ * state.put("shared_data", unwrap(my_dict))
+ * </pre>
+ * 
+ * Usage in JavaScript:
+ * <pre>
+ * const myObj = {key: "value", nested: {data: 123}};
+ * state.put("shared_data", unwrap(myObj));
+ * </pre>
+ */
+public class Unwrapper {
+    
+    /**
+     * Unwraps a polyglot value to a native Java object.
+     * This is a delegate to PolyglotConverter.unwrap()
+     */
+    public Object unwrap(Object value) {
+        return PolyglotConverter.unwrap(value);
+    }
+    
+    /**
+     * Checks if a value needs to be unwrapped.
+     * This is a delegate to PolyglotConverter.needsUnwrap()
+     */
+    public boolean needsUnwrap(Object value) {
+        return PolyglotConverter.needsUnwrap(value);
+    }
+}

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/ValueConverter.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/common/ValueConverter.java
@@ -1,0 +1,130 @@
+package com.bloxbean.cardano.yaci.store.plugin.polyglot.common;
+
+import org.graalvm.polyglot.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+
+/**
+ * Utility class to convert GraalVM Value objects to native Java objects.
+ * This is necessary to prevent "Context is already closed" exceptions when
+ * accessing complex objects stored by polyglot scripts after context closure.
+ */
+@Slf4j
+public class ValueConverter {
+
+    /**
+     * Converts a GraalVM Value object to a native Java object.
+     * Handles nested structures recursively.
+     * 
+     * @param value The GraalVM Value to convert
+     * @return The converted Java object, or the original value if not a GraalVM Value
+     */
+    public static Object convertToJava(Object value) {
+        if (!(value instanceof Value)) {
+            // Not a GraalVM Value, return as-is
+            if (log.isTraceEnabled()) {
+                log.trace("Value is not a GraalVM Value, returning as-is: {}", value.getClass().getName());
+            }
+            return value;
+        }
+
+        Value graalValue = (Value) value;
+        if (log.isDebugEnabled()) {
+            log.debug("Converting GraalVM Value to Java object");
+        }
+        
+        try {
+            // Handle null
+            if (graalValue.isNull()) {
+                return null;
+            }
+            
+            // Handle primitives - these usually auto-convert but let's be explicit
+            if (graalValue.isBoolean()) {
+                return graalValue.asBoolean();
+            }
+            if (graalValue.isNumber()) {
+                if (graalValue.fitsInInt()) {
+                    return graalValue.asInt();
+                } else if (graalValue.fitsInLong()) {
+                    return graalValue.asLong();
+                } else if (graalValue.fitsInDouble()) {
+                    return graalValue.asDouble();
+                } else {
+                    // BigInteger or other number type
+                    return graalValue.as(Number.class);
+                }
+            }
+            if (graalValue.isString()) {
+                return graalValue.asString();
+            }
+            
+            // Handle arrays/lists
+            if (graalValue.hasArrayElements()) {
+                List<Object> list = new ArrayList<>();
+                long size = graalValue.getArraySize();
+                for (long i = 0; i < size; i++) {
+                    Value element = graalValue.getArrayElement(i);
+                    list.add(convertToJava(element));
+                }
+                return list;
+            }
+            
+            // Handle objects/maps
+            if (graalValue.hasMembers()) {
+                Map<String, Object> map = new HashMap<>();
+                for (String key : graalValue.getMemberKeys()) {
+                    Value member = graalValue.getMember(key);
+                    // Skip function members
+                    if (member != null && !member.canExecute()) {
+                        map.put(key, convertToJava(member));
+                    }
+                }
+                return map;
+            }
+            
+            // Handle dates
+            if (graalValue.isDate()) {
+                return graalValue.asDate();
+            }
+            if (graalValue.isTime()) {
+                return graalValue.asTime();
+            }
+            if (graalValue.isInstant()) {
+                return graalValue.asInstant();
+            }
+            
+            // If we can't convert it, try to get it as a generic object
+            // This might still fail if the context is closed
+            if (log.isDebugEnabled()) {
+                log.debug("Unable to convert GraalVM Value of type: {}, attempting generic conversion", 
+                    graalValue.getMetaObject() != null ? graalValue.getMetaObject().toString() : "unknown");
+            }
+            
+            return graalValue.as(Object.class);
+            
+        } catch (Exception e) {
+            log.warn("Failed to convert GraalVM Value to Java object: {}", e.getMessage());
+            // Return the original value if conversion fails
+            return value;
+        }
+    }
+    
+    /**
+     * Checks if a value needs conversion (i.e., is a GraalVM Value with complex type)
+     * 
+     * @param value The value to check
+     * @return true if the value needs conversion, false otherwise
+     */
+    public static boolean needsConversion(Object value) {
+        if (!(value instanceof Value)) {
+            return false;
+        }
+        
+        Value graalValue = (Value) value;
+        
+        // Primitives usually auto-convert, but complex types need explicit conversion
+        return graalValue.hasArrayElements() || graalValue.hasMembers();
+    }
+}

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsPolyglotPluginFactory.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsPolyglotPluginFactory.java
@@ -186,4 +186,15 @@ public class JsPolyglotPluginFactory implements PluginFactory {
         else
             throw new IllegalArgumentException("No script or inline-script found in event-handler definition for js plugin: " + def);
     }
+
+    @Override
+    public <T> SchedulerPlugin<T> createSchedulerPlugin(PluginDef def) {
+        if (def.getExpression() != null)
+            throw new IllegalArgumentException("Use script or inline-script for scheduler plugin. {}" + def);
+        else if (def.getInlineScript() != null || def.getScript() != null)
+            return new JsScriptStorePlugin<>(engine, def, PluginType.SCHEDULER, pluginStateService, variableProviderFactory,
+                    contextProvider, globalScriptContextRegistry);
+        else
+            throw new IllegalArgumentException("No script or inline-script found in scheduler definition for js plugin: " + def);
+    }
 }

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsScriptStorePlugin.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsScriptStorePlugin.java
@@ -7,9 +7,11 @@ import com.bloxbean.cardano.yaci.store.plugin.polyglot.common.pool.ContextProvid
 import com.bloxbean.cardano.yaci.store.plugin.polyglot.common.GlobalScriptContextRegistry;
 import com.bloxbean.cardano.yaci.store.plugin.polyglot.common.GraalPolyglotScriptStorePlugin;
 import com.bloxbean.cardano.yaci.store.plugin.variables.VariableProviderFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 
+@Slf4j
 public class JsScriptStorePlugin<T> extends GraalPolyglotScriptStorePlugin<T> {
     private final static String LANGUAGE = "js";
 
@@ -34,18 +36,29 @@ public class JsScriptStorePlugin<T> extends GraalPolyglotScriptStorePlugin<T> {
     }
 
     public String wrapInFunction(String script, String fnName) {
-        var argName = "items";
-        if (getPluginType() == PluginType.EVENT_HANDLER)
-            argName = "event";
+        if (getPluginType() == PluginType.SCHEDULER) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("function ").append(fnName).append("() {\n");
+            for (String line : script.split("\\R")) {
+                sb.append("    ").append(line).append('\n');
+            }
+            sb.append("}\n");
+            log.debug(sb.toString());
+            return sb.toString();
+        } else {
+            var argName = "items";
+            if (getPluginType() == PluginType.EVENT_HANDLER)
+                argName = "event";
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("function ").append(fnName).append("(" + argName + ") {\n");
-        for (String line : script.split("\\R")) {
-            sb.append("    ").append(line).append('\n');
+            StringBuilder sb = new StringBuilder();
+            sb.append("function ").append(fnName).append("(" + argName + ") {\n");
+            for (String line : script.split("\\R")) {
+                sb.append("    ").append(line).append('\n');
+            }
+            sb.append("}\n");
+            log.debug(sb.toString());
+            return sb.toString();
         }
-        sb.append("}\n");
-        System.out.println(sb.toString());
-        return sb.toString();
     }
 
 }

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonPolyglotPluginFactory.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonPolyglotPluginFactory.java
@@ -200,4 +200,15 @@ public class PythonPolyglotPluginFactory implements PluginFactory {
             throw new IllegalArgumentException("No script or inline-script found in event-handler definition for python plugin: " + def);
     }
 
+    @Override
+    public <T> SchedulerPlugin<T> createSchedulerPlugin(PluginDef def) {
+        if (def.getExpression() != null)
+            throw new IllegalArgumentException("Use script or inline-script for scheduler plugin. {}" + def);
+        else if (def.getInlineScript() != null || def.getScript() != null) {
+            return new PythonScriptStorePlugin<>(engine, def, PluginType.SCHEDULER, venvPath, pluginStateService,
+                    variableProviderFactory, contextProvider, globalScriptContextRegistry);
+        } else
+            throw new IllegalArgumentException("No script or inline-script found in scheduler definition for python plugin: " + def);
+    }
+
 }

--- a/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonScriptStorePlugin.java
+++ b/components/plugin-polyglot/src/main/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonScriptStorePlugin.java
@@ -52,15 +52,24 @@ public class PythonScriptStorePlugin<T> extends GraalPolyglotScriptStorePlugin<T
     }
 
     public String wrapInFunction(String script, String fnName) {
-        var argName = "items";
-        if (getPluginType() == PluginType.EVENT_HANDLER)
-            argName = "event";
+        if (getPluginType() == PluginType.SCHEDULER) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("def ").append(fnName).append("():\n");
+            for (String line : script.split("\\R")) {
+                sb.append("    ").append(line).append('\n');
+            }
+            return sb.toString();
+        } else {
+            var argName = "items";
+            if (getPluginType() == PluginType.EVENT_HANDLER)
+                argName = "event";
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("def ").append(fnName).append("(" + argName + "):\n");
-        for (String line : script.split("\\R")) {
-            sb.append("    ").append(line).append('\n');
+            StringBuilder sb = new StringBuilder();
+            sb.append("def ").append(fnName).append("(" + argName + "):\n");
+            for (String line : script.split("\\R")) {
+                sb.append("    ").append(line).append('\n');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 }

--- a/components/plugin-polyglot/src/test/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsSchedulerPluginIntegrationTest.java
+++ b/components/plugin-polyglot/src/test/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/js/JsSchedulerPluginIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.bloxbean.cardano.yaci.store.plugin.polyglot.js;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.polyglot.BasePluginTest;
+import com.bloxbean.cardano.yaci.store.plugin.scheduler.SchedulerVariableContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for JavaScript scheduler plugins
+ */
+public class JsSchedulerPluginIntegrationTest extends BasePluginTest {
+    
+    private JsPolyglotPluginFactory jsFactory;
+    
+    @BeforeEach
+    void setupJs() {
+        // Setup JS factory using the base class setup
+        jsFactory = new JsPolyglotPluginFactory(
+            pluginContextUtil,
+            pluginCacheService,
+            variableProviderFactory,
+            contextProvider,
+            globalScriptContextRegistry
+        );
+    }
+    
+    @Test
+    void testJavaScriptSchedulerPluginExecution() {
+        // Create a JavaScript scheduler plugin definition
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-js-scheduler");
+        schedulerDef.setLang("js");
+        schedulerDef.setInlineScript("""
+            // Access scheduler variables directly (no function wrapper needed)
+            var counter = state.get('jsCounter') || 0;
+            counter = counter + 1;
+            state.put('jsCounter', counter);
+            state.put('lastJsExecution', executionTime);
+            state.put('jsExecutionCount', executionCount);
+            
+            // Use custom variables if available
+            if (typeof customMessage !== 'undefined') {
+                state.put('customMessage', customMessage);
+            }
+            """);
+        schedulerDef.setExitOnError(false);
+        
+        // Set custom variables
+        Map<String, Object> customVars = new HashMap<>();
+        customVars.put("customMessage", "Hello from JS scheduler!");
+        schedulerDef.setCustomVariables(customVars);
+        
+        // Create the plugin
+        SchedulerPlugin<?> plugin = jsFactory.createSchedulerPlugin(schedulerDef);
+        
+        // Verify plugin was created successfully
+        assertThat(plugin).isNotNull();
+        assertThat(plugin.getName()).isEqualTo("test-js-scheduler");
+        
+        // Manually execute the plugin with scheduler context
+        Map<String, Object> schedulerVars = new HashMap<>();
+        schedulerVars.put("executionTime", System.currentTimeMillis());
+        schedulerVars.put("executionCount", 1L);
+        schedulerVars.put("isManualTrigger", true);
+        schedulerVars.put("customMessage", "Hello from JS scheduler!");
+        
+        // Set scheduler variables in context
+        SchedulerVariableContext.setVariables(schedulerVars);
+        
+        try {
+            // Execute plugin
+            plugin.execute();
+            
+            // Verify state was updated
+            var pluginState = pluginCacheService.forPlugin("test-js-scheduler");
+            Integer counter = (Integer) pluginState.get("jsCounter");
+            assertThat(counter).isEqualTo(1);
+            
+            Long lastExecution = (Long) pluginState.get("lastJsExecution");
+            assertThat(lastExecution).isNotNull();
+            
+            String customMessage = (String) pluginState.get("customMessage");
+            assertThat(customMessage).isEqualTo("Hello from JS scheduler!");
+            
+        } finally {
+            // Clear scheduler context
+            SchedulerVariableContext.clearVariables();
+        }
+    }
+    
+    @Test
+    void testJavaScriptSchedulerWithComplexLogic() {
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-js-complex-scheduler");
+        schedulerDef.setLang("js");
+        schedulerDef.setInlineScript("""
+            // Complex data processing example (no function wrapper needed)
+            var data = state.get('processingQueue') || [];
+            
+            // Add new item to queue
+            var newItem = {
+                id: executionCount,
+                timestamp: executionTime,
+                processed: false
+            };
+            data.push(newItem);
+            
+            // Process items (simulate batch processing)
+            var processed = 0;
+            for (var i = 0; i < data.length; i++) {
+                if (!data[i].processed) {
+                    data[i].processed = true;
+                    data[i].processedAt = executionTime;
+                    processed++;
+                    
+                    // Only process 2 items per execution
+                    if (processed >= 2) break;
+                }
+            }
+            
+            state.put('processingQueue', data);
+            state.put('lastProcessedCount', processed);
+            state.put('totalItems', data.length);
+            
+            // Store result object
+            state.put('result', {
+                processed: processed,
+                queueSize: data.length,
+                executionTime: executionTime
+            });
+            """);
+        schedulerDef.setExitOnError(false);
+        
+        // Create plugin
+        SchedulerPlugin<?> plugin = jsFactory.createSchedulerPlugin(schedulerDef);
+        
+        // Set scheduler variables
+        Map<String, Object> schedulerVars = new HashMap<>();
+        schedulerVars.put("executionTime", System.currentTimeMillis());
+        schedulerVars.put("executionCount", 3L);
+        schedulerVars.put("isManualTrigger", false);
+        
+        SchedulerVariableContext.setVariables(schedulerVars);
+        
+        try {
+            // Execute plugin
+            plugin.execute();
+            
+            // Verify complex processing worked
+            var pluginState = pluginCacheService.forPlugin("test-js-complex-scheduler");
+            Integer totalItems = (Integer) pluginState.get("totalItems");
+            assertThat(totalItems).isEqualTo(1);  // Should have added one item
+            
+            Integer lastProcessedCount = (Integer) pluginState.get("lastProcessedCount");
+            assertThat(lastProcessedCount).isEqualTo(1);  // Should have processed the one item
+            
+        } finally {
+            SchedulerVariableContext.clearVariables();
+        }
+    }
+}

--- a/components/plugin-polyglot/src/test/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonSchedulerPluginIntegrationTest.java
+++ b/components/plugin-polyglot/src/test/java/com/bloxbean/cardano/yaci/store/plugin/polyglot/python/PythonSchedulerPluginIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.bloxbean.cardano.yaci.store.plugin.polyglot.python;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.polyglot.BasePluginTest;
+import com.bloxbean.cardano.yaci.store.plugin.scheduler.SchedulerVariableContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for Python scheduler plugins
+ */
+public class PythonSchedulerPluginIntegrationTest extends BasePluginTest {
+    
+    private PythonPolyglotPluginFactory pythonFactory;
+    
+    @BeforeEach
+    void setupPython() {
+        // Setup Python factory using the base class setup
+        pythonFactory = new PythonPolyglotPluginFactory(
+            pluginContextUtil,
+            pluginCacheService,
+            variableProviderFactory,
+            contextProvider,
+            globalScriptContextRegistry
+        );
+    }
+    
+    @Test
+    void testPythonSchedulerPluginExecution() {
+        // Create a Python scheduler plugin definition
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-python-scheduler");
+        schedulerDef.setLang("python");
+        schedulerDef.setInlineScript("""
+            # Access scheduler variables directly (no function wrapper needed)
+            counter = state.get('pyCounter') or 0
+            counter = counter + 1
+            state.put('pyCounter', counter)
+            state.put('lastPyExecution', executionTime)
+            state.put('pyExecutionCount', executionCount)
+            
+            # Use custom variables if available
+            if 'pythonMessage' in globals():
+                state.put('pythonMessage', pythonMessage)
+            
+            # Store metrics - need to unwrap the dictionary before storing
+            metrics = {
+                'counter': counter,
+                'execution_time': executionTime,
+                'execution_count': executionCount
+            }
+            state.put('metrics', unwrapper.unwrap(metrics))
+            """);
+        schedulerDef.setExitOnError(false);
+        
+        // Set custom variables
+        Map<String, Object> customVars = new HashMap<>();
+        customVars.put("pythonMessage", "Hello from Python scheduler!");
+        customVars.put("maxExecutions", 10);
+        schedulerDef.setCustomVariables(customVars);
+        
+        // Create the plugin
+        SchedulerPlugin<?> plugin = pythonFactory.createSchedulerPlugin(schedulerDef);
+        
+        // Verify plugin was created successfully
+        assertThat(plugin).isNotNull();
+        assertThat(plugin.getName()).isEqualTo("test-python-scheduler");
+        
+        // Manually execute the plugin with scheduler context
+        Map<String, Object> schedulerVars = new HashMap<>();
+        schedulerVars.put("executionTime", System.currentTimeMillis());
+        schedulerVars.put("executionCount", 1L);
+        schedulerVars.put("isManualTrigger", true);
+        schedulerVars.put("pythonMessage", "Hello from Python scheduler!");
+        
+        // Set scheduler variables in context
+        SchedulerVariableContext.setVariables(schedulerVars);
+        
+        try {
+            // Execute plugin
+            plugin.execute();
+            
+            // Verify state was updated
+            var pluginState = pluginCacheService.forPlugin("test-python-scheduler");
+            Integer counter = (Integer) pluginState.get("pyCounter");
+            assertThat(counter).isEqualTo(1);
+            
+            Long lastExecution = (Long) pluginState.get("lastPyExecution");
+            assertThat(lastExecution).isNotNull();
+            
+            String pythonMessage = (String) pluginState.get("pythonMessage");
+            assertThat(pythonMessage).isEqualTo("Hello from Python scheduler!");
+            
+            // Check execution count was stored
+            Long executionCount = (Long) pluginState.get("pyExecutionCount");
+            assertThat(executionCount).isEqualTo(1L);
+            
+        } finally {
+            // Clear scheduler context
+            SchedulerVariableContext.clearVariables();
+        }
+    }
+    
+    @Test
+    void testPythonSchedulerWithDataProcessing() {
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-python-data-scheduler");
+        schedulerDef.setLang("python");
+        schedulerDef.setInlineScript("""
+            # Simulate data collection and processing (no function wrapper needed)
+            data_points = state.get('dataPoints') or []
+            
+            # Add new data point
+            new_point = {
+                'id': executionCount,
+                'timestamp': executionTime,
+                'value': executionCount * 10,  # Some computed value
+                'processed': False
+            }
+            data_points.append(new_point)
+            
+            # Process data points (batch processing simulation)
+            processed_count = 0
+            for point in data_points:
+                if not point['processed']:
+                    # Simulate processing
+                    point['processed'] = True
+                    point['processed_at'] = executionTime
+                    point['result'] = point['value'] * 2  # Some transformation
+                    processed_count += 1
+                    
+                    # Process max 3 items per execution
+                    if processed_count >= 3:
+                        break
+            
+            # Store results - need to unwrap complex objects
+            state.put('dataPoints', unwrapper.unwrap(data_points))
+            state.put('lastProcessedCount', processed_count)
+            state.put('totalDataPoints', len(data_points))
+            
+            # Calculate statistics
+            processed_points = [p for p in data_points if p['processed']]
+            avg_value = sum(p['value'] for p in processed_points) / len(processed_points) if processed_points else 0
+            
+            stats = {
+                'total_points': len(data_points),
+                'processed_points': len(processed_points),
+                'avg_value': avg_value,
+                'last_execution': executionTime
+            }
+            # Store individual statistics instead of a complex object
+            state.put('stats_total_points', len(data_points))
+            state.put('stats_processed_points', len(processed_points))
+            state.put('stats_avg_value', avg_value)
+            state.put('stats_last_execution', executionTime)
+            """);
+        schedulerDef.setExitOnError(false);
+        
+        // Create plugin
+        SchedulerPlugin<?> plugin = pythonFactory.createSchedulerPlugin(schedulerDef);
+        
+        // Set scheduler variables
+        Map<String, Object> schedulerVars = new HashMap<>();
+        schedulerVars.put("executionTime", System.currentTimeMillis());
+        schedulerVars.put("executionCount", 2L);
+        schedulerVars.put("isManualTrigger", false);
+        
+        SchedulerVariableContext.setVariables(schedulerVars);
+        
+        try {
+            // Execute plugin
+            plugin.execute();
+            
+            // Verify data processing worked
+            var pluginState = pluginCacheService.forPlugin("test-python-data-scheduler");
+            Integer totalDataPoints = (Integer) pluginState.get("totalDataPoints");
+            assertThat(totalDataPoints).isEqualTo(1);  // Should have added one data point
+            
+            // Verify individual statistics were stored
+            Integer totalPoints = (Integer) pluginState.get("stats_total_points");
+            Integer processedPoints = (Integer) pluginState.get("stats_processed_points");
+            assertThat(totalPoints).isEqualTo(1);
+            assertThat(processedPoints).isEqualTo(1);
+            
+        } finally {
+            SchedulerVariableContext.clearVariables();
+        }
+    }
+}

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/core/PluginRegistry.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/core/PluginRegistry.java
@@ -3,10 +3,13 @@ package com.bloxbean.cardano.yaci.store.plugin.core;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.plugin.api.*;
 import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
 import com.bloxbean.cardano.yaci.store.plugin.api.config.ScriptRef;
+import com.bloxbean.cardano.yaci.store.plugin.scheduler.SchedulerService;
 import com.bloxbean.cardano.yaci.store.plugin.variables.VariableProviderFactory;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -23,6 +26,9 @@ public class PluginRegistry {
     private final List<PluginFactory> factories;
     private final VariableProviderFactory variableProviderFactory;
 
+    @Autowired(required = false)
+    private SchedulerService schedulerService;
+
     // filterKey -> List of filter instances
     // filterKey is the <store_name>.<target>.<action> (e.g. "utxo.unspent.save" or "utxo.spent.save")
     private final Map<String, InitPlugin> initPlugins = new ConcurrentHashMap<>();
@@ -30,6 +36,7 @@ public class PluginRegistry {
     private final Map<String, List<PreActionPlugin<?>>> preActions = new ConcurrentHashMap<>();
     private final Map<String, List<PostActionPlugin<?>>> postActions = new ConcurrentHashMap<>();
     private final Map<String, List<EventHandlerPlugin<?>>> eventHandlers = new ConcurrentHashMap<>();
+    private final Map<String, SchedulerPlugin<?>> schedulerPlugins = new ConcurrentHashMap<>();
 
     public PluginRegistry(StoreProperties storeProperties,
                           List<PluginFactory> factories,
@@ -55,6 +62,7 @@ public class PluginRegistry {
         initPreActionPlugins();
         initPostActionPlugins();
         initEventHandlersPlugins();
+        initSchedulerPlugins();
     }
 
    private void initVariableProviders() {
@@ -232,6 +240,50 @@ public class PluginRegistry {
 
     public List<EventHandlerPlugin<?>> getEventHandlerPlugins(String key) {
         return eventHandlers.getOrDefault(key, Collections.emptyList());
+    }
+
+    private void initSchedulerPlugins() {
+        List<SchedulerPluginDef> schedulerDefs = storeProperties.getSchedulers();
+        if (schedulerDefs == null || schedulerDefs.isEmpty()) {
+            log.info("No scheduler plugin definitions found in configuration.");
+            return;
+        }
+
+        if (schedulerService == null) {
+            log.warn("SchedulerService not available, skipping scheduler plugin initialization");
+            return;
+        }
+
+        for (var schedulerDef : schedulerDefs) {
+            try {
+                var factory = factories.stream()
+                        .filter(f -> f.getLang().equals(schedulerDef.getLang()))
+                        .findFirst()
+                        .orElseThrow(() ->
+                                new IllegalArgumentException("Unknown scheduler plugin language: " + schedulerDef.getLang() + ", plugin: " + schedulerDef));
+
+                SchedulerPlugin<?> schedulerPlugin = factory.createSchedulerPlugin(schedulerDef);
+                log.info("Created scheduler plugin: {} with language: {}", schedulerDef.getName(), schedulerDef.getLang());
+
+                // Store in registry
+                schedulerPlugins.put(schedulerDef.getName(), schedulerPlugin);
+
+                // Register with scheduler service
+                schedulerService.registerScheduler(schedulerDef.getName(), schedulerPlugin, schedulerDef);
+
+            } catch (Exception e) {
+                log.error("Failed to initialize scheduler plugin: {}", schedulerDef.getName(), e);
+                if (schedulerDef.isExitOnError()) {
+                    throw new RuntimeException("Failed to initialize scheduler plugin: " + schedulerDef.getName(), e);
+                }
+            }
+        }
+
+        log.info("Initialized {} scheduler plugins", schedulerPlugins.size());
+    }
+
+    public SchedulerPlugin<?> getSchedulerPlugin(String name) {
+        return schedulerPlugins.get(name);
     }
 
     @Override

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelStorePluginFactory.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelStorePluginFactory.java
@@ -85,6 +85,16 @@ public class MvelStorePluginFactory implements PluginFactory {
             throw new IllegalArgumentException("No script or inline-script found in event-handler definition for mvel plugin: " + def);
     }
 
+    @Override
+    public <T> SchedulerPlugin<T> createSchedulerPlugin(PluginDef def) {
+        if (def.getExpression() != null)
+            throw new IllegalArgumentException("Expression is not supported for scheduler plugin. Use inline-script or script instead: " + def);
+        else if (def.getInlineScript() != null || def.getScript() != null)
+            return createFromScript(def, PluginType.SCHEDULER);
+        else
+            throw new IllegalArgumentException("No inline-script or script found in scheduler definition for mvel plugin: " + def);
+    }
+
     private <T> MvelScriptStorePlugin<T> createFromScript(PluginDef def, PluginType pluginType) {
         if (def.getScript() != null) {
             var script = def.getScript();

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/impl/spel/SpelStorePluginFactory.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/impl/spel/SpelStorePluginFactory.java
@@ -55,5 +55,10 @@ public class SpelStorePluginFactory implements PluginFactory {
         throw new UnsupportedOperationException("Event Handler plugin is not supported for spel");
     }
 
+    @Override
+    public <T> SchedulerPlugin<T> createSchedulerPlugin(PluginDef def) {
+        throw new UnsupportedOperationException("Scheduler plugin is not supported for spel");
+    }
+
 }
 

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerConfiguration.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerConfiguration.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.yaci.store.plugin.scheduler;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Configuration for scheduler plugin support.
+ * Creates the TaskScheduler bean needed for scheduling plugins.
+ */
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "store.plugins.enabled", havingValue = "true", matchIfMissing = true)
+public class SchedulerConfiguration {
+    
+    @Bean(name = "pluginTaskScheduler")
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);  // Adjust based on expected concurrent schedulers
+        scheduler.setThreadNamePrefix("plugin-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerService.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerService.java
@@ -1,0 +1,297 @@
+package com.bloxbean.cardano.yaci.store.plugin.scheduler;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateService;
+import com.bloxbean.cardano.yaci.store.plugin.variables.VariableProviderFactory;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Service responsible for managing and executing scheduler plugins.
+ * Supports interval-based scheduling for MVP.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final TaskScheduler taskScheduler;
+    private final PluginStateService pluginStateService;
+    private final VariableProviderFactory variableProviderFactory;
+
+    // Track scheduled tasks
+    private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+    private final Map<String, SchedulerPlugin<?>> schedulerPlugins = new ConcurrentHashMap<>();
+    private final Map<String, SchedulerExecutionInfo> executionInfo = new ConcurrentHashMap<>();
+
+    /**
+     * Register a scheduler plugin with the service
+     */
+    public void registerScheduler(String name, SchedulerPlugin<?> plugin, PluginDef pluginDef) {
+        if (!(pluginDef instanceof SchedulerPluginDef)) {
+            log.warn("Plugin definition is not a SchedulerPluginDef, skipping: {}", name);
+            return;
+        }
+
+        SchedulerPluginDef schedulerDef = (SchedulerPluginDef) pluginDef;
+        schedulerPlugins.put(name, plugin);
+
+        try {
+            schedulePlugin(name, plugin, schedulerDef);
+            log.info("Scheduled plugin: {} with schedule: {}", name, schedulerDef.getSchedule());
+        } catch (Exception e) {
+            log.error("Failed to schedule plugin: {}", name, e);
+            if (schedulerDef.isExitOnError()) {
+                throw new RuntimeException("Failed to schedule plugin: " + name, e);
+            }
+        }
+    }
+
+    /**
+     * Schedule a plugin based on its configuration
+     */
+    private void schedulePlugin(String pluginName, SchedulerPlugin<?> plugin, SchedulerPluginDef pluginDef) {
+        SchedulerPluginDef.ScheduleConfig schedule = pluginDef.getSchedule();
+        if (schedule == null) {
+            log.warn("No schedule configuration found for plugin: {}", pluginName);
+            return;
+        }
+
+        Runnable task = createSchedulerTask(pluginName, plugin, pluginDef);
+
+        ScheduledFuture<?> future;
+        switch (schedule.getType()) {
+            case INTERVAL:
+                long intervalSeconds = Long.parseLong(schedule.getValue());
+                future = taskScheduler.scheduleAtFixedRate(task, Duration.ofSeconds(intervalSeconds));
+                log.debug("Scheduled {} with interval of {} seconds", pluginName, intervalSeconds);
+                break;
+
+            case CRON:
+                // TODO: Implement in future enhancement
+                log.warn("CRON scheduling not yet implemented for plugin: {}", pluginName);
+                return;
+
+            case BLOCK:
+                // TODO: Implement in future enhancement
+                log.warn("BLOCK scheduling not yet implemented for plugin: {}", pluginName);
+                return;
+
+            default:
+                throw new IllegalArgumentException("Unsupported schedule type: " + schedule.getType());
+        }
+
+        scheduledTasks.put(pluginName, future);
+        executionInfo.put(pluginName, new SchedulerExecutionInfo(pluginName));
+    }
+
+    /**
+     * Create a runnable task for the scheduler
+     */
+    private Runnable createSchedulerTask(String pluginName, SchedulerPlugin<?> plugin, SchedulerPluginDef pluginDef) {
+        return () -> {
+            try {
+                executeScheduler(pluginName, plugin, pluginDef, false);
+            } catch (Exception e) {
+                log.error("Error executing scheduler plugin: {}", pluginName, e);
+                handleSchedulerError(pluginName, e, pluginDef.isExitOnError());
+            }
+        };
+    }
+
+    /**
+     * Execute a scheduler plugin
+     */
+    private void executeScheduler(String pluginName, SchedulerPlugin<?> plugin, SchedulerPluginDef pluginDef, boolean isManualTrigger) {
+        long startTime = System.currentTimeMillis();
+
+        try {
+            // Update execution info
+            SchedulerExecutionInfo info = executionInfo.get(pluginName);
+            if (info != null) {
+                info.incrementExecutionCount();
+                info.setLastExecutionTime(startTime);
+                info.setStatus(SchedulerStatus.RUNNING);
+            }
+
+            // Prepare variables for injection
+            Map<String, Object> variables = prepareSchedulerVariables(pluginName, pluginDef, startTime, isManualTrigger);
+
+            // Set variables in thread-local context for the plugin to access
+            injectVariables(variables);
+
+            try {
+                // Execute plugin (no parameters - variables are injected)
+                plugin.execute();
+
+                if (info != null) {
+                    info.setStatus(SchedulerStatus.COMPLETED);
+                }
+
+                long duration = System.currentTimeMillis() - startTime;
+                log.debug("Successfully executed scheduler plugin: {} in {}ms", pluginName, duration);
+
+            } finally {
+                // Clear injected variables
+                clearInjectedVariables();
+            }
+
+        } catch (Exception e) {
+            SchedulerExecutionInfo info = executionInfo.get(pluginName);
+            if (info != null) {
+                info.setStatus(SchedulerStatus.FAILED);
+                info.setLastError(e.getMessage());
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Prepare variables for scheduler execution
+     */
+    private Map<String, Object> prepareSchedulerVariables(String pluginName, SchedulerPluginDef pluginDef, long executionTime, boolean isManualTrigger) {
+        Map<String, Object> variables = new HashMap<>();
+
+        // Scheduler-specific variables
+        variables.put("executionTime", executionTime);
+        variables.put("isManualTrigger", isManualTrigger);
+
+        // TODO: Add current block info when blockchain integration is available
+        variables.put("currentBlock", 0L);  // Placeholder
+        variables.put("currentBlockHash", "");  // Placeholder
+
+        // Execution history
+        SchedulerExecutionInfo info = executionInfo.get(pluginName);
+        if (info != null) {
+            variables.put("executionCount", info.getExecutionCount());
+            variables.put("lastExecutionTime", info.getLastExecutionTime());
+        }
+
+        // Custom variables from configuration
+        if (pluginDef.getCustomVariables() != null) {
+            variables.putAll(pluginDef.getCustomVariables());
+        }
+
+        return variables;
+    }
+
+    /**
+     * Inject variables into thread-local context
+     */
+    private void injectVariables(Map<String, Object> variables) {
+        // This will be properly implemented with variable provider factory
+        // For MVP, we'll use a simple approach
+        SchedulerVariableContext.setVariables(variables);
+    }
+
+    /**
+     * Clear injected variables from thread-local context
+     */
+    private void clearInjectedVariables() {
+        SchedulerVariableContext.clearVariables();
+    }
+
+    /**
+     * Handle scheduler execution errors
+     */
+    private void handleSchedulerError(String pluginName, Exception error, boolean exitOnError) {
+        log.error("Scheduler plugin {} failed: {}", pluginName, error.getMessage());
+
+        // Update error info
+        SchedulerExecutionInfo info = executionInfo.get(pluginName);
+        if (info != null) {
+            info.setLastError(error.getMessage());
+            info.setStatus(SchedulerStatus.FAILED);
+        }
+
+        if (exitOnError) {
+            // Cancel the scheduler
+            cancelScheduler(pluginName);
+            log.warn("Scheduler plugin {} has been cancelled due to exitOnError=true", pluginName);
+        }
+    }
+
+    /**
+     * Cancel a scheduled task
+     */
+    public void cancelScheduler(String pluginName) {
+        ScheduledFuture<?> future = scheduledTasks.get(pluginName);
+        if (future != null) {
+            future.cancel(false);
+            scheduledTasks.remove(pluginName);
+
+            SchedulerExecutionInfo info = executionInfo.get(pluginName);
+            if (info != null) {
+                info.setStatus(SchedulerStatus.CANCELLED);
+            }
+
+            log.info("Cancelled scheduler: {}", pluginName);
+        }
+    }
+
+    /**
+     * Get scheduler status information
+     */
+    public Map<String, SchedulerExecutionInfo> getSchedulerStatuses() {
+        return new HashMap<>(executionInfo);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        log.info("Shutting down scheduler service, cancelling all scheduled tasks");
+        for (String pluginName : scheduledTasks.keySet()) {
+            cancelScheduler(pluginName);
+        }
+    }
+
+    /**
+     * Information about scheduler execution
+     */
+    public static class SchedulerExecutionInfo {
+        private final String name;
+        private long executionCount = 0;
+        private Long lastExecutionTime;
+        private String lastError;
+        private SchedulerStatus status = SchedulerStatus.SCHEDULED;
+
+        public SchedulerExecutionInfo(String name) {
+            this.name = name;
+        }
+
+        public synchronized void incrementExecutionCount() {
+            this.executionCount++;
+        }
+
+        // Getters and setters
+        public String getName() { return name; }
+        public long getExecutionCount() { return executionCount; }
+        public Long getLastExecutionTime() { return lastExecutionTime; }
+        public void setLastExecutionTime(Long time) { this.lastExecutionTime = time; }
+        public String getLastError() { return lastError; }
+        public void setLastError(String error) { this.lastError = error; }
+        public SchedulerStatus getStatus() { return status; }
+        public void setStatus(SchedulerStatus status) { this.status = status; }
+    }
+
+    /**
+     * Scheduler status enum
+     */
+    public enum SchedulerStatus {
+        SCHEDULED,
+        RUNNING,
+        COMPLETED,
+        FAILED,
+        CANCELLED
+    }
+}

--- a/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerVariableContext.java
+++ b/components/plugin/src/main/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerVariableContext.java
@@ -1,0 +1,44 @@
+package com.bloxbean.cardano.yaci.store.plugin.scheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Thread-local context for scheduler variables.
+ * Provides a way to inject variables into the execution context of scheduler plugins.
+ */
+public class SchedulerVariableContext {
+    
+    private static final ThreadLocal<Map<String, Object>> CONTEXT = ThreadLocal.withInitial(HashMap::new);
+    
+    /**
+     * Set variables in the current thread's context
+     */
+    public static void setVariables(Map<String, Object> variables) {
+        if (variables != null) {
+            CONTEXT.set(new HashMap<>(variables));
+        }
+    }
+    
+    /**
+     * Get a variable from the current thread's context
+     */
+    public static Object getVariable(String name) {
+        Map<String, Object> variables = CONTEXT.get();
+        return variables != null ? variables.get(name) : null;
+    }
+    
+    /**
+     * Get all variables from the current thread's context
+     */
+    public static Map<String, Object> getVariables() {
+        return new HashMap<>(CONTEXT.get());
+    }
+    
+    /**
+     * Clear variables from the current thread's context
+     */
+    public static void clearVariables() {
+        CONTEXT.remove();
+    }
+}

--- a/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelSchedulerPluginBasicTest.java
+++ b/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelSchedulerPluginBasicTest.java
@@ -1,0 +1,207 @@
+package com.bloxbean.cardano.yaci.store.plugin.impl.mvel;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.PluginType;
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.ScriptDef;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateConfig;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MvelSchedulerPluginBasicTest {
+    static PluginStateConfig pluginStateConfig;
+    static PluginStateService pluginStateService;
+
+    @BeforeAll
+    static void setup() {
+        pluginStateConfig = new PluginStateConfig();
+        pluginStateService = new PluginStateService(pluginStateConfig.globalState(),
+                pluginStateConfig.pluginStates());
+    }
+
+    @Test
+    void createSchedulerPlugin_withInlineScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("state.put('inlineTest', true)");
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        assertThat(schedulerPlugin).isNotNull();
+        assertThat(schedulerPlugin.getName()).isEqualTo("test-scheduler");
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+    }
+
+    @Test
+    void createSchedulerPlugin_withScriptFile() throws IOException {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        String scriptContent = """
+                def executeScheduler() {
+                    state.put('scriptTest', true);
+                }
+                """;
+
+        Path tempScriptFile = Files.createTempFile("scheduler_script", ".mvel");
+        Files.writeString(tempScriptFile, scriptContent);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+
+        ScriptDef scriptDef = new ScriptDef();
+        scriptDef.setFile(tempScriptFile.toFile().getAbsolutePath());
+        scriptDef.setFunction("executeScheduler");
+        pluginDef.setScript(scriptDef);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        assertThat(schedulerPlugin).isNotNull();
+        assertThat(schedulerPlugin.getName()).isEqualTo("test-scheduler");
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+
+        // Clean up
+        Files.deleteIfExists(tempScriptFile);
+    }
+
+    @Test
+    void createSchedulerPlugin_withExpression_throwsException() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setExpression("state.put('created', true)");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> factory.createSchedulerPlugin(pluginDef));
+
+        assertThat(exception.getMessage()).contains("Expression is not supported for scheduler plugin");
+    }
+
+    @Test
+    void createSchedulerPlugin_throwsExceptionWhenNoScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        // No expression, inlineScript, or script set
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> factory.createSchedulerPlugin(pluginDef));
+
+        assertThat(exception.getMessage()).contains("No inline-script or script found in scheduler definition");
+    }
+
+    @Test
+    void executeSchedulerPlugin_withInlineScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("""
+                // Basic test that only uses state
+                counter = state.get('counter');
+                if (counter == null) {
+                    counter = 0;
+                }
+                counter = counter + 1;
+                state.put('counter', counter);
+                """);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute multiple times to test counter
+        schedulerPlugin.execute();
+        schedulerPlugin.execute();
+        schedulerPlugin.execute();
+
+        // Verify state was updated correctly
+        var pluginState = pluginStateService.forPlugin("test-scheduler");
+        assertThat(pluginState.get("counter")).isEqualTo(3);
+    }
+
+    @Test
+    void executeSchedulerPlugin_withScriptFileAndFunction() throws IOException {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        String scriptContent = """
+                def processTask() {
+                    // Basic test that only uses state
+                    tasks = state.get('tasks');
+                    if (tasks == null) {
+                        tasks = [];
+                    }
+                    newTask = ['executed': true];
+                    tasks.add(newTask);
+                    state.put('tasks', tasks);
+                    state.put('lastProcessed', true);
+                }
+                """;
+
+        Path tempScriptFile = Files.createTempFile("scheduler_script", ".mvel");
+        Files.writeString(tempScriptFile, scriptContent);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("task-scheduler");
+        pluginDef.setLang("mvel");
+
+        ScriptDef scriptDef = new ScriptDef();
+        scriptDef.setFile(tempScriptFile.toFile().getAbsolutePath());
+        scriptDef.setFunction("processTask");
+        pluginDef.setScript(scriptDef);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute scheduler
+        schedulerPlugin.execute();
+
+        // Verify state
+        var pluginState = pluginStateService.forPlugin("task-scheduler");
+        assertThat(pluginState.get("lastProcessed")).isEqualTo(true);
+
+        @SuppressWarnings("unchecked")
+        var tasks = (java.util.List<java.util.Map<String, Object>>) pluginState.get("tasks");
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).get("executed")).isEqualTo(true);
+
+        // Clean up
+        Files.deleteIfExists(tempScriptFile);
+    }
+
+    @Test
+    void schedulerPlugin_implementsCorrectInterface() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, null);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("interface-test");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("state.put('interfaceTest', true)");
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Verify it implements the SchedulerPlugin interface correctly
+        assertThat(schedulerPlugin).isInstanceOf(SchedulerPlugin.class);
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+
+        // Should be able to call execute() without parameters
+        schedulerPlugin.execute();
+
+        // Verify it executed
+        var pluginState = pluginStateService.forPlugin("interface-test");
+        assertThat(pluginState.get("interfaceTest")).isEqualTo(true);
+    }
+}

--- a/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelSchedulerPluginTest.java
+++ b/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/impl/mvel/MvelSchedulerPluginTest.java
@@ -1,0 +1,251 @@
+package com.bloxbean.cardano.yaci.store.plugin.impl.mvel;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.PluginType;
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.ScriptDef;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateConfig;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateService;
+import com.bloxbean.cardano.yaci.store.plugin.variables.VariableProviderFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MvelSchedulerPluginTest {
+    static PluginStateConfig pluginStateConfig;
+    static PluginStateService pluginStateService;
+    static VariableProviderFactory variableProviderFactory;
+
+    @BeforeAll
+    static void setup() {
+        pluginStateConfig = new PluginStateConfig();
+        pluginStateService = new PluginStateService(pluginStateConfig.globalState(),
+                pluginStateConfig.pluginStates());
+    }
+
+    @BeforeEach
+    void setupEach() {
+        // For basic tests, we'll use null variableProviderFactory like existing tests
+        variableProviderFactory = null;
+    }
+
+    @Test
+    void createSchedulerPlugin_withExpression_throwsException() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setExpression("state.put('created', true)");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> factory.createSchedulerPlugin(pluginDef));
+
+        assertThat(exception.getMessage()).contains("Expression is not supported for scheduler plugin");
+    }
+
+    @Test
+    void createSchedulerPlugin_withInlineScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("""
+                state.put('inlineTest', true);
+                """);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        assertThat(schedulerPlugin).isNotNull();
+        assertThat(schedulerPlugin.getName()).isEqualTo("test-scheduler");
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+    }
+
+    @Test
+    void createSchedulerPlugin_withScriptFile() throws IOException {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        String scriptContent = """
+                def executeScheduler() {
+                    state.put('scriptTest', true);
+                }
+                """;
+
+        Path tempScriptFile = Files.createTempFile("scheduler_script", ".mvel");
+        Files.writeString(tempScriptFile, scriptContent);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+
+        ScriptDef scriptDef = new ScriptDef();
+        scriptDef.setFile(tempScriptFile.toFile().getAbsolutePath());
+        scriptDef.setFunction("executeScheduler");
+        pluginDef.setScript(scriptDef);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        assertThat(schedulerPlugin).isNotNull();
+        assertThat(schedulerPlugin.getName()).isEqualTo("test-scheduler");
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+
+        // Clean up
+        Files.deleteIfExists(tempScriptFile);
+    }
+
+    @Test
+    void createSchedulerPlugin_throwsExceptionWhenNoScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        // No expression, inlineScript, or script set
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> factory.createSchedulerPlugin(pluginDef));
+
+        assertThat(exception.getMessage()).contains("No inline-script or script found in scheduler definition");
+    }
+
+
+    @Test
+    void executeSchedulerPlugin_withInlineScript() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("""
+                // Simulate a scheduled task
+                counter = state.get('counter');
+                if (counter == null) counter = 0;
+                counter = counter + 1;
+                state.put("counter", counter);
+                """);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute multiple times to test counter
+        schedulerPlugin.execute();
+        schedulerPlugin.execute();
+        schedulerPlugin.execute();
+
+        // Verify state was updated correctly
+        var pluginState = pluginStateService.forPlugin("test-scheduler");
+        assertThat(pluginState.get("counter")).isEqualTo(3);
+    }
+
+    @Test
+    void executeSchedulerPlugin_withScriptFileAndFunction() throws IOException {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        String scriptContent = """
+                def processMetrics() {
+                    // Simulate metrics processing
+                    metrics = state.get('metrics');
+                    if (metrics == null) metrics = [];
+                    newMetric = [
+                        'executed': true
+                    ];
+                    metrics.add(newMetric);
+                    state.put('metrics', metrics);
+                    state.put('lastProcessed', true);
+                }
+                """;
+
+        Path tempScriptFile = Files.createTempFile("scheduler_script", ".mvel");
+        Files.writeString(tempScriptFile, scriptContent);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("metrics-scheduler");
+        pluginDef.setLang("mvel");
+
+        ScriptDef scriptDef = new ScriptDef();
+        scriptDef.setFile(tempScriptFile.toFile().getAbsolutePath());
+        scriptDef.setFunction("processMetrics");
+        pluginDef.setScript(scriptDef);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute scheduler
+        schedulerPlugin.execute();
+
+        // Verify state
+        var pluginState = pluginStateService.forPlugin("metrics-scheduler");
+        assertThat(pluginState.get("lastProcessed")).isEqualTo(true);
+
+        @SuppressWarnings("unchecked")
+        var metrics = (java.util.List<Map<String, Object>>) pluginState.get("metrics");
+        assertThat(metrics).hasSize(1);
+        assertThat(metrics.get(0).get("executed")).isEqualTo(true);
+
+        // Clean up
+        Files.deleteIfExists(tempScriptFile);
+    }
+
+    @Test
+    void executeSchedulerPlugin_basicExecution() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("basic-test-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("""
+                // Test basic execution
+                state.put('basicTest', true);
+                """);
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute scheduler
+        schedulerPlugin.execute();
+
+        // Verify execution worked
+        var pluginState = pluginStateService.forPlugin("basic-test-scheduler");
+        assertThat(pluginState.get("basicTest")).isEqualTo(true);
+    }
+
+    @Test
+    void executeSchedulerPlugin_handlesErrors() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("error-scheduler");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("undefinedVariable.someMethod();"); // This should cause an error
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Execute should throw an exception
+        assertThrows(Exception.class, schedulerPlugin::execute);
+    }
+
+    @Test
+    void schedulerPlugin_implementsCorrectInterface() {
+        MvelStorePluginFactory factory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        PluginDef pluginDef = new PluginDef();
+        pluginDef.setName("interface-test");
+        pluginDef.setLang("mvel");
+        pluginDef.setInlineScript("state.put('interfaceTest', true)");
+
+        SchedulerPlugin<Object> schedulerPlugin = factory.createSchedulerPlugin(pluginDef);
+
+        // Verify it implements the SchedulerPlugin interface correctly
+        assertThat(schedulerPlugin).isInstanceOf(SchedulerPlugin.class);
+        assertThat(schedulerPlugin.getPluginType()).isEqualTo(PluginType.SCHEDULER);
+
+        // Should be able to call execute() without parameters
+        schedulerPlugin.execute();
+    }
+}

--- a/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerServiceIntegrationTest.java
+++ b/components/plugin/src/test/java/com/bloxbean/cardano/yaci/store/plugin/scheduler/SchedulerServiceIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.bloxbean.cardano.yaci.store.plugin.scheduler;
+
+import com.bloxbean.cardano.yaci.store.plugin.api.SchedulerPlugin;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateConfig;
+import com.bloxbean.cardano.yaci.store.plugin.cache.PluginStateService;
+import com.bloxbean.cardano.yaci.store.plugin.impl.mvel.MvelStorePluginFactory;
+import com.bloxbean.cardano.yaci.store.plugin.variables.VariableProviderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for SchedulerService with actual scheduling
+ */
+public class SchedulerServiceIntegrationTest {
+
+    private SchedulerService schedulerService;
+    private PluginStateService pluginStateService;
+    private MvelStorePluginFactory mvelFactory;
+    private ThreadPoolTaskScheduler taskScheduler;
+
+    @BeforeEach
+    void setup() {
+        // Setup task scheduler
+        taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(5);
+        taskScheduler.setThreadNamePrefix("test-scheduler-");
+        taskScheduler.initialize();
+
+        // Setup plugin state service
+        PluginStateConfig pluginStateConfig = new PluginStateConfig();
+        pluginStateService = new PluginStateService(
+            pluginStateConfig.globalState(),
+            pluginStateConfig.pluginStates()
+        );
+
+        // Setup variable provider factory (can be null for basic test)
+        VariableProviderFactory variableProviderFactory = new VariableProviderFactory(null);
+
+        // Setup MVEL factory
+        mvelFactory = new MvelStorePluginFactory(pluginStateService, variableProviderFactory);
+
+        // Create scheduler service
+        schedulerService = new SchedulerService(taskScheduler, pluginStateService, variableProviderFactory);
+    }
+
+    @Test
+    void testSchedulerExecutesAtInterval() throws InterruptedException {
+        // Create a scheduler plugin definition
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-interval-scheduler");
+        schedulerDef.setLang("mvel");
+        schedulerDef.setInlineScript("""
+            // Increment counter on each execution
+            counter = state.get('counter');
+            if (counter == null) {
+                counter = 0;
+            }
+            counter = counter + 1;
+            state.put('counter', counter);
+            state.put('lastExecution', executionTime);
+            logger.info("Scheduler executed, counter: " + counter);
+            """);
+        schedulerDef.setExitOnError(false);
+
+        // Set schedule for every 1 second
+        SchedulerPluginDef.ScheduleConfig schedule = new SchedulerPluginDef.ScheduleConfig();
+        schedule.setType(SchedulerPluginDef.ScheduleType.INTERVAL);
+        schedule.setValue("1"); // 1 second interval
+        schedulerDef.setSchedule(schedule);
+
+        // Create the plugin
+        SchedulerPlugin<?> plugin = mvelFactory.createSchedulerPlugin(schedulerDef);
+
+        // Register with scheduler service
+        schedulerService.registerScheduler(schedulerDef.getName(), plugin, schedulerDef);
+
+        // Wait for scheduler to execute at least 3 times
+        Thread.sleep(3500); // Wait 3.5 seconds
+
+        // Check that the scheduler has executed multiple times
+        var pluginState = pluginStateService.forPlugin("test-interval-scheduler");
+        Integer counter = (Integer) pluginState.get("counter");
+        assertThat(counter).isNotNull();
+        assertThat(counter).isGreaterThanOrEqualTo(3);
+
+        // Check last execution time was set
+        Long lastExecution = (Long) pluginState.get("lastExecution");
+        assertThat(lastExecution).isNotNull();
+        assertThat(lastExecution).isGreaterThan(0);
+
+        // Clean up
+        schedulerService.cancelScheduler(schedulerDef.getName());
+    }
+
+    @Test
+    void testSchedulerWithCustomVariables() throws InterruptedException {
+        // Create a scheduler with custom variables
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-custom-vars-scheduler");
+        schedulerDef.setLang("mvel");
+        schedulerDef.setInlineScript("""
+            // Access custom variables
+            multiplier = customMultiplier;
+            if (multiplier == null) {
+                multiplier = 1;
+            }
+            
+            value = state.get('value');
+            if (value == null) {
+                value = 1;
+            }
+            value = value * multiplier;
+            state.put('value', value);
+            state.put('customGreeting', customGreeting);
+            logger.info("Value updated to: " + value);
+            """);
+        schedulerDef.setExitOnError(false);
+
+        // Set custom variables
+        Map<String, Object> customVars = new HashMap<>();
+        customVars.put("customMultiplier", 2);
+        customVars.put("customGreeting", "Hello from scheduler!");
+        schedulerDef.setCustomVariables(customVars);
+
+        // Set schedule
+        SchedulerPluginDef.ScheduleConfig schedule = new SchedulerPluginDef.ScheduleConfig();
+        schedule.setType(SchedulerPluginDef.ScheduleType.INTERVAL);
+        schedule.setValue("1");
+        schedulerDef.setSchedule(schedule);
+
+        // Create and register plugin
+        SchedulerPlugin<?> plugin = mvelFactory.createSchedulerPlugin(schedulerDef);
+        schedulerService.registerScheduler(schedulerDef.getName(), plugin, schedulerDef);
+
+        // Wait for execution
+        Thread.sleep(2500); // Wait 2.5 seconds for at least 2 executions
+
+        // Verify custom variables were used
+        var pluginState = pluginStateService.forPlugin("test-custom-vars-scheduler");
+        Integer value = (Integer) pluginState.get("value");
+        assertThat(value).isNotNull();
+        assertThat(value).isGreaterThanOrEqualTo(2); // Should be at least 2 after first execution
+
+        String greeting = (String) pluginState.get("customGreeting");
+        assertThat(greeting).isEqualTo("Hello from scheduler!");
+
+        // Clean up
+        schedulerService.cancelScheduler(schedulerDef.getName());
+    }
+
+    @Test
+    void testSchedulerCancellation() throws InterruptedException {
+        // Create a scheduler
+        SchedulerPluginDef schedulerDef = new SchedulerPluginDef();
+        schedulerDef.setName("test-cancel-scheduler");
+        schedulerDef.setLang("mvel");
+        schedulerDef.setInlineScript("""
+            executions = state.get('executions');
+            if (executions == null) {
+                executions = 0;
+            }
+            executions = executions + 1;
+            state.put('executions', executions);
+            """);
+        schedulerDef.setExitOnError(false);
+
+        SchedulerPluginDef.ScheduleConfig schedule = new SchedulerPluginDef.ScheduleConfig();
+        schedule.setType(SchedulerPluginDef.ScheduleType.INTERVAL);
+        schedule.setValue("1");
+        schedulerDef.setSchedule(schedule);
+
+        SchedulerPlugin<?> plugin = mvelFactory.createSchedulerPlugin(schedulerDef);
+        schedulerService.registerScheduler(schedulerDef.getName(), plugin, schedulerDef);
+
+        // Let it run for 2 seconds
+        Thread.sleep(2000);
+
+        // Cancel the scheduler
+        schedulerService.cancelScheduler(schedulerDef.getName());
+
+        // Get execution count at cancellation
+        var pluginState = pluginStateService.forPlugin("test-cancel-scheduler");
+        Integer executionsAtCancel = (Integer) pluginState.get("executions");
+
+        // Wait another 2 seconds
+        Thread.sleep(2000);
+
+        // Verify execution count hasn't increased
+        Integer executionsAfterWait = (Integer) pluginState.get("executions");
+        assertThat(executionsAfterWait).isEqualTo(executionsAtCancel);
+
+        // Verify status
+        Map<String, SchedulerService.SchedulerExecutionInfo> statuses = schedulerService.getSchedulerStatuses();
+        SchedulerService.SchedulerExecutionInfo info = statuses.get("test-cancel-scheduler");
+        assertThat(info).isNotNull();
+        assertThat(info.getStatus()).isEqualTo(SchedulerService.SchedulerStatus.CANCELLED);
+    }
+
+    // TODO: Add error handling test - requires better MVEL error simulation
+}

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -242,6 +242,7 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setPreActions(properties.getPlugins().getPreActions());
         storeProperties.setPostActions(properties.getPlugins().getPostActions());
         storeProperties.setEventHandlers(properties.getPlugins().getEventHandlers());
+        storeProperties.setSchedulers(properties.getPlugins().getSchedulers());
 
         storeProperties.setPythonVenv(properties.getPlugins().getPython().getVenv());
         storeProperties.setPluginGlobalScripts(properties.getPlugins().getScripts());

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.store.starter.core;
 
 import com.bloxbean.cardano.yaci.store.plugin.api.config.PluginDef;
+import com.bloxbean.cardano.yaci.store.plugin.api.config.SchedulerPluginDef;
 import com.bloxbean.cardano.yaci.store.plugin.api.config.ScriptRef;
 import lombok.Getter;
 import lombok.Setter;
@@ -128,6 +129,7 @@ public class YaciStoreProperties {
         private Map<String, List<PluginDef>> preActions = new HashMap<>();
         private Map<String, List<PluginDef>> postActions = new HashMap<>();
         private Map<String, List<PluginDef>> eventHandlers = new HashMap<>();
+        private List<SchedulerPluginDef> schedulers = new ArrayList<>();
 
         private PythonSettings python = new PythonSettings();
     }


### PR DESCRIPTION
 - Add SchedulerPlugin interface and SchedulerPluginDef configuration
 - Implement SchedulerService with Spring TaskScheduler integration
 - Add scheduler variable context for runtime variable injection
 - Support interval-based scheduling with configurable error handling
 - Extend plugin factories (MVEL, SpEL, JavaScript, Python) with scheduler support
 - Add polyglot converter utilities for complex object handling in scripts
- Add comprehensive integration tests for all plugin types
 - Configure scheduler in Spring Boot starter with conditional loading
 
 **Example:**
 
 ```
 store:
  plugins:
    enabled: true
    
    # Scheduler plugins configuration
    schedulers:
      # Example 1: Simple interval-based scheduler using MVEL
      - name: "metrics-logger"
        lang: "mvel"
        schedule:
          type: "INTERVAL"
          value: "60"  # Execute every 60 seconds
        inlineScript: |
          // Log metrics every minute
          executionNum = state.get('executionNumber');
          if (executionNum == null) {
              executionNum = 0;
          }
          executionNum = executionNum + 1;
          state.put('executionNumber', executionNum);
 ```