### PR TITLE
[Merge to 2-0-x] fix: prevent AlwaysNoConfidence stake double-counting in NO_CONFIDENCE vote tally

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
@@ -42,9 +42,15 @@ public final class VoteTallyCalculator {
             DRep No Stake – The total stake of:
             1. Registered dReps that voted 'No', plus
             2. Registered dReps that did not vote for this action, plus
-            3. The AlwaysNoConfidence dRep.
+            3. The AlwaysNoConfidence dRep (only when NOT a NoConfidence action,
+               since for NoConfidence actions the AlwaysNoConfidence stake is already counted in YES).
         */
-        BigInteger noStake = no.add(notVoted).add(noConfidence);
+        BigInteger noStake;
+        if (type == GovActionType.NO_CONFIDENCE) {
+            noStake = no.add(notVoted);
+        } else {
+            noStake = no.add(notVoted).add(noConfidence);
+        }
 
         return VoteTallies.DRepTallies.builder()
                 .totalYesStake(yes)

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
@@ -34,7 +34,27 @@ class VoteTallyCalculatorTest {
 
         VoteTallies.DRepTallies tallies = VoteTallyCalculator.computeDRepTallies(votes, GovActionType.NO_CONFIDENCE);
 
+        // yes = 100 + 30 (noConfidence added to YES for NO_CONFIDENCE actions)
         assertEquals(BigInteger.valueOf(130), tallies.getTotalYesStake());
+        // no = 20 + 10 (noConfidence NOT added to NO — already counted in YES)
+        assertEquals(BigInteger.valueOf(30), tallies.getTotalNoStake());
+    }
+
+    @Test
+    // For non-NoConfidence actions, AlwaysNoConfidence stake should only appear in NO (not YES)
+    void computeDRepTalliesWhenActionIsNotNoConfidence() {
+        VotingData.DRepVotes votes = VotingData.DRepVotes.builder()
+                .yesVoteStake(BigInteger.valueOf(100))
+                .noConfidenceStake(BigInteger.valueOf(30))
+                .noVoteStake(BigInteger.valueOf(20))
+                .doNotVoteStake(BigInteger.valueOf(10))
+                .build();
+
+        VoteTallies.DRepTallies tallies = VoteTallyCalculator.computeDRepTallies(votes, GovActionType.HARD_FORK_INITIATION_ACTION);
+
+        // yes = 100 (noConfidence NOT added to YES for non-NoConfidence actions)
+        assertEquals(BigInteger.valueOf(100), tallies.getTotalYesStake());
+        // no = 20 + 10 + 30 (noConfidence acts as implicit NO)
         assertEquals(BigInteger.valueOf(60), tallies.getTotalNoStake());
     }
 


### PR DESCRIPTION
check https://github.com/bloxbean/yaci-store/pull/834