### PR TITLE
fix(governance-rules): SPO vote do not pass when all stake abstain and threshold is non-zero

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/spo/SPOVotingEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/spo/SPOVotingEvaluator.java
@@ -29,17 +29,22 @@ public class SPOVotingEvaluator implements VotingEvaluator<VotingData> {
         BigInteger totalYes = spoVoteTallies.getTotalYesStake();
         BigInteger totalAbstain = spoVoteTallies.getTotalAbstainStake();
         BigInteger totalStake = spoData.getTotalStake();
-        
-        if (totalStake.equals(BigInteger.ZERO) || totalAbstain.equals(totalStake)) {
+
+        BigDecimal requiredThreshold = getRequiredThreshold(actionType, context);
+
+        // Auto-pass only when threshold is zero
+        if (requiredThreshold.compareTo(BigDecimal.ZERO) == 0) {
             return VotingStatus.PASS_THRESHOLD;
+        }
+
+        if (totalStake.equals(BigInteger.ZERO) || totalAbstain.equals(totalStake)) {
+            return VotingStatus.NOT_PASS_THRESHOLD;
         }
 
         // the ratio = yes/(total - abstain)
         BigDecimal acceptedRatio = new BigDecimal(totalYes)
             .divide(new BigDecimal(totalStake.subtract(totalAbstain)), BigNumberUtils.mathContext);
-            
-        BigDecimal requiredThreshold = getRequiredThreshold(actionType, context);
-        
+
         return BigNumberUtils.isHigherOrEquals(acceptedRatio, requiredThreshold) ?
                 VotingStatus.PASS_THRESHOLD : VotingStatus.NOT_PASS_THRESHOLD;
     }

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/spo/SPOVotingEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/spo/SPOVotingEvaluatorTest.java
@@ -1,0 +1,241 @@
+package com.bloxbean.cardano.yaci.store.governancerules.voting.spo;
+
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yaci.core.model.governance.actions.NoConfidence;
+import com.bloxbean.cardano.yaci.store.common.domain.PoolVotingThresholds;
+import com.bloxbean.cardano.yaci.store.common.util.UnitIntervalUtil;
+import com.bloxbean.cardano.yaci.store.governancerules.api.VotingData;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingEvaluationContext;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SPOVotingEvaluatorTest {
+
+    private final SPOVotingEvaluator evaluator = new SPOVotingEvaluator();
+
+    /**
+     * When all active SPO stake is counted as abstain, the denominator (total - abstain)
+     * becomes zero and the acceptance ratio is effectively 0, which is below any positive
+     * threshold → returns NOT_PASS_THRESHOLD.
+     */
+    @Test
+    void evaluate_returnsNotPassThreshold_whenAllStakeAbstains_andThresholdIsNonZero() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .abstainVoteStake(BigInteger.valueOf(100_000_000))
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .totalStake(BigInteger.valueOf(100_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    /**
+     * During the bootstrap phase, pools that did not vote are counted as abstain.
+     * If all pools do not vote, the acceptance ratio is effectively 0 → returns NOT_PASS_THRESHOLD.
+     */
+    @Test
+    void evaluate_returnsNotPassThreshold_whenAllPoolsDoNotVote_duringBootstrap_andThresholdIsNonZero() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .abstainVoteStake(BigInteger.ZERO)
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.valueOf(100_000_000))
+                        .totalStake(BigInteger.valueOf(100_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(true)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    /**
+     * When the required threshold is exactly zero, the vote auto-passes
+     * regardless of participating stake.
+     */
+    @Test
+    void evaluate_returnsPassThreshold_whenThresholdIsZero() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(BigDecimal.ZERO))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .abstainVoteStake(BigInteger.valueOf(100_000_000))
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .totalStake(BigInteger.valueOf(100_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    /**
+     * Yes stake exceeds threshold: yes=600M, abstain=100M, total=1000M
+     * → ratio = 600/(1000-100) ≈ 0.67 ≥ 0.51 → passes.
+     */
+    @Test
+    void evaluate_returnsPassThreshold_whenYesStakeMeetsThreshold() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(600_000_000))
+                        .abstainVoteStake(BigInteger.valueOf(100_000_000))
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.valueOf(300_000_000))
+                        .totalStake(BigInteger.valueOf(1_000_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.PASS_THRESHOLD);
+    }
+
+    /**
+     * Yes stake below threshold: yes=400M, abstain=0, total=1000M
+     * → ratio = 400/1000 = 0.40 < 0.67 → not pass.
+     */
+    @Test
+    void evaluate_returnsNotPassThreshold_whenYesStakeBelowThreshold() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.67")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(400_000_000))
+                        .abstainVoteStake(BigInteger.ZERO)
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.valueOf(600_000_000))
+                        .totalStake(BigInteger.valueOf(1_000_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    /**
+     * Returns INSUFFICIENT_DATA when spoVotes is null.
+     */
+    @Test
+    void evaluate_returnsInsufficientData_whenSpoVotesIsNull() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtMotionNoConfidence(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(null)
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(thresholds)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.INSUFFICIENT_DATA);
+    }
+
+    /**
+     * Returns INSUFFICIENT_DATA when poolThresholds is null.
+     */
+    @Test
+    void evaluate_returnsInsufficientData_whenPoolThresholdsIsNull() {
+        NoConfidence govAction = mock(NoConfidence.class);
+        when(govAction.getType()).thenReturn(GovActionType.NO_CONFIDENCE);
+
+        VotingData votingData = VotingData.builder()
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(600_000_000))
+                        .abstainVoteStake(BigInteger.ZERO)
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.valueOf(400_000_000))
+                        .totalStake(BigInteger.valueOf(1_000_000_000))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .govAction(govAction)
+                .poolThresholds(null)
+                .isInBootstrapPhase(false)
+                .build();
+
+        assertThat(evaluator.evaluate(votingData, context)).isEqualTo(VotingStatus.INSUFFICIENT_DATA);
+    }
+}


### PR DESCRIPTION
#880  
## Summary

  Fix incorrect auto-pass in `SPOVotingEvaluator` when all active SPO stake is counted as abstain.

  Previously, the evaluator returned `PASS_THRESHOLD` whenever `totalAbstain == totalStake` (or `totalStake == 0`), without checking the configured threshold. This caused governance actions to incorrectly pass when no
  non-abstaining stake participated.

  The correct behaviour: when the denominator `(totalStake - totalAbstain)` is zero, the acceptance ratio is effectively 0. A ratio of 0 is below any non-zero threshold, so the result should be `NOT_PASS_THRESHOLD`. The
   only legitimate auto-pass is when the threshold itself is 0 (no votes are required for this action type).