### PR TITLE
 (admin-cli,dbutils): add safe ledger-state rollback behavior

### DIFF
--- a/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
+++ b/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
@@ -113,7 +113,7 @@ public class DBCommands {
         }
     }
 
-//    @Command(description = "Rollback ledger state data to a previous epoch")
+    @Command(description = "Rollback ledger state data to a previous epoch")
     public void rollbackLedgerStateData(@Option(longNames = "epoch", required = true, description = "Epoch to rollback to") int epoch) {
 
         writeLn(info("Start to rollback data ..."));

--- a/components/dbutils/src/main/resources/rollback-ledger-state.yml
+++ b/components/dbutils/src/main/resources/rollback-ledger-state.yml
@@ -1,12 +1,82 @@
-tables:
-  - adapot
-  - instant_reward
-  - reward
-  - reward_rest
-  - unclaimed_reward_rest
-  - adapot_jobs
-  - epoch_stake
-  - drep_dist
-  - gov_action_proposal_status
-  - drep_expiry
-  - epoch_param
+rollback:
+  tables:
+    - name: "adapot"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
+
+    - name: "adapot_jobs"
+      operation: "UPDATE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="
+      update_set:
+        - column: "status"
+          value: "'STARTED'"
+
+    - name: "epoch_stake"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="
+        offset: -1
+
+    - name: "reward"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
+
+    - name: "reward_rest"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
+
+    - name: "unclaimed_reward_rest"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
+
+    - name: "drep_dist"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="
+
+    - name: "gov_action_proposal_status"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="
+
+    - name: "epoch_param"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
+
+    - name: "gov_epoch_activity"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="
+
+    - name: "committee_state"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "epoch"
+        operator: ">="


### PR DESCRIPTION
  - Re-enable rollbackLedgerStateData CLI using rollback-ledger-state.yml
  - Define explicit rollback config for ledger-state tables in rollback-ledger-state.yml
  - Add special-case ledger-state handling in RollbackService:
      - keep reward rows with type='refund' (delete only non-refund)
      - reset adapot_jobs to status='STARTED' for REWARD_CALC from rollback epoch
  - Extend RollbackServiceTest to cover new ledger-state behavior for reward and adapot_jobs
  
#709 