### PR TITLE
fix: correct AdaPot job epoch offset in preExportValidation

### DIFF
--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/EpochStakeExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/EpochStakeExporter.java
@@ -46,9 +46,10 @@ public class EpochStakeExporter extends AbstractTableExporter {
 
     @Override
     public boolean preExportValidation(PartitionValue partition) {
-        // Epoch stake table depends on AdaPot job completion
+        // epoch_stake[N] is populated by AdaPot job N+1, which calls takeStakeSnapshot(epoch-1)
+        // during calculateRewards(). Wait for job N+1 to complete before exporting epoch N.
         int epoch = ((PartitionValue.EpochPartition) partition).epoch();
-        return isRewardCalcAdaPotJobCompleted(epoch);
+        return isRewardCalcAdaPotJobCompleted(epoch + 1);
     }
 
     @Override

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardExporter.java
@@ -42,9 +42,10 @@ public class RewardExporter extends AbstractTableExporter {
 
     @Override
     public boolean preExportValidation(PartitionValue partition) {
-        // Reward table depends on AdaPot job completion
+        // reward[earned_epoch=N] is populated by AdaPot job N+2, which calls updateEpochRewards()
+        // with earnedEpoch = epoch - 2. Wait for job N+2 to complete before exporting epoch N.
         int epoch = ((PartitionValue.EpochPartition) partition).epoch();
-        return isRewardCalcAdaPotJobCompleted(epoch);
+        return isRewardCalcAdaPotJobCompleted(epoch + 2);
     }
 
     @Override

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardRestExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardRestExporter.java
@@ -51,9 +51,11 @@ public class RewardRestExporter extends AbstractTableExporter {
 
     @Override
     public boolean preExportValidation(PartitionValue partition) {
-        // Reward rest table depends on AdaPot job completion
+        // reward_rest[earned_epoch=N] is populated at the start of AdaPot job N+1 via
+        // PreAdaPotJobProcessingEvent(N+1), which triggers TreasuryWithdrawalProcessor and
+        // ProposalRefundProcessor with epoch = N. Wait for job N+1 to complete before exporting epoch N.
         int epoch = ((PartitionValue.EpochPartition) partition).epoch();
-        return isRewardCalcAdaPotJobCompleted(epoch);
+        return isRewardCalcAdaPotJobCompleted(epoch + 1);
     }
 
     /**

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/UnclaimedRewardRestExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/UnclaimedRewardRestExporter.java
@@ -50,9 +50,11 @@ public class UnclaimedRewardRestExporter extends AbstractTableExporter {
 
     @Override
     public boolean preExportValidation(PartitionValue partition) {
-        // Unclaimed reward rest table depends on AdaPot job completion
+        // unclaimed_reward_rest[earned_epoch=N] is populated at the start of AdaPot job N+1 via
+        // PreAdaPotJobProcessingEvent(N+1), which triggers TreasuryWithdrawalProcessor and
+        // ProposalRefundProcessor with epoch = N. Wait for job N+1 to complete before exporting epoch N.
         int epoch = ((PartitionValue.EpochPartition) partition).epoch();
-        return isRewardCalcAdaPotJobCompleted(epoch);
+        return isRewardCalcAdaPotJobCompleted(epoch + 1);
     }
 
     /**


### PR DESCRIPTION

## Problem
#831 
  In analytics-store, analytics exports for `epoch_stake`, `reward`, `reward_rest`, and `unclaimed_reward_rest` occasionally completed with `SUCCESS` status but `row_count = 0`, even though PostgreSQL contained data for those
  epochs. Once marked `COMPLETED`, these partitions are never re-exported by the scheduler.

  ##  Cause

  Each exporter's `preExportValidation()` gated the export on `isRewardCalcAdaPotJobCompleted(epoch)`. However, the data for epoch N in these tables is not written by AdaPot job N — it is written by a later job:

  | Table | Data for epoch N written by | Reason |
  |---|---|---|
  | `epoch_stake` | Job N+1 | `takeStakeSnapshot(epoch-1)` inside `calculateRewards()` |
  | `reward` | Job N+2 | `updateEpochRewards()` uses `earnedEpoch = epoch - 2` |
  | `reward_rest` | Job N+1 | `PreAdaPotJobProcessingEvent(N+1)` → `TreasuryWithdrawalProcessor` / `ProposalRefundProcessor` with `epoch = N` |
  | `unclaimed_reward_rest` | Job N+1 | Same as `reward_rest` |

  When the scheduler ran right after job N completed, PostgreSQL had no data yet for epoch N in these tables. DuckDB returned 0 rows, and the partition was permanently marked `COMPLETED`.

  ## Fix

  Advance the epoch check in `preExportValidation()` by the correct offset for each exporter:

  - `EpochStakeExporter`: `epoch` → `epoch + 1`
  - `RewardExporter`: `epoch` → `epoch + 2`
  - `RewardRestExporter`: `epoch` → `epoch + 1`
  - `UnclaimedRewardRestExporter`: `epoch` → `epoch + 1`

