### PR TITLE
feat(analytics-store): add configurable DuckDB memory limit

### DIFF
--- a/aggregates/analytics-store/README.md
+++ b/aggregates/analytics-store/README.md
@@ -223,6 +223,7 @@ duckdb -c "
 | `yaci.store.analytics.ducklake.catalog-username` | _(main datasource)_ | PostgreSQL catalog username (used when `catalog-type=postgresql`) |
 | `yaci.store.analytics.ducklake.catalog-password` | _(main datasource)_ | PostgreSQL catalog password (used when `catalog-type=postgresql`) |
 | `yaci.store.analytics.ducklake.catalog-path` | `./data/analytics/ducklake.catalog.db` | DuckDB catalog file path |
+| `yaci.store.analytics.duckdb.memory-limit` | _(empty = DuckDB default)_ | DuckDB buffer manager memory limit (e.g., `1GB`, `512MB`) |
 | `yaci.store.analytics.logging.file` | `./logs/analytics-store.log` | Dedicated analytics log file path |
 
 ## Known Caveats
@@ -237,6 +238,21 @@ When querying with DuckDB CLI or Python, you **must start from the same working 
 ```properties
 yaci.store.analytics.export-path=/var/lib/yaci-store/analytics
 ```
+
+### DuckDB memory usage in JVM
+
+DuckDB defaults to using 80% of system physical RAM for its buffer manager. Since DuckDB runs inside the JVM process, this can cause memory contention — JVM heap + DuckDB buffer may together exceed available system RAM, leading to OOM kills (especially in containers/Kubernetes).
+
+To limit DuckDB memory usage:
+
+```properties
+# Limit DuckDB buffer manager to 1GB per connection
+yaci.store.analytics.duckdb.memory-limit=1GB
+```
+
+If not set, DuckDB uses its default (80% of system RAM). It is recommended to set this explicitly in production and container environments.
+
+Note: With writer pool (1 connection) + reader pool (N connections), total potential DuckDB memory is `memory_limit * (1 + N)`. Some DuckDB aggregate functions may also allocate memory outside the buffer manager, so actual usage can slightly exceed the configured limit.
 
 ### DuckLake requires `public` schema in PostgreSQL
 

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/config/AnalyticsStoreProperties.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/config/AnalyticsStoreProperties.java
@@ -109,6 +109,21 @@ public class AnalyticsStoreProperties {
 
     @Data
     public static class DuckDb {
+        /**
+         * DuckDB memory_limit setting.
+         * Controls the maximum memory DuckDB's buffer manager can use per connection.
+         * DuckDB defaults to 80% of system RAM if not set, which can cause OOM
+         * when running inside a JVM process.
+         *
+         * Format: DuckDB size string (e.g., "1GB", "512MB", "2GB")
+         * Empty = use DuckDB default (80% of system RAM).
+         * Recommended: Set explicitly in production/container environments.
+         *
+         * Note: Some aggregate functions may allocate memory outside the buffer
+         * manager, so actual usage can slightly exceed this limit.
+         */
+        private String memoryLimit;
+
         private DuckDbDataSource datasource = new DuckDbDataSource();
         private ReaderConfig reader = new ReaderConfig();
 

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/config/DuckDbDataSourceConfig.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/config/DuckDbDataSourceConfig.java
@@ -53,6 +53,11 @@ public class DuckDbDataSourceConfig {
         dataSource.setMaxLifetime(0);             // No max lifetime (connection reused indefinitely)
         dataSource.setIdleTimeout(0);             // No idle timeout (keep connection alive)
 
+        String initSql = buildConnectionInitSql();
+        if (initSql != null) {
+            dataSource.setConnectionInitSql(initSql);
+        }
+
         return dataSource;
     }
 
@@ -82,6 +87,11 @@ public class DuckDbDataSourceConfig {
         dataSource.setMaximumPoolSize(poolSize);
         dataSource.setMinimumIdle(Math.min(2, poolSize));
 
+        String initSql = buildConnectionInitSql();
+        if (initSql != null) {
+            dataSource.setConnectionInitSql(initSql);
+        }
+
         return dataSource;
     }
 
@@ -96,5 +106,17 @@ public class DuckDbDataSourceConfig {
      */
     private String buildJdbcUrl() {
         return "jdbc:duckdb:";
+    }
+
+    /**
+     * Build SQL to configure DuckDB instance settings.
+     * Executed once per new physical connection by HikariCP's connectionInitSql.
+     */
+    private String buildConnectionInitSql() {
+        String memoryLimit = properties.getDuckdb().getMemoryLimit();
+        if (memoryLimit != null && !memoryLimit.isBlank()) {
+            return "SET memory_limit = '" + memoryLimit + "'";
+        }
+        return null;
     }
 }

--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/ducklake/DuckLakeCatalogInitializer.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/ducklake/DuckLakeCatalogInitializer.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -64,6 +65,9 @@ public class DuckLakeCatalogInitializer {
             // Configure catalog compression settings
             connectionHelper.configureDuckLakeCatalogSettings(conn);
 
+            // Log effective DuckDB memory settings
+            logDuckDbSettings(conn);
+
             log.info("✅ DuckLake catalog initialized successfully");
             log.debug("DuckDB connection will close now, releasing any attached PostgreSQL connections");
 
@@ -83,6 +87,20 @@ public class DuckLakeCatalogInitializer {
             // Try to query catalog metadata using duckdb_tables()
             stmt.executeQuery("SELECT COUNT(*) FROM duckdb_tables() WHERE database_name = 'ducklake_catalog';");
             log.debug("Catalog verification successful");
+        }
+    }
+
+    /**
+     * Log effective DuckDB memory settings for operational visibility.
+     */
+    private void logDuckDbSettings(Connection conn) {
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT current_setting('memory_limit')")) {
+            if (rs.next()) {
+                log.info("DuckDB memory_limit={}", rs.getString(1));
+            }
+        } catch (SQLException e) {
+            log.debug("Could not query DuckDB memory_limit: {}", e.getMessage());
         }
     }
 }

--- a/config/application-analytics.properties
+++ b/config/application-analytics.properties
@@ -23,6 +23,10 @@ yaci.store.analytics.admin.enabled=true
 #yaci.store.analytics.parquet-export.compression-level=3
 
 
+## DuckDB memory limit (applied per connection via HikariCP connectionInitSql)
+## DuckDB defaults to 80% of system RAM — risks OOM inside JVM
+#yaci.store.analytics.duckdb.memory-limit=1GB
+
 ## DuckLake catalog configuration
 yaci.store.analytics.storage.type=ducklake
 yaci.store.analytics.ducklake.catalog-type=duckdb

--- a/docs/app/docs/v2/stores/configuration/page.mdx
+++ b/docs/app/docs/v2/stores/configuration/page.mdx
@@ -166,6 +166,21 @@ store.executor.use-virtual-thread-for-batch-processing=true
 store.executor.use-virtual-thread-for-event-processing=true
 ```
 
+### DuckDB Memory Limit (Analytics Store)
+
+When the analytics store is enabled, DuckDB runs in-process via JDBC for Parquet exports. By default, DuckDB allocates up to **80% of system physical RAM** for its buffer manager. Since DuckDB shares the process with the JVM, this can cause out-of-memory issues — especially in containers or when the JVM heap is also large.
+
+To limit DuckDB memory usage, set the `memory-limit` property:
+
+```properties
+# Limit DuckDB buffer manager memory (e.g., 1GB, 512MB, 2GB)
+yaci.store.analytics.duckdb.memory-limit=1GB
+```
+
+<Callout type="warning">
+If not configured, DuckDB uses its default (80% of system RAM). It is recommended to set this explicitly in production and container environments to prevent OOM kills.
+</Callout>
+
 ### Database Insert Performance
 
 ```properties


### PR DESCRIPTION
# Summary

- Add configurable `yaci.store.analytics.duckdb.memory-limit` property to control DuckDB buffer manager memory usage per connection  
- DuckDB defaults to **80% of system RAM**, which risks OOM when running inside a JVM process (especially in containers/Kubernetes)  
- Use HikariCP's `connectionInitSql` to apply `SET memory_limit` once per new physical connection
- Default is unset (DuckDB's own 80% default), allowing operators to explicitly configure for their environment  
- Log effective `memory_limit` on startup for operational visibility  

---

# Changed Files

| File | Change |
|------|--------|
| `AnalyticsStoreProperties.java` | Add `memoryLimit` config field to `DuckDb` inner class |
| `DuckDbDataSourceConfig.java` | Add `buildConnectionInitSql()`, apply to writer + reader DataSource pools |
| `DuckLakeCatalogInitializer.java` | Log effective DuckDB `memory_limit` on startup |
| `application-analytics.properties` | Add commented config example |
| `aggregates/analytics-store/README.md` | Document memory caveat + config reference |
| `docs/.../configuration/page.mdx` | Add "DuckDB Memory Limit" section to doc site |

---

# Configuration

```properties
# Limit DuckDB buffer manager memory (default: unset = 80% of system RAM)
yaci.store.analytics.duckdb.memory-limit=1GB
```

---

# Test Plan

- Build passes:
  ```bash
  ./gradlew :aggregates:analytics-store:build
  ```
- Startup log shows `DuckDB memory_limit=X` when configured  
- Without config, DuckDB uses its default (80% system RAM)  
- Invalid value (e.g., `abc`) causes fail-fast on startup (HikariCP connection creation fails)  