### PR TITLE
perf(analytics-store): use postgres_query(), forces DuckDB to send raw SQL to PostgreSQL

### DIFF
--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/DatumExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/DatumExporter.java
@@ -50,16 +50,18 @@ public class DatumExporter extends AbstractTableExporter {
         String schema = getSourceSchema();
         String dateStr = ((PartitionValue.DatePartition) partition).date().toString();
         return String.format("""
-            SELECT
-                d.hash,
-                d.datum,
-                d.created_at_tx,
-                d.slot,
-                CAST('%s' AS DATE) as block_date
-            FROM source_db.%s.datum d
-            WHERE d.slot >= %d
-              AND d.slot < %d
-            ORDER BY d.slot, d.hash
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    d.hash,
+                    d.datum,
+                    d.created_at_tx,
+                    d.slot,
+                    CAST(''%s'' AS DATE) as block_date
+                FROM %s.datum d
+                WHERE d.slot >= %d
+                  AND d.slot < %d
+                ORDER BY d.slot, d.hash
+            ')
             """,
             dateStr, schema,
             slotRange.startSlot(),

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/EpochStakeExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/EpochStakeExporter.java
@@ -58,16 +58,18 @@ public class EpochStakeExporter extends AbstractTableExporter {
         int epoch = ((PartitionValue.EpochPartition) partition).epoch();
         
         return String.format("""
-            SELECT
-                es.epoch,
-                es.address,
-                es.amount,
-                es.pool_id,
-                es.delegation_epoch,
-                es.active_epoch
-            FROM source_db.%s.epoch_stake es
-            WHERE es.epoch = %d
-            ORDER BY es.epoch, es.address
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    es.epoch,
+                    es.address,
+                    es.amount,
+                    es.pool_id,
+                    es.delegation_epoch,
+                    es.active_epoch
+                FROM %s.epoch_stake es
+                WHERE es.epoch = %d
+                ORDER BY es.epoch, es.address
+            ')
             """,
             schema,
             epoch

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/RewardExporter.java
@@ -55,17 +55,19 @@ public class RewardExporter extends AbstractTableExporter {
 
         // We use earned_epoch for partitioning rewards.
         return String.format("""
-            SELECT
-                r.address,
-                r.earned_epoch AS epoch,
-                r.spendable_epoch ,
-                r.type,
-                r.pool_id,
-                r.amount,
-                r.slot
-            FROM source_db.%s.reward r
-            WHERE r.earned_epoch = %d
-            ORDER BY r.earned_epoch, r.address
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    r.address,
+                    r.earned_epoch AS epoch,
+                    r.spendable_epoch ,
+                    r.type,
+                    r.pool_id,
+                    r.amount,
+                    r.slot
+                FROM %s.reward r
+                WHERE r.earned_epoch = %d
+                ORDER BY r.earned_epoch, r.address
+            ')
             """,
             schema,
             epoch

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/SpentOutputsExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/SpentOutputsExporter.java
@@ -63,19 +63,21 @@ public class SpentOutputsExporter extends AbstractTableExporter {
     protected String buildQuery(PartitionValue partition, SlotRange slotRange) {
         String schema = getSourceSchema();
         return String.format("""
-            SELECT
-                ti.tx_hash,
-                ti.output_index,
-                ti.spent_tx_hash,
-                ti.spent_at_slot,
-                ti.spent_at_block,
-                ti.spent_at_block_hash,
-                to_timestamp(COALESCE(ti.spent_block_time, 0)) as spent_block_time,
-                ti.spent_epoch
-            FROM source_db.%s.tx_input ti
-            WHERE ti.spent_at_slot >= %d
-              AND ti.spent_at_slot < %d
-            ORDER BY ti.spent_at_slot, ti.spent_tx_hash
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    ti.tx_hash,
+                    ti.output_index,
+                    ti.spent_tx_hash,
+                    ti.spent_at_slot,
+                    ti.spent_at_block,
+                    ti.spent_at_block_hash,
+                    to_timestamp(COALESCE(ti.spent_block_time, 0)) as spent_block_time,
+                    ti.spent_epoch
+                FROM %s.tx_input ti
+                WHERE ti.spent_at_slot >= %d
+                  AND ti.spent_at_slot < %d
+                ORDER BY ti.spent_at_slot
+            ')
             """,
             schema,
             slotRange.startSlot(),

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionExporter.java
@@ -56,34 +56,36 @@ public class TransactionExporter extends AbstractTableExporter {
     protected String buildQuery(PartitionValue partition, SlotRange slotRange) {
         String schema = getSourceSchema();
         return String.format("""
-            SELECT
-                t.tx_hash,
-                t.block_hash,
-                t.block,
-                t.slot,
-                t.epoch,
-                to_timestamp(COALESCE(t.block_time, 0)) as block_time,
-                t.tx_index,
-                t.fee,
-                t.invalid,
-                t.network_id,
-                t.auxiliary_datahash,
-                t.script_datahash,
-                t.total_collateral,
-                t.ttl,
-                t.validity_interval_start,
-                t.treasury_donation,
-                t.inputs,
-                t.outputs,
-                t.reference_inputs,
-                t.collateral_inputs,
-                t.collateral_return,
-                t.collateral_return_json,
-                t.required_signers
-            FROM source_db.%s.transaction t
-            WHERE t.slot >= %d
-              AND t.slot < %d
-            ORDER BY t.slot, t.tx_hash
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    t.tx_hash,
+                    t.block_hash,
+                    t.block,
+                    t.slot,
+                    t.epoch,
+                    to_timestamp(COALESCE(t.block_time, 0)) as block_time,
+                    t.tx_index,
+                    t.fee,
+                    t.invalid,
+                    t.network_id,
+                    t.auxiliary_datahash,
+                    t.script_datahash,
+                    t.total_collateral,
+                    t.ttl,
+                    t.validity_interval_start,
+                    t.treasury_donation,
+                    t.inputs,
+                    t.outputs,
+                    t.reference_inputs,
+                    t.collateral_inputs,
+                    t.collateral_return,
+                    t.collateral_return_json,
+                    t.required_signers
+                FROM %s.transaction t
+                WHERE t.slot >= %d
+                  AND t.slot < %d
+                ORDER BY t.slot
+            ')
             """,
             schema,
             slotRange.startSlot(),

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionMetadataExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionMetadataExporter.java
@@ -44,20 +44,22 @@ public class TransactionMetadataExporter extends AbstractTableExporter {
     protected String buildQuery(PartitionValue partition, SlotRange slotRange) {
         String schema = getSourceSchema();
         return String.format("""
-            SELECT
-                tm.id,
-                tm.slot,
-                tm.tx_hash,
-                tm.label,
-                tm.body,
-                tm.cbor,
-                tm.block,
-                to_timestamp(COALESCE(tm.block_time, 0)) as block_time,
-                tm.update_datetime
-            FROM source_db.%s.transaction_metadata tm
-            WHERE tm.slot >= %d
-              AND tm.slot < %d
-            ORDER BY tm.slot, tm.tx_hash
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    tm.id,
+                    tm.slot,
+                    tm.tx_hash,
+                    tm.label,
+                    tm.body,
+                    tm.cbor,
+                    tm.block,
+                    to_timestamp(COALESCE(tm.block_time, 0)) as block_time,
+                    tm.update_datetime
+                FROM %s.transaction_metadata tm
+                WHERE tm.slot >= %d
+                  AND tm.slot < %d
+                ORDER BY tm.slot, tm.tx_hash
+            ')
             """,
             schema,
             slotRange.startSlot(),

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionScriptsExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/TransactionScriptsExporter.java
@@ -44,26 +44,28 @@ public class TransactionScriptsExporter extends AbstractTableExporter {
     protected String buildQuery(PartitionValue partition, SlotRange slotRange) {
         String schema = getSourceSchema();
         return String.format("""
-            SELECT
-                ts.id,
-                ts.slot,
-                ts.block_hash,
-                ts.tx_hash,
-                ts.script_hash,
-                ts.script_type,
-                ts.datum_hash,
-                ts.redeemer_cbor,
-                ts.unit_mem,
-                ts.unit_steps,
-                ts.purpose,
-                ts.redeemer_index,
-                ts.redeemer_datahash,
-                ts.block,
-                to_timestamp(COALESCE(ts.block_time, 0)) as block_time
-            FROM source_db.%s.transaction_scripts ts
-            WHERE ts.slot >= %d
-              AND ts.slot < %d
-            ORDER BY ts.slot, ts.tx_hash, ts.redeemer_index
+            SELECT * FROM postgres_query('source_db', '
+                SELECT
+                    ts.id,
+                    ts.slot,
+                    ts.block_hash,
+                    ts.tx_hash,
+                    ts.script_hash,
+                    ts.script_type,
+                    ts.datum_hash,
+                    ts.redeemer_cbor,
+                    ts.unit_mem,
+                    ts.unit_steps,
+                    ts.purpose,
+                    ts.redeemer_index,
+                    ts.redeemer_datahash,
+                    ts.block,
+                    to_timestamp(COALESCE(ts.block_time, 0)) as block_time
+                FROM %s.transaction_scripts ts
+                WHERE ts.slot >= %d
+                  AND ts.slot < %d
+                ORDER BY ts.slot, ts.tx_hash, ts.redeemer_index
+            ')
             """,
             schema,
             slotRange.startSlot(),


### PR DESCRIPTION
 ## Summary

  - Wrap 7 large-table exporters with `postgres_query('source_db', '...')` so DuckDB delegates
    SQL execution to PostgreSQL instead of using ctid-based parallel page scanning
  - This ensures PostgreSQL uses indexed scans, returning only matching rows

  ## Problem

DuckDB's `postgres_scanner` uses ctid-based page scanning for base tables — dividing the table                                                                                                                           
into small page-range chunks and querying each chunk with ctid predicates. 'postgres_scanner' can push down WHERE conditions, but it does not guarantee that PostgreSQL will perform an index scan. This is because it organizes reads by ctid/page by default to enable parallel scanning
