### PR TITLE
fix(governance-rules): Add committeeMinSize check in post-bootstrap 

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/HardForkRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/HardForkRatificationEvaluator.java
@@ -80,6 +80,8 @@ public class HardForkRatificationEvaluator implements RatificationEvaluator {
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/NewConstitutionRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/NewConstitutionRatificationEvaluator.java
@@ -66,6 +66,8 @@ public class NewConstitutionRatificationEvaluator implements RatificationEvaluat
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/NoConfidenceRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/NoConfidenceRatificationEvaluator.java
@@ -65,6 +65,8 @@ public class NoConfidenceRatificationEvaluator implements RatificationEvaluator 
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
@@ -90,6 +90,8 @@ public class ParameterChangeRatificationEvaluator implements RatificationEvaluat
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/TreasuryWithdrawalRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/TreasuryWithdrawalRatificationEvaluator.java
@@ -69,6 +69,8 @@ public class TreasuryWithdrawalRatificationEvaluator implements RatificationEval
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/UpdateCommitteeRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/UpdateCommitteeRatificationEvaluator.java
@@ -67,6 +67,8 @@ public class UpdateCommitteeRatificationEvaluator implements RatificationEvaluat
                 .committee(context.getGovernanceContext().getCommittee())
                 .drepThresholds(context.getGovernanceContext().getProtocolParams().getDrepVotingThresholds())
                 .poolThresholds(context.getGovernanceContext().getProtocolParams().getPoolVotingThresholds())
+                .isInBootstrapPhase(context.getGovernanceContext().isInBootstrapPhase())
+                .committeeMinSize(context.getGovernanceContext().getProtocolParams().getCommitteeMinSize())
                 .build();
     }
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VotingEvaluationContext.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VotingEvaluationContext.java
@@ -14,5 +14,6 @@ public class VotingEvaluationContext {
     ConstitutionCommittee committee;
     DrepVoteThresholds drepThresholds;
     PoolVotingThresholds poolThresholds;
+    Integer committeeMinSize;
     boolean isInBootstrapPhase;
 }

--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluator.java
@@ -25,7 +25,14 @@ public class CommitteeVotingEvaluator implements VotingEvaluator<VotingData> {
         if (ConstitutionCommitteeState.NO_CONFIDENCE.equals(committee.getState())) {
             return VotingStatus.NOT_PASS_THRESHOLD;
         }
-        
+
+        // Post-bootstrap: committee must meet minimum size requirement
+        if (!context.isInBootstrapPhase()
+                && context.getCommitteeMinSize() != null
+                && committee.getMembers().size() < context.getCommitteeMinSize()) {
+            return VotingStatus.NOT_PASS_THRESHOLD;
+        }
+
         var threshold = committee.getThreshold().safeRatio();
         if (threshold.equals(BigDecimal.ZERO)) {
             return VotingStatus.PASS_THRESHOLD;

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
@@ -113,6 +113,107 @@ class CommitteeVotingEvaluatorTest {
         assertThat(result).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
     }
 
+    // --- committeeMinSize tests
+    @Test
+    void evaluate_returnsNotPassThreshold_whenCommitteeBelowMinSize_postBootstrap() {
+        // 2 active members, committeeMinSize = 5, post-bootstrap -> NOT_PASS_THRESHOLD
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(ConstitutionCommitteeState.NORMAL)
+                .threshold(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .members(List.of(member("cold1", "hot1"), member("cold2", "hot2")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of("hot1", Vote.YES, "hot2", Vote.YES))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .committee(committee)
+                .isInBootstrapPhase(false)
+                .committeeMinSize(5)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    @Test
+    void evaluate_returnsPassThreshold_whenCommitteeMeetsMinSize_postBootstrap() {
+        // 5 active members, committeeMinSize = 5, sufficient YES votes -> PASS_THRESHOLD
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(ConstitutionCommitteeState.NORMAL)
+                .threshold(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .members(List.of(
+                        member("cold1", "hot1"), member("cold2", "hot2"), member("cold3", "hot3"),
+                        member("cold4", "hot4"), member("cold5", "hot5")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of(
+                                "hot1", Vote.YES, "hot2", Vote.YES, "hot3", Vote.YES,
+                                "hot4", Vote.YES, "hot5", Vote.ABSTAIN))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .committee(committee)
+                .isInBootstrapPhase(false)
+                .committeeMinSize(5)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    @Test
+    void evaluate_skipsMinSizeCheck_duringBootstrapPhase() {
+        // 2 active members, committeeMinSize = 5, bootstrap phase -> check skipped, PASS_THRESHOLD
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(ConstitutionCommitteeState.NORMAL)
+                .threshold(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .members(List.of(member("cold1", "hot1"), member("cold2", "hot2")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of("hot1", Vote.YES, "hot2", Vote.YES))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .committee(committee)
+                .isInBootstrapPhase(true)
+                .committeeMinSize(5)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    @Test
+    void evaluate_skipsMinSizeCheck_whenCommitteeMinSizeIsNull() {
+        // 2 active members, committeeMinSize = null, post-bootstrap -> check skipped, PASS_THRESHOLD
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(ConstitutionCommitteeState.NORMAL)
+                .threshold(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .members(List.of(member("cold1", "hot1"), member("cold2", "hot2")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of("hot1", Vote.YES, "hot2", Vote.YES))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .committee(committee)
+                .isInBootstrapPhase(false)
+                .committeeMinSize(null)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
     private static CommitteeMember member(String coldKey, String hotKey) {
         return CommitteeMember.builder()
                 .coldKey(coldKey)


### PR DESCRIPTION
## Context
In post-bootstrap , when the committee size below committeeMinSize after bootstrap phase, proposals requiring committee approval should fail. Check #824 

## Summary

  - Add `committeeMinSize` field to `VotingEvaluationContext` and enforce the minimum committee size check in `CommitteeVotingEvaluator.evaluate()` post-bootstrap
  - When active committee members < `committeeMinSize` and not in bootstrap phase, committee vote returns `NOT_PASS_THRESHOLD` — matching Haskell ledger behavior where the threshold becomes `NoVotingThreshold`
  - The check is skipped during bootstrap phase (consistent with `hardforkConwayBootstrapPhase` short-circuit in the Haskell spec)
  - Add 4 unit tests covering: below min size, meets min size, bootstrap phase skip, and null committeeMinSize