### PR TITLE
 fix(admin-ui): add @ReadOnly(false) to prevent startup crash in read-only mode

### DIFF
--- a/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/HealthController.java
+++ b/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/HealthController.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.adminui.controller;
 
 import com.bloxbean.cardano.yaci.store.adminui.dto.HealthStatusDto;
 import com.bloxbean.cardano.yaci.store.adminui.service.HealthStatusService;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin-ui")
 @RequiredArgsConstructor
+@ReadOnly(false)
 @Hidden
 public class HealthController {
     private final HealthStatusService healthStatusService;

--- a/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/LedgerStateController.java
+++ b/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/LedgerStateController.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.adminui.controller;
 
 import com.bloxbean.cardano.yaci.store.adminui.dto.LedgerStateStatusDto;
 import com.bloxbean.cardano.yaci.store.adminui.service.LedgerStateStatusService;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin-ui")
 @RequiredArgsConstructor
+@ReadOnly(false)
 @Hidden
 public class LedgerStateController {
     private final LedgerStateStatusService ledgerStateStatusService;

--- a/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/SyncStatusController.java
+++ b/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/controller/SyncStatusController.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.adminui.controller;
 import com.bloxbean.cardano.yaci.store.adminui.AdminUiProperties;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.SyncStatus;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.core.service.StartService;
 import com.bloxbean.cardano.yaci.store.core.service.SyncStatusService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -16,6 +17,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/admin-ui/sync")
 @RequiredArgsConstructor
+@ReadOnly(false)
 @Hidden
 public class SyncStatusController {
     private final SyncStatusService syncStatusService;

--- a/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/service/HealthStatusService.java
+++ b/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/service/HealthStatusService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.adminui.service;
 
 import com.bloxbean.cardano.yaci.store.adminui.dto.HealthStatusDto;
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.core.service.HealthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@ReadOnly(false)
 @Slf4j
 public class HealthStatusService {
     private final HealthService healthService;

--- a/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/service/LedgerStateStatusService.java
+++ b/components/admin-ui/src/main/java/com/bloxbean/cardano/yaci/store/adminui/service/LedgerStateStatusService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.adminui.service;
 
 import com.bloxbean.cardano.yaci.store.adminui.dto.LedgerStateStatusDto;
 import com.bloxbean.cardano.yaci.store.common.domain.SyncStatus;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.core.service.SyncStatusService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
+@ReadOnly(false)
 @Slf4j
 public class LedgerStateStatusService {
 


### PR DESCRIPTION

## Summary

When both `store.read-only-mode=true` and `store.admin.ui.enabled=true` are set, the application fails at startup with `UnsatisfiedDependencyException`. The `AdminUiAutoConfiguration` uses `@ComponentScan` which unconditionally registers all admin-ui beans, but several of them depend on core beans (`HealthService`, `SyncStatusService`, `StartService`) that are annotated with `@ReadOnly(false)` and therefore not available in read-only mode.

This PR adds `@ReadOnly(false)` to the 5 affected admin-ui components so they are excluded in read-only mode. Other admin-ui endpoints (config, store status, indexes) remain functional.

## Changes

- Add `@ReadOnly(false)` to `HealthController` and `HealthStatusService` (depend on `HealthService`)
- Add `@ReadOnly(false)` to `SyncStatusController` (depends on `SyncStatusService` and `StartService`)
- Add `@ReadOnly(false)` to `LedgerStateController` and `LedgerStateStatusService` (depend on `SyncStatusService`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing: start app with `store.read-only-mode=true` + `store.admin.ui.enabled=true` — should boot without crash
- [x] Verify `/api/admin-ui/config`, `/api/admin-ui/stores`, `/api/admin-ui/indexes` respond in read-only mode
- [x] Verify `/api/admin-ui/health`, `/api/admin-ui/sync/status`, `/api/admin-ui/ledger-state` return 404 in read-only mode
- [x] Verify all admin-ui endpoints work normally with `store.read-only-mode=false`

## Related Issues

Fixes #884