### PR TITLE
fix: Committee members without a registered hot key treated as abstain

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
@@ -93,10 +93,17 @@ public final class VoteTallyCalculator {
     public static VoteTallies.CommitteeTallies computeCommitteeTallies(Map<String, Vote> votesByHotKey, List<CommitteeMember> members) {
         int yes, no, abstain, didNotVote;
 
+        // Members with no registered hot key are excluded from the vote tally (treated as abstain).
+        // Only members with a registered hot key participate in yes/no/abstain/didNotVote counting.
+        List<CommitteeMember> membersWithHotKey = members.stream()
+                .filter(m -> m.getHotKey() != null)
+                .toList();
+        abstain = members.size() - membersWithHotKey.size();
+
         // calculate cc yes vote
 
         // Many CC Cold Credentials map to the same Hot Credential act as many votes.
-        Map<String, List<String>> hotKeyColdKeysMap = members.stream()
+        Map<String, List<String>> hotKeyColdKeysMap = membersWithHotKey.stream()
                 .collect(Collectors.groupingBy(
                         CommitteeMember::getHotKey,
                         Collectors.mapping(CommitteeMember::getColdKey, Collectors.toList())
@@ -111,23 +118,20 @@ public final class VoteTallyCalculator {
                 .mapToInt(e -> hotKeyColdKeysMap.get(e.getKey()).size())
                 .sum();
 
-        abstain = votesByHotKey.entrySet().stream()
+        abstain += votesByHotKey.entrySet().stream()
                 .filter(e -> e.getValue() == Vote.ABSTAIN && hotKeyColdKeysMap.containsKey(e.getKey()))
                 .mapToInt(e -> hotKeyColdKeysMap.get(e.getKey()).size())
                 .sum();
 
-        Map<String, String> coldKeyHotKeyMap = members.stream()
+        Map<String, String> coldKeyHotKeyMap = membersWithHotKey.stream()
                 .collect(Collectors.toMap(
                         CommitteeMember::getColdKey,
                         CommitteeMember::getHotKey,
                         (v1, v2) -> v1
                 ));
 
-        didNotVote = (int) members.stream()
-                .filter(member -> {
-                    String hotKey = coldKeyHotKeyMap.get(member.getColdKey());
-                    return hotKey == null || !votesByHotKey.containsKey(hotKey);
-                })
+        didNotVote = (int) membersWithHotKey.stream()
+                .filter(member -> !votesByHotKey.containsKey(coldKeyHotKeyMap.get(member.getColdKey())))
                 .count();
 
         return VoteTallies.CommitteeTallies.builder()

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
@@ -78,6 +78,51 @@ class VoteTallyCalculatorTest {
     }
 
     @Test
+    // A member with no registered hot key is excluded from the tally (treated as abstain).
+    void computeCommitteeTallies_memberWithNullHotKey_isCountedAsAbstain() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", null),
+                member("cold2222222222222222222222222222222222222222222222222222", "hot1111111111111111111111111111111111111111111111111111"),
+                member("cold3333333333333333333333333333333333333333333333333333", "hot2222222222222222222222222222222222222222222222222222")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.YES,
+                "hot2222222222222222222222222222222222222222222222222222", Vote.NO
+        );
+
+        VoteTallies.CommitteeTallies tallies = VoteTallyCalculator.computeCommitteeTallies(votes, members);
+
+        assertEquals(1, tallies.getYesCount());
+        assertEquals(1, tallies.getNoCount());
+        assertEquals(1, tallies.getAbstainCount()); // null-hotKey member
+        assertEquals(0, tallies.getDoNotVoteCount());
+    }
+
+    @Test
+    // A member with a registered hot key who did not vote is counted as doNotVote (→ NO in evaluator).
+    void computeCommitteeTallies_memberWithHotKey_noVote_isCountedAsDoNotVote() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", "hot1111111111111111111111111111111111111111111111111111"),
+                member("cold2222222222222222222222222222222222222222222222222222", "hot2222222222222222222222222222222222222222222222222222"),
+                member("cold3333333333333333333333333333333333333333333333333333", "hot3333333333333333333333333333333333333333333333333333")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.YES,
+                "hot2222222222222222222222222222222222222222222222222222", Vote.NO
+                // hot3 did not vote
+        );
+
+        VoteTallies.CommitteeTallies tallies = VoteTallyCalculator.computeCommitteeTallies(votes, members);
+
+        assertEquals(1, tallies.getYesCount());
+        assertEquals(1, tallies.getNoCount());
+        assertEquals(0, tallies.getAbstainCount());
+        assertEquals(1, tallies.getDoNotVoteCount());
+    }
+
+    @Test
     void computeCommitteeTalliesCountsEachMemberSharingHotKey() {
         List<CommitteeMember> members = List.of(
                 member("111111f83e9af24813e6cb368df6a80d38951b2a334dfcdf26815558", "aaaaaad4b9a2e70e88965d91dd69be182d5605b23bb5250b1c94bf64"),

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
@@ -1,0 +1,118 @@
+package com.bloxbean.cardano.yaci.store.governancerules.voting.committee;
+
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
+import com.bloxbean.cardano.yaci.store.governancerules.api.VotingData;
+import com.bloxbean.cardano.yaci.store.governancerules.domain.CommitteeMember;
+import com.bloxbean.cardano.yaci.store.governancerules.domain.ConstitutionCommittee;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingEvaluationContext;
+import com.bloxbean.cardano.yaci.core.model.governance.Vote;
+import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommitteeVotingEvaluatorTest {
+
+    private static final CommitteeVotingEvaluator EVALUATOR = new CommitteeVotingEvaluator();
+
+    @Test
+    void evaluate_memberWithoutHotKey_doesNotAffectAcceptedRatio() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", null),
+                member("cold2222222222222222222222222222222222222222222222222222", "hot1111111111111111111111111111111111111111111111111111"),
+                member("cold3333333333333333333333333333333333333333333333333333", "hot2222222222222222222222222222222222222222222222222222")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.YES,
+                "hot2222222222222222222222222222222222222222222222222222", Vote.NO
+        );
+
+        // ratio = 1 yes / (1 yes + 1 no) = 0.5, threshold = 0.5 → PASS
+        VotingStatus result = evaluate(members, votes, 1, 2);
+        assertEquals(VotingStatus.PASS_THRESHOLD, result);
+    }
+
+    @Test
+    void evaluate_registeredMemberWithNoVote_countsAsNo() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", "hot1111111111111111111111111111111111111111111111111111"),
+                member("cold2222222222222222222222222222222222222222222222222222", "hot2222222222222222222222222222222222222222222222222222"),
+                member("cold3333333333333333333333333333333333333333333333333333", "hot3333333333333333333333333333333333333333333333333333")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.YES
+                // hot2, hot3 did not vote → counted as NO
+        );
+
+        // ratio = 1 yes / (1 yes + 2 no) ≈ 0.33, threshold = 0.5 → NOT_PASS
+        VotingStatus result = evaluate(members, votes, 1, 2);
+        assertEquals(VotingStatus.NOT_PASS_THRESHOLD, result);
+    }
+
+    @Test
+    void evaluate_abstainVote_isExcludedFromDenominator() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", "hot1111111111111111111111111111111111111111111111111111"),
+                member("cold2222222222222222222222222222222222222222222222222222", "hot2222222222222222222222222222222222222222222222222222"),
+                member("cold3333333333333333333333333333333333333333333333333333", "hot3333333333333333333333333333333333333333333333333333")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.YES,
+                "hot2222222222222222222222222222222222222222222222222222", Vote.ABSTAIN,
+                "hot3333333333333333333333333333333333333333333333333333", Vote.NO
+        );
+
+        // ratio = 1 yes / (1 yes + 1 no) = 0.5, threshold = 0.5 → PASS
+        VotingStatus result = evaluate(members, votes, 1, 2);
+        assertEquals(VotingStatus.PASS_THRESHOLD, result);
+    }
+
+    @Test
+    void evaluate_zeroThreshold_alwaysPasses() {
+        List<CommitteeMember> members = List.of(
+                member("cold1111111111111111111111111111111111111111111111111111", "hot1111111111111111111111111111111111111111111111111111")
+        );
+
+        Map<String, Vote> votes = Map.of(
+                "hot1111111111111111111111111111111111111111111111111111", Vote.NO
+        );
+
+        VotingStatus result = evaluate(members, votes, 0, 1);
+        assertEquals(VotingStatus.PASS_THRESHOLD, result);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private VotingStatus evaluate(List<CommitteeMember> members, Map<String, Vote> votes,
+                                   long thresholdNumerator, long thresholdDenominator) {
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder().votes(votes).build())
+                .build();
+
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .members(members)
+                .threshold(new UnitInterval(BigInteger.valueOf(thresholdNumerator),
+                        BigInteger.valueOf(thresholdDenominator)))
+                .build();
+
+        VotingEvaluationContext ctx = VotingEvaluationContext.builder()
+                .committee(committee)
+                .build();
+
+        return EVALUATOR.evaluate(votingData, ctx);
+    }
+
+    private static CommitteeMember member(String coldKey, String hotKey) {
+        return CommitteeMember.builder()
+                .coldKey(coldKey)
+                .hotKey(hotKey)
+                .build();
+    }
+}


### PR DESCRIPTION
#885 
### Problem                                                                                                                                                                                                              
                                                                                                                                                                                                                           
  `VoteTallyCalculator.computeCommitteeTallies` conflated two distinct cases in the `didNotVote` bucket:                                                                                                                   
                                                                                                                                                                                                                           
  | Case | Was treated as | Correct treatment |                                                                                                                                                                            
  |---|---|---|                                                                                                                                                                                                        
  | Member with no registered hot key (`hotKey == null`) | NO | **Abstain** (excluded from denominator) |                                                                                                                  
  | Member with hot key, but did not vote | NO | NO (correct) |                                                                                                                                                            
                                                                                                                                                                                                                           
  Because `CommitteeVotingEvaluator` adds `doNotVoteCount` to NO, members without a registered hot key incorrectly inflated the NO count and lowered the acceptance ratio, making governance proposals harder to ratify  than the protocol specifies.                                                                                                                                                                                             
                                                                                                                                                                                                                           
  ### Root cause                                                                                                                                                                                                           
                                                                                                                                                                                                                           
  In `VoteTallyCalculator.java`:                                                                                                                                                                                           
  ```java                                                                                                                                                                                                              
  // BEFORE — hotKey == null and "has hotKey but no vote" both land in didNotVote                                                                                                                                          
  return hotKey == null || !votesByHotKey.containsKey(hotKey);                        
```                                                                                                                                     
                                                                                                                                                                                                                           
  Fix                                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  Partition the member list before tallying: null-hotKey members go directly to abstain; members with a registered hot key proceed through the existing yes/no/abstain/doNotVote logic unchanged. CommitteeVotingEvaluator 
requires no change — doNotVoteCount now only contains registered members who did not vote (correctly treated as NO).                                                                                                     
                                                                                                                                                                                                                           
                                                                                                                     
  Tests                                                                                                                                                                                                                    
                                                                                                                                                                                                                           
  - VoteTallyCalculatorTest — 2 new cases: null-hotKey member counted as abstain; registered-but-no-vote member counted as doNotVote                                                                                       
  - CommitteeVotingEvaluatorTest — new test class covering: null-hotKey member excluded from denominator, registered no-vote counted as NO, abstain vote excluded from denominator, zero threshold auto-pass               
                                                              