### PR TITLE
feat: add signer registry and remote signer SPI for QuickTx refs

### DIFF
--- a/adr/ADR-002-signer-ref-resolution.md
+++ b/adr/ADR-002-signer-ref-resolution.md
@@ -1,0 +1,96 @@
+# ADR-002: Signer reference resolution for TxPlan / QuickTx
+
+## Status
+Proposed
+
+## Context
+- QuickTx YAML (`TxPlan`) supports `from_ref`, `fee_payer_ref`, `collateral_payer_ref`, and `signer` references. These are resolved through `SignerRegistry` when building or signing transactions.
+- The submit component currently builds unsigned tx bodies from YAML without any registry, so any `_ref` values would fail (`TxBuildException: ... no SignerRegistry configured`).
+- We want clients to author YAML using stable references (e.g., `account://alice`, `wallet://ops`, `policy://nft`, `remote://alice`) while the server maps those to concrete signers/addresses.
+- Some signers may live on remote services (e.g., dripdropz/remote-signer in Rust) rather than local key material.
+
+## Goals
+- Define how signer references are configured and resolved on the server.
+- Allow `from_ref` to auto-populate sender/change/collateral addresses and signers during build/sign.
+- Support remote signing endpoints as a signer type (e.g., dripdropz remote-signer).
+- Keep YAML portable and free of sensitive key material.
+
+## Non-Goals
+- Define the full key management story (HSM, KMS) — only the reference and resolution model.
+- Change TxPlan YAML schema; we will leverage existing `*_ref` and `signers` fields.
+
+## Decision / Proposal
+- Introduce a `SignerRegistry` bean in the submit module, wired into `QuickTxBuilder.compose(plan, registry)`, so TxPlanBuildService and future sign flows can resolve references.
+- Registry entries are configured server-side (Spring config/yaml). Each entry binds a `ref` URI to a resolver that can:
+  - Provide a preferred address (for `from_ref`, `fee_payer_ref`, `collateral_payer_ref`).
+  - Provide a signer for one or more scopes (`payment`, `stake`, `drep`, `committeeCold`, `committeeHot`, `policy`).
+  - Optionally provide a wallet object when available to let QuickTx set sender/change addresses automatically.
+- Supported signer types (initial):
+  - `local-key`: payment/stake/policy keys stored locally (file/keystore/env); produces a `TxSigner`.
+  - `local-wallet`: HD wallet seed or xprv/xpub; can yield both address and signer.
+  - `remote-signer`: HTTP client that delegates signing to an external service (e.g., dripdropz/remote-signer). Needs endpoint, auth, and scope mapping. The signer implementation should call the remote service with the CBOR to sign and return witnesses.
+  - `address-only`: supplies an address for `from_ref`/payers without signing (useful for build-only flows).
+- Example configuration (shape to be refined in code):
+
+```yaml
+store:
+  submit:
+    signer-registry:
+      entries:
+        - ref: account://alice
+          type: local-wallet
+          scopes: [payment, stake]
+          wallet:
+            mnemonic: ${ALICE_MNEMONIC}
+            accountIndex: 0
+        - ref: policy://nft
+          type: local-key
+          scopes: [policy]
+          keys:
+            paymentSkey: file:/keys/policy.skey
+        - ref: remote://ops
+          type: remote-signer
+          scopes: [payment, stake, policy]
+          remote:
+            baseUrl: https://remote-signer.example.com
+            authToken: ${REMOTE_SIGNER_TOKEN}
+            keyId: ops-key-1
+        - ref: wallet://treasury
+          type: address-only
+          scopes: [payment]
+          address: addr1...
+```
+
+- For remote signer support:
+  - Define an interface (e.g., `RemoteSignerClient`) so implementations can target dripdropz/remote-signer or other services.
+  - Map signer scope to remote key id or role; include auth headers.
+  - Ensure we never ship private keys to clients; all signing happens server-side or remote-side.
+
+## Notes on behavior
+- If a TxPlan uses `_ref` fields, TxPlanBuildService must call `quickTxBuilder.compose(plan, signerRegistry)` instead of `compose(plan)`.
+- Build-only flows can still work with `address-only` entries; signing flows will require actual signer-capable types.
+- Missing or unresolved references should fail fast with a clear error naming the ref and scope.
+- We should log reference resolution at debug level, but never log key material or tokens.
+
+## Remote signer integration options
+- Treat `remote://*` refs as `TxSigner` producers that delegate signing to a remote service. Server-side registry entries map the ref to a client bean plus routing metadata (key id, scopes, auth).
+- Initial target (per PR discussion https://github.com/bloxbean/cardano-client-lib/pull/542#issuecomment-3468098461): DripDropz [`remote-signer`](https://github.com/dripdropz/remote-signer).
+  - gRPC bidirectional stream (`RemoteSigner.ConnectToServer` in `protos/remote_signer.proto`).
+  - Handshake: client sends `address + vkey + challenge + challenge_signature`; server replies with a signed challenge to confirm the host master key (mitm protection) before any signing happens.
+  - Signing: server streams `TransactionMessage {request_id, cbor}` where `cbor` is the tx body; client signs the tx hash with the configured key and replies with `SignatureMessage {request_id, signature}`.
+  - Keepalive: ping/pong on the same stream.
+- Wrap the gRPC client in a `RemoteSignerClient` abstraction so we can plug in other remote schemes (HTTP, different protos) without changing registry wiring.
+- Security: enforce bearer/JWT auth, verify the server master key from config, and pin allowed scopes per registry entry. Never log tokens or key material; emit structured errors/metrics instead.
+
+## Implementation sketch / next steps
+- Add a Spring-configured `SignerRegistry` bean in the submit component that loads entries from `store.submit.signer-registry`.
+- Model entry types for `local-wallet`, `local-key`, `address-only`, and `remote-signer` (endpoint, auth token/credentials, key id, allowed scopes).
+- Wire `TxPlanBuildService` to prefer `quickTxBuilder.compose(plan, signerRegistry)` when the registry exists (already supported by QuickTx).
+- Provide a `RemoteSignerClient` SPI plus a DripDropz implementation using the proto above (Netty gRPC, TLS, bearer auth, host-key pin). Map `remote://ref` → `(client, keyId)` → `TxSigner`.
+- Validate and fail fast on unknown refs or unsupported scopes; once the registry is wired, document YAML examples in `components/submit/README.md`.
+
+## Open Questions
+- How to store secrets (mnemonics, skeys, remote tokens) securely in deployments (Vault/K8s secrets)?
+- Should we allow per-signer policy restricting scopes (e.g., remote signer only for policy keys)?
+- Do we need hot-reload of registry entries without restart?
+- What wire format does the remote signer expect/return (CBOR tx body, witness set)? Align with dripdropz API before implementation.

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/config/SignerRegistryConfiguration.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/config/SignerRegistryConfiguration.java
@@ -1,0 +1,166 @@
+package com.bloxbean.cardano.yaci.store.submit.config;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.common.model.Network;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.quicktx.signing.DefaultSignerRegistry;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import com.bloxbean.cardano.client.quicktx.signing.SignerRegistry;
+import com.bloxbean.cardano.client.quicktx.signing.SignerScopes;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.submit.signing.AddressOnlySignerBinding;
+import com.bloxbean.cardano.yaci.store.submit.signing.AccountSignerBinding;
+import com.bloxbean.cardano.yaci.store.submit.signing.RemoteSignerBinding;
+import com.bloxbean.cardano.yaci.store.submit.signing.ScopedSignerBinding;
+import com.bloxbean.cardano.yaci.store.submit.signing.remote.RemoteSignerClient;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.AccountProperties;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.AddressOnlyProperties;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.Entry;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.RemoteSignerProperties;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.SignerType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Binds signer-registry configuration into a QuickTx SignerRegistry.
+ */
+@Configuration
+@EnableConfigurationProperties(SubmitSignerRegistryProperties.class)
+@ConditionalOnProperty(prefix = "store.submit.signer-registry", name = "enabled", havingValue = "true")
+@Slf4j
+public class SignerRegistryConfiguration {
+
+    @Bean
+    public SignerRegistry submitSignerRegistry(SubmitSignerRegistryProperties properties,
+                                               Environment environment,
+                                               Optional<RemoteSignerClient> remoteSignerClientOpt) {
+
+        var registry = new DefaultSignerRegistry();
+        Network network = resolveNetwork(environment);
+
+        for (Entry entry : properties.getEntries()) {
+            if (entry == null) continue;
+
+            String ref = entry.getRef();
+            if (!StringUtils.hasText(ref)) {
+                log.warn("Ignoring signer-registry entry without ref");
+                continue;
+            }
+
+            SignerType type = Optional.ofNullable(entry.getType()).orElse(SignerType.ACCOUNT);
+            Set<String> scopes = normalizeScopes(entry.getScopes());
+
+            try {
+                switch (type) {
+                    case ACCOUNT -> {
+                        AccountProperties accountProps = entry.getAccount();
+                        Account account = buildAccount(ref, accountProps, network);
+                        if (account == null) {
+                            continue;
+                        }
+
+                        SignerBinding binding = new AccountSignerBinding(account);
+                        binding = new ScopedSignerBinding(ref, binding, scopes);
+                        registry.addCustom(ref, binding);
+                        log.info("Registered account signer ref={} scopes={}", ref, scopes);
+                    }
+                    case ADDRESS_ONLY -> {
+                        AddressOnlyProperties addressProps = entry.getAddress();
+                        if (addressProps == null || !StringUtils.hasText(addressProps.getAddress())) {
+                            log.warn("Address-only signer ref={} ignored: address missing", ref);
+                            continue;
+                        }
+                        var binding = new AddressOnlySignerBinding(ref, addressProps.getAddress(), scopes);
+                        registry.addCustom(ref, binding);
+                        log.info("Registered address-only signer ref={} scopes={}", ref, scopes);
+                    }
+                    case REMOTE_SIGNER -> {
+                        if (remoteSignerClientOpt.isEmpty()) {
+                            throw new IllegalStateException("Remote signer ref=" + ref + " configured but no RemoteSignerClient bean found");
+                        }
+                        RemoteSignerProperties remoteProps = entry.getRemote();
+                        if (remoteProps == null || !StringUtils.hasText(remoteProps.getKeyId())) {
+                            log.warn("Remote signer ref={} ignored: keyId missing", ref);
+                            continue;
+                        }
+
+                        var binding = new RemoteSignerBinding(ref, scopes, remoteProps, remoteSignerClientOpt.get());
+                        registry.addCustom(ref, binding);
+                        log.info("Registered remote signer ref={} scopes={}", ref, scopes);
+                    }
+                    default -> log.warn("Unsupported signer type {} for ref {}", type, ref);
+                }
+            } catch (RuntimeException e) {
+                log.error("Failed to register signer ref={}: {}", ref, e.getMessage(), e);
+            }
+        }
+
+        return registry;
+    }
+
+    private Network resolveNetwork(Environment environment) {
+        long protocolMagic = environment.getProperty("store.cardano.protocol-magic", Long.class, Networks.preprod().getProtocolMagic());
+
+        if (protocolMagic == Networks.mainnet().getProtocolMagic()) {
+            return Networks.mainnet();
+        } else if (protocolMagic == Networks.preprod().getProtocolMagic()) {
+            return Networks.preprod();
+        } else if (protocolMagic == Networks.preview().getProtocolMagic()) {
+            return Networks.preview();
+        }
+
+        int networkId = protocolMagic == Networks.mainnet().getProtocolMagic() ? 1 : 0;
+        return new Network(networkId, protocolMagic);
+    }
+
+    private Set<String> normalizeScopes(Set<String> scopes) {
+        if (CollectionUtils.isEmpty(scopes)) {
+            return Set.of(SignerScopes.PAYMENT.toLowerCase(Locale.ROOT));
+        }
+
+        return scopes.stream()
+                .filter(StringUtils::hasText)
+                .map(scope -> scope.trim().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    private Account buildAccount(String ref, AccountProperties account, Network network) {
+        if (account == null) {
+            log.warn("Signer ref={} ignored: account details missing", ref);
+            return null;
+        }
+
+        try {
+            if (StringUtils.hasText(account.getMnemonic())) {
+                return Account.createFromMnemonic(network, account.getMnemonic(), account.getAccount(), account.getIndex());
+            }
+
+            if (StringUtils.hasText(account.getRootKeyHex())) {
+                byte[] rootKey = HexUtil.decodeHexString(account.getRootKeyHex());
+                return Account.createFromRootKey(network, rootKey, account.getAccount(), account.getIndex());
+            }
+
+            if (StringUtils.hasText(account.getBech32PrivateKey())) {
+                return new Account(network, account.getBech32PrivateKey(), account.getIndex());
+            }
+        } catch (Exception e) {
+            log.error("Failed to build account signer ref={}: {}", ref, e.getMessage(), e);
+            return null;
+        }
+
+        log.warn("Signer ref={} ignored: no key material provided", ref);
+        return null;
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/config/SubmitSignerRegistryProperties.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/config/SubmitSignerRegistryProperties.java
@@ -1,0 +1,94 @@
+package com.bloxbean.cardano.yaci.store.submit.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ConfigurationProperties(prefix = "store.submit.signer-registry")
+public class SubmitSignerRegistryProperties {
+    private boolean enabled;
+
+    @Builder.Default
+    private List<Entry> entries = new ArrayList<>();
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Entry {
+        private String ref;
+        private SignerType type;
+
+        @Builder.Default
+        private Set<String> scopes = new HashSet<>();
+
+        private AccountProperties account;
+        private AddressOnlyProperties address;
+        private RemoteSignerProperties remote;
+    }
+
+    public enum SignerType {
+        ACCOUNT,
+        ADDRESS_ONLY,
+        REMOTE_SIGNER
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AccountProperties {
+        /**
+         * Mnemonic for the local account/wallet.
+         */
+        private String mnemonic;
+
+        /**
+         * Optional bech32 / hex private key material for account creation.
+         */
+        private String bech32PrivateKey;
+        private String rootKeyHex;
+
+        /**
+         * Derivation indexes when using mnemonic / root keys.
+         */
+        @Builder.Default
+        private int account = 0;
+
+        @Builder.Default
+        private int index = 0;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AddressOnlyProperties {
+        private String address;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RemoteSignerProperties {
+        private String endpoint;
+        private String authToken;
+        private String keyId;
+        private String hostPublicKey;
+        private String verificationKey;
+        private String address;
+        private Integer timeoutMs;
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/AccountSignerBinding.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/AccountSignerBinding.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.store.submit.signing;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.client.function.helper.SignerProviders;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import com.bloxbean.cardano.hdwallet.Wallet;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Signer binding backed by a local Account.
+ */
+public class AccountSignerBinding implements SignerBinding {
+    private final Account account;
+
+    public AccountSignerBinding(Account account) {
+        this.account = account;
+    }
+
+    @Override
+    public TxSigner signerFor(String scope) {
+        String normalized = normalize(scope);
+
+        return switch (normalized) {
+            case "payment" -> SignerProviders.signerFrom(account);
+            case "stake" -> SignerProviders.stakeKeySignerFrom(account);
+            case "drep" -> SignerProviders.drepKeySignerFrom(account);
+            case "committeecold" -> SignerProviders.committeeColdKeySignerFrom(account);
+            case "committeehot" -> SignerProviders.committeeHotKeySignerFrom(account);
+            default -> throw new IllegalArgumentException("Unsupported scope '%s' for account signer".formatted(scope));
+        };
+    }
+
+    @Override
+    public Optional<Wallet> asWallet() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> preferredAddress() {
+        Address address = account.getBaseAddress();
+        return address == null ? Optional.empty() : Optional.ofNullable(address.toBech32());
+    }
+
+    private String normalize(String scope) {
+        if (scope == null) {
+            return "";
+        }
+
+        return scope.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/AddressOnlySignerBinding.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/AddressOnlySignerBinding.java
@@ -1,0 +1,49 @@
+package com.bloxbean.cardano.yaci.store.submit.signing;
+
+import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.hdwallet.Wallet;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Binding that only exposes an address (no signing). Useful for build-only flows.
+ */
+@RequiredArgsConstructor
+public class AddressOnlySignerBinding implements SignerBinding {
+    private final String ref;
+    private final String address;
+    private final Set<String> allowedScopes;
+
+    @Override
+    public TxSigner signerFor(String scope) {
+        String normalized = normalize(scope);
+        if (!CollectionUtils.isEmpty(allowedScopes) && !allowedScopes.contains(normalized)) {
+            throw new IllegalArgumentException("Scope '%s' not allowed for ref '%s'".formatted(scope, ref));
+        }
+
+        throw new IllegalStateException("Signer ref '%s' is address-only and cannot sign scope '%s'".formatted(ref, scope));
+    }
+
+    @Override
+    public Optional<Wallet> asWallet() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> preferredAddress() {
+        return Optional.ofNullable(address);
+    }
+
+    private String normalize(String scope) {
+        if (scope == null) {
+            return "";
+        }
+
+        return scope.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/RemoteSignerBinding.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/RemoteSignerBinding.java
@@ -1,0 +1,127 @@
+package com.bloxbean.cardano.yaci.store.submit.signing;
+
+import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
+import com.bloxbean.cardano.client.transaction.spec.VkeyWitness;
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.hdwallet.Wallet;
+import com.bloxbean.cardano.yaci.store.submit.config.SubmitSignerRegistryProperties.RemoteSignerProperties;
+import com.bloxbean.cardano.yaci.store.submit.signing.remote.RemoteSignerClient;
+import com.bloxbean.cardano.yaci.store.submit.signing.remote.RemoteSignerRequest;
+import com.bloxbean.cardano.yaci.store.submit.signing.remote.RemoteSignerResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Binding that delegates signing to an external remote-signer service.
+ */
+@RequiredArgsConstructor
+public class RemoteSignerBinding implements SignerBinding {
+    private final String ref;
+    private final Set<String> allowedScopes;
+    private final RemoteSignerProperties properties;
+    private final RemoteSignerClient client;
+
+    @Override
+    public TxSigner signerFor(String scope) {
+        String normalized = normalize(scope);
+        if (!CollectionUtils.isEmpty(allowedScopes) && !allowedScopes.contains(normalized)) {
+            throw new IllegalArgumentException("Scope '%s' not allowed for ref '%s'".formatted(scope, ref));
+        }
+
+        return (ctx, tx) -> addRemoteWitness(normalized, tx);
+    }
+
+    @Override
+    public Optional<Wallet> asWallet() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> preferredAddress() {
+        return Optional.ofNullable(properties.getAddress());
+    }
+
+    private Transaction addRemoteWitness(String scope, Transaction tx) {
+        byte[] txBody;
+        try {
+            txBody = CborSerializationUtil.serialize(tx.getBody().serialize());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize transaction body for ref '%s'".formatted(ref), e);
+        }
+
+        RemoteSignerRequest request = RemoteSignerRequest.builder()
+                .ref(ref)
+                .scope(scope)
+                .keyId(properties.getKeyId())
+                .txBody(txBody)
+                .endpoint(properties.getEndpoint())
+                .authToken(properties.getAuthToken())
+                .hostPublicKey(properties.getHostPublicKey())
+                .verificationKey(properties.getVerificationKey())
+                .address(properties.getAddress())
+                .timeoutMs(properties.getTimeoutMs())
+                .build();
+
+        RemoteSignerResponse response = client.sign(request);
+        byte[] signature = requireBytes(response.getSignature(), "signature");
+        byte[] verificationKey = response.getVerificationKey();
+
+        if (verificationKey == null || verificationKey.length == 0) {
+            verificationKey = decodeHex(properties.getVerificationKey(), "verificationKey");
+        }
+
+        if (verificationKey == null || verificationKey.length == 0) {
+            throw new IllegalStateException("Remote signer ref='%s' did not provide verification key".formatted(ref));
+        }
+
+        TransactionWitnessSet witnessSet = Optional.ofNullable(tx.getWitnessSet())
+                .orElseGet(TransactionWitnessSet::new);
+        var vkeyWitnesses = Optional.ofNullable(witnessSet.getVkeyWitnesses())
+                .orElseGet(ArrayList::new);
+
+        vkeyWitnesses.add(new VkeyWitness(verificationKey, signature));
+        witnessSet.setVkeyWitnesses(vkeyWitnesses);
+        tx.setWitnessSet(witnessSet);
+
+        return tx;
+    }
+
+    private byte[] requireBytes(byte[] value, String name) {
+        if (value == null || value.length == 0) {
+            throw new IllegalStateException("Remote signer ref='%s' returned empty %s".formatted(ref, name));
+        }
+
+        return value;
+    }
+
+    private byte[] decodeHex(String value, String name) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+
+        try {
+            return HexUtil.decodeHexString(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid hex for %s in ref='%s'".formatted(name, ref), e);
+        }
+    }
+
+    private String normalize(String scope) {
+        if (scope == null) {
+            return "";
+        }
+
+        return scope.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/ScopedSignerBinding.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/ScopedSignerBinding.java
@@ -1,0 +1,49 @@
+package com.bloxbean.cardano.yaci.store.submit.signing;
+
+import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.hdwallet.Wallet;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Scoped binding that rejects scopes not present in the allowed set.
+ */
+@RequiredArgsConstructor
+public class ScopedSignerBinding implements SignerBinding {
+    private final String ref;
+    private final SignerBinding delegate;
+    private final Set<String> allowedScopes;
+
+    @Override
+    public TxSigner signerFor(String scope) {
+        String normalized = normalize(scope);
+        if (!CollectionUtils.isEmpty(allowedScopes) && !allowedScopes.contains(normalized)) {
+            throw new IllegalArgumentException("Scope '%s' not allowed for ref '%s'".formatted(scope, ref));
+        }
+
+        return delegate.signerFor(scope);
+    }
+
+    @Override
+    public Optional<Wallet> asWallet() {
+        return delegate.asWallet();
+    }
+
+    @Override
+    public Optional<String> preferredAddress() {
+        return delegate.preferredAddress();
+    }
+
+    private String normalize(String scope) {
+        if (scope == null) {
+            return "";
+        }
+
+        return scope.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerClient.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerClient.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.submit.signing.remote;
+
+public interface RemoteSignerClient {
+
+    /**
+     * Delegate signing to a remote signer.
+     *
+     * @param request request containing tx body and routing metadata
+     * @return signature + verification key to add as a witness
+     */
+    RemoteSignerResponse sign(RemoteSignerRequest request) throws RemoteSignerException;
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerException.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerException.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yaci.store.submit.signing.remote;
+
+public class RemoteSignerException extends RuntimeException {
+    public RemoteSignerException(String message) {
+        super(message);
+    }
+
+    public RemoteSignerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerRequest.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerRequest.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.submit.signing.remote;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class RemoteSignerRequest {
+    String ref;
+    String keyId;
+    String scope;
+    byte[] txBody;
+    String endpoint;
+    String authToken;
+    String hostPublicKey;
+    String verificationKey;
+    String address;
+    Integer timeoutMs;
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerResponse.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/signing/remote/RemoteSignerResponse.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yaci.store.submit.signing.remote;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class RemoteSignerResponse {
+    byte[] signature;
+    byte[] verificationKey;
+}


### PR DESCRIPTION
## Summary
- add submit-level signer registry that binds QuickTx `_ref` values to local accounts, address-only refs, or remote signers
- introduce signer bindings (scoped, account, address-only, remote) and a RemoteSignerClient SPI for delegating signatures
- update submit README and tx-submit sample config to document new signer-registry entries and remote-signer fields
- align ADR-002 with remote-signer integration approach

## Notes
- no default RemoteSignerClient is shipped yet; `remote://` refs require providing a bean (e.g., DripDropz gRPC client) 
(Will implement after disscustion)
