### PR TITLE
governance: correct committee member expiration in handling ratified UpdateCommittee proposal

### DIFF
--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/processor/CommitteeMemberProcessor.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/processor/CommitteeMemberProcessor.java
@@ -159,7 +159,7 @@ public class CommitteeMemberProcessor {
                     updatedCommitteeMembers.add(CommitteeMember.builder()
                             .hash(credential.getHash())
                             .startEpoch(epoch)
-                            .expiredEpoch(epoch + term)
+                            .expiredEpoch(term)
                             .credType(credential.getType().equals(StakeCredType.ADDR_KEYHASH)
                                     ? CredentialType.ADDR_KEYHASH
                                     : CredentialType.SCRIPTHASH)

--- a/stores/governance/src/test/java/com/bloxbean/cardano/yaci/store/governance/processor/CommitteeMemberProcessorTest.java
+++ b/stores/governance/src/test/java/com/bloxbean/cardano/yaci/store/governance/processor/CommitteeMemberProcessorTest.java
@@ -60,7 +60,7 @@ class CommitteeMemberProcessorTest {
         Credential newMember2 = new Credential(StakeCredType.SCRIPTHASH, "ffffff06fd4e8f51062dc431362369b2a43140abced8aa2ff2256d7b");
 
         UpdateCommittee updateCommittee = new UpdateCommittee(null, Set.of(removedMember1, removedMember2),
-                Map.of(newMember1, 50, newMember2, 60),
+                Map.of(newMember1, 150, newMember2, 160),
                 UnitInterval.fromString("75/100"));
 
         GovActionProposal proposal = GovActionProposal
@@ -118,14 +118,14 @@ class CommitteeMemberProcessorTest {
 
         assertThat(savedMembers.stream().anyMatch(member -> member.getHash().equals("eeeeee06fd4e8f51062dc431362369b2a43140abced8aa2ff2256d7b")
                 && member.getStartEpoch() == 101
-                && member.getExpiredEpoch() == 151
+                && member.getExpiredEpoch() == 150
                 && member.getCredType() == CredentialType.ADDR_KEYHASH
                 && member.getSlot() == 6000L))
                 .isTrue();
 
         assertThat(savedMembers.stream().anyMatch(member -> member.getHash().equals("ffffff06fd4e8f51062dc431362369b2a43140abced8aa2ff2256d7b")
                 && member.getStartEpoch() == 101
-                && member.getExpiredEpoch() == 161
+                && member.getExpiredEpoch() == 160
                 && member.getCredType() == CredentialType.SCRIPTHASH
                 && member.getSlot() == 6000L))
                 .isTrue();


### PR DESCRIPTION
Governance: correct committee member expiration 
  - Treat the term in newMembersAndTerms as an  expiry epoch, not a relative offset.
  - Previously used epoch + term, inflating expirations for newly added members.
  - Aligns with ledger semantics and GovernanceActionUtil.isValidCommitteeTerm.
  
  #727 