### PR TITLE
fix(governance-rules): fail DRep vote when participating stake is zero and threshold is non-zero

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/drep/DRepVotingEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/drep/DRepVotingEvaluator.java
@@ -32,15 +32,22 @@ public class DRepVotingEvaluator implements VotingEvaluator<VotingData> {
         BigInteger totalYes = dRepVoteTallies.getTotalYesStake();
         BigInteger totalNo = dRepVoteTallies.getTotalNoStake();
         BigInteger totalYesAndNo = totalYes.add(totalNo);
-        
-        if (totalYesAndNo.equals(BigInteger.ZERO)) {
+
+        BigDecimal requiredThreshold = getRequiredThreshold(context);
+
+        // Auto-pass only when threshold is zero (matches Haskell: r == minBound)
+        if (requiredThreshold.compareTo(BigDecimal.ZERO) == 0) {
             return VotingStatus.PASS_THRESHOLD;
         }
+
+        if (totalYesAndNo.equals(BigInteger.ZERO)) {
+            // Zero participating stake with non-zero threshold: ratio = 0, vote fails
+            return VotingStatus.NOT_PASS_THRESHOLD;
+        }
+
         // the ratio = yes/(yes + no)
         BigDecimal acceptedRatio = BigNumberUtils.divide(totalYes, totalYesAndNo);
 
-        BigDecimal requiredThreshold = getRequiredThreshold(context);
-        
         return BigNumberUtils.isHigherOrEquals(acceptedRatio, requiredThreshold) ?
             VotingStatus.PASS_THRESHOLD : VotingStatus.NOT_PASS_THRESHOLD;
     }

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/drep/DRepVotingEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/drep/DRepVotingEvaluatorTest.java
@@ -1,0 +1,189 @@
+package com.bloxbean.cardano.yaci.store.governancerules.voting.drep;
+
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yaci.core.model.governance.actions.TreasuryWithdrawalsAction;
+import com.bloxbean.cardano.yaci.store.common.domain.DrepVoteThresholds;
+import com.bloxbean.cardano.yaci.store.common.util.UnitIntervalUtil;
+import com.bloxbean.cardano.yaci.store.governancerules.api.VotingData;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingEvaluationContext;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DRepVotingEvaluatorTest {
+
+    private final DRepVotingEvaluator evaluator = new DRepVotingEvaluator();
+
+    /**
+     * When no DReps have participating stake (all inactive or none registered),
+     * the accepted ratio is 0, which is below any positive threshold → vote must fail.
+     */
+    @Test
+    void evaluate_returnsNotPassThreshold_whenTotalStakeIsZero_andThresholdIsNonZero() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtTreasuryWithdrawal(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.67")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .noVoteStake(BigInteger.ZERO)
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(thresholds)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    /**
+     * When the required threshold is exactly zero, the vote auto-passes
+     * regardless of participating stake.
+     */
+    @Test
+    void evaluate_returnsPassThreshold_whenThresholdIsZero() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtTreasuryWithdrawal(UnitIntervalUtil.decimalToUnitInterval(BigDecimal.ZERO))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .noVoteStake(BigInteger.ZERO)
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(thresholds)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    /**
+     * Yes stake exceeds threshold: yes=600M, no=400M, threshold=0.51 → ratio=0.60 → passes.
+     */
+    @Test
+    void evaluate_returnsPassThreshold_whenYesStakeMeetsThreshold() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtTreasuryWithdrawal(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(600_000_000))
+                        .noVoteStake(BigInteger.valueOf(400_000_000))
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(thresholds)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    /**
+     * Yes stake below threshold: yes=400M, no=600M, threshold=0.67 → ratio=0.40 → fails.
+     */
+    @Test
+    void evaluate_returnsNotPassThreshold_whenYesStakeBelowThreshold() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtTreasuryWithdrawal(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.67")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(400_000_000))
+                        .noVoteStake(BigInteger.valueOf(600_000_000))
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(thresholds)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    /**
+     * Returns INSUFFICIENT_DATA when drepVotes is null.
+     */
+    @Test
+    void evaluate_returnsInsufficientData_whenDrepVotesIsNull() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtTreasuryWithdrawal(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.67")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(null)
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(thresholds)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.INSUFFICIENT_DATA);
+    }
+
+    /**
+     * Returns INSUFFICIENT_DATA when drepThresholds is null.
+     */
+    @Test
+    void evaluate_returnsInsufficientData_whenDrepThresholdsIsNull() {
+        TreasuryWithdrawalsAction govAction = mock(TreasuryWithdrawalsAction.class);
+        when(govAction.getType()).thenReturn(GovActionType.TREASURY_WITHDRAWALS_ACTION);
+
+        VotingData votingData = VotingData.builder()
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(600_000_000))
+                        .noVoteStake(BigInteger.valueOf(400_000_000))
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .drepThresholds(null)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.INSUFFICIENT_DATA);
+    }
+}


### PR DESCRIPTION
#876 
## Summary

  `DRepVotingEvaluator` was returning `PASS_THRESHOLD` whenever `totalYes + totalNo == 0`, regardless of the configured threshold. This happens when no DReps have participating stake — for example on networks with no
  registered DReps, or when all active DReps have abstained.

  The correct behaviour, matching the Cardano ledger, is:

  - **Auto-pass only when the threshold itself is zero** — not when stake is zero.
  - When participating stake is zero and the threshold is non-zero, the acceptance ratio is `0`, which is below any positive threshold → the vote **fails**.

  ## Changes

  **`DRepVotingEvaluator.java`**

  - Moved `getRequiredThreshold()` before the zero-stake guard.
  - Added an early `PASS_THRESHOLD` return when `requiredThreshold == 0` (threshold-based auto-pass).
  - Changed the zero-stake path to return `NOT_PASS_THRESHOLD` when the threshold is non-zero.

  **`DRepVotingEvaluatorTest.java`** (new)

  - Zero stake + non-zero threshold → `NOT_PASS_THRESHOLD`
  - Zero threshold → `PASS_THRESHOLD` (auto-pass)
  - Yes stake meets threshold → `PASS_THRESHOLD`
  - Yes stake below threshold → `NOT_PASS_THRESHOLD`
  - Null `drepVotes` → `INSUFFICIENT_DATA`
  - Null `drepThresholds` → `INSUFFICIENT_DATA`

  ## Impact

  Primarily affects small or early-stage networks (testnets, DevKit environments) where no DReps are registered.