### PR TITLE
chore: bump yaci version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.4.1"
+yaci = "com.bloxbean.cardano:yaci:0.4.2"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.1"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.1"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.1"


### PR DESCRIPTION
yaci 0.4.1 -> 0.4.2