### PR TITLE
fix(analytics-store): fix performance problem in balance exporters to avoid full table scan

### DIFF
--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/AddressBalanceExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/AddressBalanceExporter.java
@@ -57,31 +57,33 @@ public class AddressBalanceExporter extends AbstractTableExporter {
         String schema = getSourceSchema();
         return String.format("""
             SELECT
-                ab.address,
-                ab.quantity,
-                ab.unit,
-                to_timestamp(COALESCE(ab.block_time, 0)) as block_time,
-                ab.block,
-                ab.epoch,
-                ab.slot,
-                ab.addr_full
-            FROM source_db.%s.address_balance ab
-            INNER JOIN (
+                address,
+                quantity,
+                unit,
+                to_timestamp(COALESCE(block_time, 0)) as block_time,
+                block,
+                epoch,
+                slot,
+                addr_full
+            FROM (
                 SELECT
                     address,
+                    quantity,
                     unit,
-                    MAX(slot) as max_slot
+                    block_time,
+                    block,
+                    epoch,
+                    slot,
+                    addr_full,
+                    ROW_NUMBER() OVER (PARTITION BY address, unit ORDER BY slot DESC) as rn
                 FROM source_db.%s.address_balance
                 WHERE slot >= %d
                   AND slot < %d
-                GROUP BY address, unit
-            ) latest
-            ON ab.address = latest.address
-               AND ab.unit = latest.unit
-               AND ab.slot = latest.max_slot
-            ORDER BY ab.address, ab.unit
+            ) ranked
+            WHERE rn = 1
+            ORDER BY address, unit
             """,
-            schema, schema,
+            schema,
             slotRange.startSlot(),
             slotRange.endSlot()
         );

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/StakeAddressBalanceExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/StakeAddressBalanceExporter.java
@@ -48,27 +48,29 @@ public class StakeAddressBalanceExporter extends AbstractTableExporter {
         String schema = getSourceSchema();
         return String.format("""
             SELECT
-                sab.address,
-                sab.quantity,
-                to_timestamp(COALESCE(sab.block_time, 0)) as block_time,
-                sab.block,
-                sab.epoch,
-                sab.slot
-            FROM source_db.%s.stake_address_balance sab
-            INNER JOIN (
+                address,
+                quantity,
+                to_timestamp(COALESCE(block_time, 0)) as block_time,
+                block,
+                epoch,
+                slot
+            FROM (
                 SELECT
                     address,
-                    MAX(slot) as max_slot
+                    quantity,
+                    block_time,
+                    block,
+                    epoch,
+                    slot,
+                    ROW_NUMBER() OVER (PARTITION BY address ORDER BY slot DESC) as rn
                 FROM source_db.%s.stake_address_balance
                 WHERE slot >= %d
                   AND slot < %d
-                GROUP BY address
-            ) latest
-            ON sab.address = latest.address
-               AND sab.slot = latest.max_slot
-            ORDER BY sab.address
+            ) ranked
+            WHERE rn = 1
+            ORDER BY address
             """,
-            schema, schema,
+            schema,
             slotRange.startSlot(),
             slotRange.endSlot()
         );


### PR DESCRIPTION
### Summary

  - Replace self-join + MAX(slot) query pattern with ROW_NUMBER() window function in StakeAddressBalanceExporter and AddressBalanceExporter
  - The old self-join caused DuckDB's postgres_scanner to pull the entire table for the outer reference (no WHERE filter to push down), resulting in full table scans
  - New approach uses a single filtered scan with ROW_NUMBER() OVER (PARTITION BY ... ORDER BY slot DESC), which postgres_scanner can push the slot filter for

### Why

When DuckDB executes a self-join via postgres_scanner, each table reference is processed independently. The inner subquery had a WHERE slot filter (pushed down OK), but the outer had none, causing a full table transfer from PostgreSQL to DuckDB. 