### PR TITLE
[Merge to 2.0.x] Fix missing ECONOMIC group for minFeeRefScriptCostPerByte in ProtocolParamUtil

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/util/ProtocolParamUtil.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/util/ProtocolParamUtil.java
@@ -15,7 +15,7 @@ public class ProtocolParamUtil {
         List<ProtocolParamGroup> groups = new ArrayList<>();
         if (isNonNull(params.getMinFeeA(), params.getMinFeeB(), params.getKeyDeposit(), params.getPoolDeposit(),
                 params.getMinPoolCost(), params.getPriceMem(), params.getPriceStep(), params.getAdaPerUtxoByte(),
-                params.getExpansionRate(), params.getTreasuryGrowthRate())) {
+                params.getExpansionRate(), params.getTreasuryGrowthRate(), params.getMinFeeRefScriptCostPerByte())) {
             groups.add(ProtocolParamGroup.ECONOMIC);
         }
 


### PR DESCRIPTION
Check https://github.com/bloxbean/yaci-store/pull/833