### PR TITLE
 (governance-aggr-api): add 'DROPPED' proposal status, derive proposal status from AdaPot jobs

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/api/governanceaggr/dto/ProposalStatus.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/api/governanceaggr/dto/ProposalStatus.java
@@ -4,5 +4,6 @@ public enum ProposalStatus {
     LIVE,
     RATIFIED,
     EXPIRED,
+    DROPPED,
     ENACTED
 }

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/storage/impl/GovActionProposalStatusStorageReaderImpl.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/storage/impl/GovActionProposalStatusStorageReaderImpl.java
@@ -1,13 +1,8 @@
 package com.bloxbean.cardano.yaci.store.governanceaggr.storage.impl;
 
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
-import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
-import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
-import com.bloxbean.cardano.yaci.store.common.util.JsonUtil;
 import com.bloxbean.cardano.yaci.store.governanceaggr.domain.GovActionProposalStatus;
-import com.bloxbean.cardano.yaci.store.governanceaggr.domain.ProposalVotingStats;
 import com.bloxbean.cardano.yaci.store.governanceaggr.storage.GovActionProposalStatusStorageReader;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.Field;


### PR DESCRIPTION
  - Replace EpochParamStorage with AdaPotJobStorage to base proposal status on the last completed AdaPot job epoch
  - Add DROPPED proposal status and update corresponding logic
  - Refactor proposal DTO construction into a method