### PR TITLE
feat(scripts): add Yaci Store ↔ DB Sync data comparison tool

### DIFF
--- a/scripts/compare/.gitignore
+++ b/scripts/compare/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+logs/
+config.json

--- a/scripts/compare/README.md
+++ b/scripts/compare/README.md
@@ -72,7 +72,7 @@ All scripts accept the same base flags:
 Script-specific flags:
 
 - `compare_reward_rest.py`: `--reward-type {treasury,reserves,proposal_refund}` (default `proposal_refund`)
-- `compare_epoch_stake.py`: `--reverse` (iterate high → low), `--delay SECONDS` (sleep between epochs to avoid DB overload)
+- `compare_epoch_stake.py`: `--reverse` (iterate high → low), `--delay SECONDS` (sleep between epochs to avoid DB overload), `--include-zero-amount` (compare raw `epoch_stake` rows instead of ignoring `amount = 0`)
 - `compare_all.py`: `--only KEY[,KEY...]` / `--skip KEY[,KEY...]` to filter the set of comparators run, and `--reward-types treasury,reserves,proposal_refund` to choose which reward types `compare_reward_rest.py` runs for (default: all three). Comparator keys: `adapot`, `epoch_stake`, `reward_rest`, `drep_amount`, `drep_active_until`, `gov_action_proposal_status`.
 
 ## Run everything in one command
@@ -169,7 +169,7 @@ python3 compare_all.py --start-epoch 510 --end-epoch 520 --config config.json
 
 ## Notes on the underlying data
 
-- **epoch_stake**: Yaci Store query uses `epoch = epoch - 2`, mirroring the offset in the original Java comparator.
+- **epoch_stake**: Yaci Store query uses `epoch = epoch - 2`, mirroring the offset in the original Java comparator. By default, zero-amount rows are ignored on both sides to match current DB Sync active-stake semantics; use `--include-zero-amount` if you need to inspect raw table differences.
 - **drep_dist**: `ABSTAIN` and `NO_CONFIDENCE` are excluded from the per-hash comparison and checked separately as aggregate totals.
 - **gov_action_proposal_status**: Yaci Store has only three statuses (`ACTIVE`, `RATIFIED`, `EXPIRED`) and stores one row per (proposal, epoch) snapshot. DB Sync stores one row per proposal with end-state epoch columns; the script derives the expected Yaci status from `ratified_epoch`, `enacted_epoch`, `dropped_epoch`, `expired_epoch`, and `submit_epoch`. See the comments in `compare_gov_action_proposal_status.py` for the full lifecycle mapping.
 - **reward_rest**: compared as a multiset (counts of identical rows must match), not just presence/absence.

--- a/scripts/compare/README.md
+++ b/scripts/compare/README.md
@@ -1,0 +1,175 @@
+# Yaci Store ↔ DB Sync Comparison Scripts
+
+Python scripts that compare data between a **Cardano DB Sync** PostgreSQL database and a **Yaci Store** PostgreSQL database, epoch by epoch. They replace the older Java-based `*DataComparator` utilities — no build step, configurable via JSON file or CLI flags.
+
+## Contents
+
+| Script | What it compares | Source tables |
+|---|---|---|
+| `compare_all.py` | Runs every comparator below in one command | — |
+| `compare_adapot.py` | `treasury` and `reserves` per epoch | `ada_pots` ↔ `adapot` |
+| `compare_epoch_stake.py` | Per-(stake address, pool) staked `amount` | `epoch_stake` ↔ `epoch_stake` (Yaci uses `epoch - 2` offset) |
+| `compare_reward_rest.py` | `reward_rest` rows as a multiset (address, type, earned_epoch, amount, spendable_epoch) | `reward_rest` ↔ `reward_rest` |
+| `compare_drep_amount.py` | DRep distribution `amount` per drep hash + `ABSTAIN` / `NO_CONFIDENCE` aggregates | `drep_distr` ↔ `drep_dist` |
+| `compare_drep_active_until.py` | DRep `active_until` epoch per drep hash | `drep_distr` ↔ `drep_dist` |
+| `compare_gov_action_proposal_status.py` | Governance action proposal status (`ACTIVE` / `RATIFIED` / `EXPIRED`) — derived from DB Sync epoch columns | `gov_action_proposal` ↔ `gov_action_proposal_status` |
+| `common.py` | Shared utilities: config loading, DB connection, `Logger`, hash normalization | — |
+| `config.json` / `config.example.json` | Default connection settings | — |
+
+## Requirements
+
+- Python 3
+- `psycopg2-binary`
+
+```bash
+pip3 install psycopg2-binary
+```
+
+## Configuration
+
+Connections can be supplied through a JSON config file, environment URLs, or individual CLI flags. Resolution order: built-in defaults → config file → CLI args (CLI wins).
+
+`config.example.json`:
+
+```json
+{
+  "dbsync_url": "postgresql://10.4.10.135:5678/cexplorer",
+  "dbsync_user": "dbsync",
+  "dbsync_password": "dbsync",
+  "store_url": "postgresql://10.4.10.112:5432/yaci_store",
+  "store_user": "yaci",
+  "store_password": "dbpass",
+  "store_schema": "yaci_store",
+  "quiet": false,
+  "max_mismatches": 0,
+  "delay": 0
+}
+```
+
+Copy it to `config.json` and edit:
+
+```bash
+cp config.example.json config.json
+```
+
+## Common CLI flags
+
+All scripts accept the same base flags:
+
+| Flag | Purpose |
+|---|---|
+| `--config FILE` | Path to a JSON config file |
+| `--dbsync-url URL` | DB Sync PostgreSQL connection URL |
+| `--dbsync-user` / `--dbsync-password` | Override userinfo on the DB Sync URL |
+| `--store-url URL` | Yaci Store PostgreSQL connection URL |
+| `--store-user` / `--store-password` | Override userinfo on the Yaci Store URL |
+| `--store-schema NAME` | Yaci Store schema (default `yaci_store`) |
+| `--epoch N` | Compare a single epoch |
+| `--start-epoch N --end-epoch M` | Compare an inclusive epoch range |
+| `--max-mismatches N` | Stop printing once `N` mismatches are reached for that epoch (0 = unlimited) |
+| `--quiet` | Write to log file only, do not echo to console |
+
+Script-specific flags:
+
+- `compare_reward_rest.py`: `--reward-type {treasury,reserves,proposal_refund}` (default `proposal_refund`)
+- `compare_epoch_stake.py`: `--reverse` (iterate high → low), `--delay SECONDS` (sleep between epochs to avoid DB overload)
+- `compare_all.py`: `--only KEY[,KEY...]` / `--skip KEY[,KEY...]` to filter the set of comparators run, and `--reward-types treasury,reserves,proposal_refund` to choose which reward types `compare_reward_rest.py` runs for (default: all three). Comparator keys: `adapot`, `epoch_stake`, `reward_rest`, `drep_amount`, `drep_active_until`, `gov_action_proposal_status`.
+
+## Run everything in one command
+
+`compare_all.py` is a wrapper that runs every comparator in this directory sequentially against the same epoch (or epoch range), forwards all common flags, and prints a combined summary at the end. Each child script still writes its own timestamped log under `logs/`.
+
+```bash
+# Run every comparator for a single epoch
+python3 compare_all.py --epoch 800 --config config.json
+
+# Run every comparator across an epoch range
+python3 compare_all.py --start-epoch 740 --end-epoch 902 --config config.json
+
+# Run only a subset
+python3 compare_all.py --epoch 800 --only adapot,drep_amount --config config.json
+
+# Run everything except the heavy ones
+python3 compare_all.py --epoch 800 --skip epoch_stake,reward_rest --config config.json
+
+# Restrict reward_rest to specific types (default runs all three)
+python3 compare_all.py --epoch 1075 --reward-types treasury,reserves --config config.json
+```
+
+The wrapper exits with a non-zero status if any child comparator returned a non-zero exit code, so it can be wired into CI directly. Example overall summary:
+
+```
+============================================================
+OVERALL SUMMARY (compare_all)
+============================================================
+  Total runtime : 312.4s
+  Comparators   : 8
+
+  Comparator                                 RC    Time(s)
+  ---------------------------------------- ----  ----------
+  adapot                                     OK        2.1
+  epoch_stake                                OK      120.5
+  reward_rest (type=treasury)                OK       18.2
+  reward_rest (type=reserves)                OK       17.9
+  reward_rest (type=proposal_refund)         OK       18.5
+  drep_amount                                OK       45.0
+  drep_active_until                          OK       40.1
+  gov_action_proposal_status                 OK       50.1
+
+  Failures      : 0/8
+============================================================
+```
+
+## Logging
+
+Every run writes a timestamped log file under `logs/`:
+
+```
+logs/adapot_compare_<timestamp>.log
+logs/epoch_stake_compare_<timestamp>.log
+logs/reward_rest_compare_<type>_<timestamp>.log
+logs/drep_compare_amount_<timestamp>.log
+logs/drep_compare_active_until_<timestamp>.log
+logs/gov_action_proposal_status_compare_<timestamp>.log
+```
+
+Each log ends with a summary block:
+
+```
+SUMMARY (...):
+  Epochs compared     : N
+  Epochs w/ mismatch  : X/N
+  Total mismatches    : M
+```
+
+## Examples
+
+```bash
+# Compare AdaPot treasury/reserves for one epoch
+python3 compare_adapot.py --epoch 800 --config config.json
+
+# Compare epoch_stake across a range, with 5-second pause between epochs
+python3 compare_epoch_stake.py --start-epoch 740 --end-epoch 902 --delay 5 --config config.json
+
+# Compare reward_rest with a specific reward type
+python3 compare_reward_rest.py --epoch 1075 --reward-type treasury --config config.json
+
+# Compare DRep distribution amounts for a range
+python3 compare_drep_amount.py --start-epoch 510 --end-epoch 520 --config config.json
+
+# Compare DRep active_until
+python3 compare_drep_active_until.py --epoch 624 --config config.json
+
+# Compare governance action proposal status
+python3 compare_gov_action_proposal_status.py --start-epoch 510 --end-epoch 520 --config config.json
+
+# Run every comparator above in one command
+python3 compare_all.py --start-epoch 510 --end-epoch 520 --config config.json
+```
+
+## Notes on the underlying data
+
+- **epoch_stake**: Yaci Store query uses `epoch = epoch - 2`, mirroring the offset in the original Java comparator.
+- **drep_dist**: `ABSTAIN` and `NO_CONFIDENCE` are excluded from the per-hash comparison and checked separately as aggregate totals.
+- **gov_action_proposal_status**: Yaci Store has only three statuses (`ACTIVE`, `RATIFIED`, `EXPIRED`) and stores one row per (proposal, epoch) snapshot. DB Sync stores one row per proposal with end-state epoch columns; the script derives the expected Yaci status from `ratified_epoch`, `enacted_epoch`, `dropped_epoch`, `expired_epoch`, and `submit_epoch`. See the comments in `compare_gov_action_proposal_status.py` for the full lifecycle mapping.
+- **reward_rest**: compared as a multiset (counts of identical rows must match), not just presence/absence.

--- a/scripts/compare/README.md
+++ b/scripts/compare/README.md
@@ -67,13 +67,13 @@ All scripts accept the same base flags:
 | `--epoch N` | Compare a single epoch |
 | `--start-epoch N --end-epoch M` | Compare an inclusive epoch range |
 | `--max-mismatches N` | Stop printing once `N` mismatches are reached for that epoch (0 = unlimited) |
-| `--quiet` | Write to log file only, do not echo to console |
+| `--quiet` | Write to log file only, do not echo to console. In `compare_all.py`, suppress child output but still print wrapper progress and final summary |
 
 Script-specific flags:
 
 - `compare_reward_rest.py`: `--reward-type {treasury,reserves,proposal_refund}` (default `proposal_refund`)
 - `compare_epoch_stake.py`: `--reverse` (iterate high → low), `--delay SECONDS` (sleep between epochs to avoid DB overload), `--include-zero-amount` (compare raw `epoch_stake` rows instead of ignoring `amount = 0`)
-- `compare_all.py`: `--only KEY[,KEY...]` / `--skip KEY[,KEY...]` to filter the set of comparators run, and `--reward-types treasury,reserves,proposal_refund` to choose which reward types `compare_reward_rest.py` runs for (default: all three). Comparator keys: `adapot`, `epoch_stake`, `reward_rest`, `drep_amount`, `drep_active_until`, `gov_action_proposal_status`.
+- `compare_all.py`: `--only KEY[,KEY...]` / `--skip KEY[,KEY...]` to filter the set of comparators run, `--reward-types treasury,reserves,proposal_refund` to choose which reward types `compare_reward_rest.py` runs for (default: all three), and `--summary-file FILE` to override the final summary output path. Comparator keys: `adapot`, `epoch_stake`, `reward_rest`, `drep_amount`, `drep_active_until`, `gov_action_proposal_status`.
 
 ## Run everything in one command
 
@@ -94,30 +94,44 @@ python3 compare_all.py --epoch 800 --skip epoch_stake,reward_rest --config confi
 
 # Restrict reward_rest to specific types (default runs all three)
 python3 compare_all.py --epoch 1075 --reward-types treasury,reserves --config config.json
+
+# Write the final summary to a custom file
+python3 compare_all.py --epoch 800 --summary-file /tmp/yaci_compare_summary.log --config config.json
 ```
 
-The wrapper exits with a non-zero status if any child comparator returned a non-zero exit code, so it can be wired into CI directly. Example overall summary:
+The wrapper streams each child comparator as it runs, then repeats the important result fields at the end so you do not have to scroll back through the output. It also writes the same final summary to `logs/compare_all_summary_<timestamp>.log` by default, or to `--summary-file FILE` when provided. It exits with a non-zero status if any comparator reports mismatches, errors, or an unparseable summary. Example final summary:
 
 ```
-============================================================
-OVERALL SUMMARY (compare_all)
-============================================================
-  Total runtime : 312.4s
-  Comparators   : 8
+====================================================================================================
+FINAL RESULT SUMMARY (compare_all)
+====================================================================================================
+  Started at        : 2026-05-11T10:00:00
+  Finished at       : 2026-05-11T10:05:12
+  Command           : /usr/bin/python3 compare_all.py --start-epoch 740 --end-epoch 902 --config config.json
+  Epoch scope       : epochs 740 -> 902
+  Total runtime     : 312.4s
+  Comparators run   : 8
+  Status counts     : OK=7, MISMATCH=1, ERROR=0, UNKNOWN=0
+  Total mismatches  : 12
 
-  Comparator                                 RC    Time(s)
-  ---------------------------------------- ----  ----------
-  adapot                                     OK        2.1
-  epoch_stake                                OK      120.5
-  reward_rest (type=treasury)                OK       18.2
-  reward_rest (type=reserves)                OK       17.9
-  reward_rest (type=proposal_refund)         OK       18.5
-  drep_amount                                OK       45.0
-  drep_active_until                          OK       40.1
-  gov_action_proposal_status                 OK       50.1
+  Comparator                               Status      Epochs  Bad epochs  Mismatches   RC  Time(s)
+  ---------------------------------------- --------- -------- ----------- ----------- ---- --------
+  adapot                                   OK             163       0/163           0    0      2.1
+  epoch_stake                              MISMATCH       163       4/163          12    0    120.5
+  reward_rest (type=treasury)              OK             163       0/163           0    0     18.2
+  reward_rest (type=reserves)              OK             163       0/163           0    0     17.9
+  reward_rest (type=proposal_refund)       OK             163       0/163           0    0     18.5
+  drep_amount                              OK             163       0/163           0    0     45.0
+  drep_active_until                        OK             163       0/163           0    0     40.1
+  gov_action_proposal_status               OK             163       0/163           0    0     50.1
 
-  Failures      : 0/8
-============================================================
+  Logs:
+    adapot: /path/to/scripts/compare/logs/adapot_compare_20260511_100000.log
+    epoch_stake: /path/to/scripts/compare/logs/epoch_stake_compare_20260511_100002.log
+    ...
+====================================================================================================
+
+Final summary written to: /path/to/scripts/compare/logs/compare_all_summary_20260511_100000.log
 ```
 
 ## Logging
@@ -131,6 +145,7 @@ logs/reward_rest_compare_<type>_<timestamp>.log
 logs/drep_compare_amount_<timestamp>.log
 logs/drep_compare_active_until_<timestamp>.log
 logs/gov_action_proposal_status_compare_<timestamp>.log
+logs/compare_all_summary_<timestamp>.log
 ```
 
 Each log ends with a summary block:

--- a/scripts/compare/common.py
+++ b/scripts/compare/common.py
@@ -1,0 +1,167 @@
+"""
+Shared utilities for compare scripts: config loading, Logger, DB connection.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse, urlunparse, quote
+
+try:
+    import psycopg2
+except ImportError:
+    print("ERROR: psycopg2 library is not installed.")
+    print("Run: pip3 install psycopg2-binary")
+    sys.exit(1)
+
+
+# ============================================================
+# Default connection config
+# ============================================================
+DEFAULT_DBSYNC_URL = "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer"
+DEFAULT_STORE_URL = "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store"
+DEFAULT_STORE_SCHEMA = "yaci_store"
+
+
+# ============================================================
+# Config loading
+# ============================================================
+def load_config(config_path):
+    """Load config from a JSON file. Returns a dict."""
+    with open(config_path, "r") as f:
+        return json.load(f)
+
+
+def add_common_args(parser):
+    """Add common arguments (config file, DB connections, output) to an ArgumentParser."""
+    parser.add_argument("--config", metavar="FILE", help="Path to JSON config file (CLI args override file values)")
+    parser.add_argument("--dbsync-url", help="DB Sync connection URL")
+    parser.add_argument("--dbsync-user", help="DB Sync username (override URL userinfo)")
+    parser.add_argument("--dbsync-password", help="DB Sync password (override URL userinfo)")
+    parser.add_argument("--store-url", help="Yaci Store connection URL")
+    parser.add_argument("--store-user", help="Yaci Store username (override URL userinfo)")
+    parser.add_argument("--store-password", help="Yaci Store password (override URL userinfo)")
+    parser.add_argument("--store-schema", help="Yaci Store schema name")
+    parser.add_argument("--quiet", action="store_true", default=None, help="Write to log file only, do not print to console")
+
+
+def resolve_config(args):
+    """
+    Merge config from: defaults -> config file -> CLI args.
+    CLI args always win. Config file overrides defaults.
+    Modifies args in-place and returns it.
+    """
+    # Start with defaults
+    defaults = {
+        "dbsync_url": DEFAULT_DBSYNC_URL,
+        "store_url": DEFAULT_STORE_URL,
+        "store_schema": DEFAULT_STORE_SCHEMA,
+        "quiet": False,
+        "max_mismatches": 0,
+        "delay": 0,
+    }
+
+    # Layer config file on top of defaults
+    if args.config:
+        file_cfg = load_config(args.config)
+        defaults.update(file_cfg)
+
+    # Map CLI arg names (with hyphens) to config keys (with underscores)
+    cli_mapping = {
+        "dbsync_url": "dbsync_url",
+        "dbsync_user": "dbsync_user",
+        "dbsync_password": "dbsync_password",
+        "store_url": "store_url",
+        "store_user": "store_user",
+        "store_password": "store_password",
+        "store_schema": "store_schema",
+        "quiet": "quiet",
+        "max_mismatches": "max_mismatches",
+        "delay": "delay",
+    }
+
+    for attr, cfg_key in cli_mapping.items():
+        cli_val = getattr(args, attr, None)
+        if cli_val is None:
+            # CLI arg not provided -> use config/default
+            setattr(args, attr, defaults.get(cfg_key, None))
+
+    # Apply user/pass overrides to URLs if provided
+    args.dbsync_url = apply_credentials(args.dbsync_url, args.dbsync_user, args.dbsync_password)
+    args.store_url = apply_credentials(args.store_url, args.store_user, args.store_password)
+
+    return args
+
+
+def apply_credentials(url, user, password):
+    """Override the userinfo component of a postgresql URL with user/password if provided."""
+    if not url or (not user and not password):
+        return url
+    parsed = urlparse(url)
+    existing_user = parsed.username or ""
+    existing_pass = parsed.password or ""
+    new_user = user if user is not None else existing_user
+    new_pass = password if password is not None else existing_pass
+
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+
+    userinfo = ""
+    if new_user or new_pass:
+        userinfo = quote(new_user, safe="")
+        if new_pass:
+            userinfo += ":" + quote(new_pass, safe="")
+        userinfo += "@"
+
+    netloc = f"{userinfo}{host}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+# ============================================================
+# Logger
+# ============================================================
+class Logger:
+    def __init__(self, log_file, quiet=False):
+        self.log_file = log_file
+        self.quiet = quiet
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        with open(log_file, "w") as f:
+            f.write("")
+
+    def log(self, message=""):
+        if not self.quiet:
+            print(message)
+        with open(self.log_file, "a") as f:
+            f.write(message + "\n")
+
+    def error(self, message, exc=None):
+        err_msg = f"ERROR: {message}"
+        if exc:
+            err_msg += f"\n  {type(exc).__name__}: {exc}"
+        print(err_msg, file=sys.stderr)
+        with open(self.log_file, "a") as f:
+            f.write(err_msg + "\n")
+
+
+# ============================================================
+# DB helpers
+# ============================================================
+def normalize_hash(h):
+    """Normalize drep/pool hash: lowercase hex, strip 0x prefix, accept bytes."""
+    if h is None:
+        return None
+    if isinstance(h, (bytes, bytearray, memoryview)):
+        h = bytes(h).hex()
+    h = str(h)
+    if h.startswith("0x") or h.startswith("0X"):
+        h = h[2:]
+    return h.lower()
+
+
+def connect(url, schema=None):
+    conn = psycopg2.connect(url)
+    if schema:
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}")
+    return conn

--- a/scripts/compare/compare_adapot.py
+++ b/scripts/compare/compare_adapot.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_adapot.py - Compare AdaPot data between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_adapot.py --epoch 800 --config config.json
+
+   # Compare adapot for a specific epoch
+   python3 compare_adapot.py --epoch 800
+
+   # Compare across an epoch range (740 to 902)
+   python3 compare_adapot.py --start-epoch 740 --end-epoch 902
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_adapot.py --epoch 800 \
+       --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
+       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_adapot.py --epoch 800 --quiet
+
+3. Output:
+   - Prints to console (and writes to log file in logs/ directory)
+   - Log file named: logs/adapot_compare_<timestamp>.log
+   - Compares 2 fields: treasury and reserves
+
+4. Notes:
+   - DB Sync stores adapot in the ada_pots table (last record by slot_no)
+   - Yaci Store stores adapot in the adapot table
+   - Config file (JSON) provides defaults, CLI args override
+
+PROBLEM SOLVED:
+---------------
+This script replaces AdapotDataComparator.java, with advantages:
+  - No build/compile needed, runs directly with Python
+  - Flexible configuration via config file or command-line arguments
+  - Automatic timestamped logging
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config
+
+
+# ============================================================
+# Compare: adapot (treasury + reserves)
+# ============================================================
+def compare_adapot(epoch, dbsync_url, store_url, store_schema, logger):
+    dbsync_query = """
+        SELECT treasury, reserves
+        FROM ada_pots
+        WHERE epoch_no = %s
+        ORDER BY slot_no DESC
+        LIMIT 1
+    """
+    store_query = "SELECT treasury, reserves FROM adapot WHERE epoch = %s"
+
+    dbsync_treasury = None
+    dbsync_reserves = None
+    store_treasury = None
+    store_reserves = None
+
+    # --- Fetch DB Sync ---
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, (epoch,))
+            row = cur.fetchone()
+            if row:
+                dbsync_treasury, dbsync_reserves = int(row[0]), int(row[1])
+            else:
+                logger.log(f"  No data in DB Sync for epoch {epoch}")
+                return 0
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    # --- Fetch Yaci Store ---
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (epoch,))
+            row = cur.fetchone()
+            if row:
+                store_treasury, store_reserves = int(row[0]), int(row[1])
+            else:
+                logger.log(f"  No data in Yaci Store for epoch {epoch}")
+                return 0
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    # --- Compare ---
+    mismatch_count = 0
+
+    if dbsync_treasury != store_treasury:
+        mismatch_count += 1
+        logger.log(f"  Mismatch TREASURY: DB Sync={dbsync_treasury}, Yaci Store={store_treasury}")
+
+    if dbsync_reserves != store_reserves:
+        mismatch_count += 1
+        logger.log(f"  Mismatch RESERVES: DB Sync={dbsync_reserves}, Yaci Store={store_reserves}")
+
+    return mismatch_count
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare AdaPot data (treasury, reserves) between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 800
+  %(prog)s --epoch 800 --config config.json
+  %(prog)s --start-epoch 740 --end-epoch 902
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch, end_epoch = args.epoch, args.epoch
+    else:
+        start_epoch, end_epoch = args.start_epoch, args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+        if end_epoch < start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"adapot_compare_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log("===== Starting AdaPot comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epoch range: {start_epoch} -> {end_epoch}")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+    total_epochs = end_epoch - start_epoch + 1
+
+    for epoch in range(start_epoch, end_epoch + 1):
+        logger.log(f"############ Epoch {epoch} - adapot ############")
+
+        count = compare_adapot(epoch, args.dbsync_url, args.store_url, args.store_schema, logger)
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - Treasury and Reserves match between DB Sync and Yaci Store")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+    logger.log("=" * 50)
+    logger.log("SUMMARY (adapot):")
+    logger.log(f"  Epochs compared     : {total_epochs}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{total_epochs}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_adapot.py
+++ b/scripts/compare/compare_adapot.py
@@ -23,8 +23,8 @@ USAGE:
 
    # Custom database connections (CLI args override config file)
    python3 compare_adapot.py --epoch 800 \
-       --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
-       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --dbsync-url "postgresql://dbsync:dbsync@localhost:5678/cexplorer" \
+       --store-url "postgresql://yaci:dbpass@localhost:5432/yaci_store" \
        --store-schema yaci_store
 
    # Output to log file only, suppress console output

--- a/scripts/compare/compare_all.py
+++ b/scripts/compare/compare_all.py
@@ -29,6 +29,8 @@ USAGE:
 
 import argparse
 import os
+import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime
@@ -46,6 +48,85 @@ COMPARATORS = [
 ]
 
 REWARD_TYPES_DEFAULT = ["treasury", "reserves", "proposal_refund"]
+
+
+def new_child_summary():
+    return {
+        "log_file": None,
+        "epochs_compared": None,
+        "epochs_with_mismatch": None,
+        "epochs_total": None,
+        "total_mismatches": None,
+        "reported_errors": 0,
+    }
+
+
+def parse_child_output_line(line, summary):
+    stripped = line.strip()
+
+    if stripped.startswith("Log file:"):
+        summary["log_file"] = stripped.split(":", 1)[1].strip()
+        return
+
+    if stripped.startswith("ERROR:") or "Database connection error" in stripped:
+        summary["reported_errors"] += 1
+        return
+
+    match = re.match(r"Epochs compared\s*:\s*(\d+)", stripped)
+    if match:
+        summary["epochs_compared"] = int(match.group(1))
+        return
+
+    match = re.match(r"Epochs w/ mismatch\s*:\s*(\d+)\s*/\s*(\d+)", stripped)
+    if match:
+        summary["epochs_with_mismatch"] = int(match.group(1))
+        summary["epochs_total"] = int(match.group(2))
+        return
+
+    match = re.match(r"Total mismatches\s*:\s*(\d+)", stripped)
+    if match:
+        summary["total_mismatches"] = int(match.group(1))
+
+
+def format_count(value):
+    return "n/a" if value is None else str(value)
+
+
+def format_mismatch_epochs(result):
+    summary = result["summary"]
+    mismatch_epochs = summary["epochs_with_mismatch"]
+    total_epochs = summary["epochs_total"] or summary["epochs_compared"]
+    if mismatch_epochs is None or total_epochs is None:
+        return "n/a"
+    return f"{mismatch_epochs}/{total_epochs}"
+
+
+def result_status(result):
+    summary = result["summary"]
+    if result["rc"] != 0 or summary["reported_errors"] > 0:
+        return "ERROR"
+    if summary["total_mismatches"] is None:
+        return "UNKNOWN"
+    if summary["total_mismatches"] > 0:
+        return "MISMATCH"
+    return "OK"
+
+
+def format_epoch_scope(args):
+    if args.epoch is not None:
+        return f"epoch {args.epoch}"
+    return f"epochs {args.start_epoch} -> {args.end_epoch}"
+
+
+def default_summary_file(started_at):
+    ts = started_at.strftime("%Y%m%d_%H%M%S")
+    return os.path.join(HERE, "logs", f"compare_all_summary_{ts}.log")
+
+
+def resolve_summary_file(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.abspath(path)
 
 
 def build_epoch_args(args):
@@ -73,8 +154,6 @@ def build_passthrough_args(args):
         out += ["--store-password", args.store_password]
     if args.store_schema:
         out += ["--store-schema", args.store_schema]
-    if args.quiet:
-        out += ["--quiet"]
     if args.max_mismatches is not None:
         out += ["--max-mismatches", str(args.max_mismatches)]
     return out
@@ -98,20 +177,122 @@ def select_comparators(args):
 
 
 def run_one(label, script, extra_args, args):
-    cmd = [sys.executable, os.path.join(HERE, script)]
+    cmd = [sys.executable, "-u", os.path.join(HERE, script)]
     cmd += build_epoch_args(args)
     cmd += build_passthrough_args(args)
     cmd += extra_args
 
     print(f"\n========================================================")
     print(f"  Running: {label}")
-    print(f"  Command: {' '.join(cmd)}")
+    if not args.quiet:
+        print(f"  Command: {' '.join(cmd)}")
     print(f"========================================================")
 
     started = datetime.now()
-    rc = subprocess.call(cmd, cwd=HERE)
+    summary = new_child_summary()
+    process = subprocess.Popen(
+        cmd,
+        cwd=HERE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    for line in process.stdout:
+        if not args.quiet:
+            print(line, end="")
+        parse_child_output_line(line, summary)
+
+    rc = process.wait()
     duration = (datetime.now() - started).total_seconds()
-    return rc, duration
+    return {
+        "label": label,
+        "rc": rc,
+        "duration": duration,
+        "summary": summary,
+    }
+
+
+def calculate_summary_counts(results):
+    failed = sum(1 for result in results if result_status(result) == "ERROR")
+    mismatched = sum(1 for result in results if result_status(result) == "MISMATCH")
+    unknown = sum(1 for result in results if result_status(result) == "UNKNOWN")
+    total_mismatches = sum(
+        result["summary"]["total_mismatches"]
+        for result in results
+        if result["summary"]["total_mismatches"] is not None
+    )
+    known_mismatch_counts = sum(
+        1 for result in results if result["summary"]["total_mismatches"] is not None
+    )
+
+    return failed, mismatched, unknown, total_mismatches, known_mismatch_counts
+
+
+def build_overall_summary_text(results, total_duration, started_at, finished_at, command, epoch_scope):
+    failed, mismatched, unknown, total_mismatches, known_mismatch_counts = calculate_summary_counts(results)
+    lines = []
+
+    lines.append("=" * 100)
+    lines.append("FINAL RESULT SUMMARY (compare_all)")
+    lines.append("=" * 100)
+    lines.append(f"  Started at        : {started_at.isoformat(timespec='seconds')}")
+    lines.append(f"  Finished at       : {finished_at.isoformat(timespec='seconds')}")
+    lines.append(f"  Command           : {command}")
+    lines.append(f"  Epoch scope       : {epoch_scope}")
+    lines.append(f"  Total runtime     : {total_duration:.1f}s")
+    lines.append(f"  Comparators run   : {len(results)}")
+    lines.append(f"  Status counts     : OK={sum(1 for r in results if result_status(r) == 'OK')}, "
+                 f"MISMATCH={mismatched}, ERROR={failed}, UNKNOWN={unknown}")
+    if known_mismatch_counts == len(results):
+        lines.append(f"  Total mismatches  : {total_mismatches}")
+    else:
+        lines.append(f"  Total mismatches  : {total_mismatches} known ({len(results) - known_mismatch_counts} unknown)")
+    lines.append("")
+    lines.append(f"  {'Comparator':<40} {'Status':<9} {'Epochs':>8} {'Bad epochs':>11} {'Mismatches':>11} {'RC':>4} {'Time(s)':>8}")
+    lines.append(f"  {'-'*40} {'-'*9} {'-'*8} {'-'*11} {'-'*11} {'-'*4} {'-'*8}")
+    for result in results:
+        summary = result["summary"]
+        lines.append(
+            f"  {result['label']:<40} "
+            f"{result_status(result):<9} "
+            f"{format_count(summary['epochs_compared']):>8} "
+            f"{format_mismatch_epochs(result):>11} "
+            f"{format_count(summary['total_mismatches']):>11} "
+            f"{result['rc']:>4} "
+            f"{result['duration']:>8.1f}"
+        )
+
+    lines.append("")
+    lines.append("  Logs:")
+    for result in results:
+        log_file = result["summary"]["log_file"] or "n/a"
+        lines.append(f"    {result['label']}: {log_file}")
+    lines.append("=" * 100)
+
+    return "\n".join(lines), failed, mismatched, unknown
+
+
+def write_summary_file(summary_file, summary_text):
+    os.makedirs(os.path.dirname(summary_file), exist_ok=True)
+    with open(summary_file, "w") as f:
+        f.write(summary_text + "\n")
+
+
+def print_overall_summary(results, total_duration, started_at, finished_at, command, epoch_scope, summary_file):
+    summary_text, failed, mismatched, unknown = build_overall_summary_text(
+        results,
+        total_duration,
+        started_at,
+        finished_at,
+        command,
+        epoch_scope,
+    )
+
+    print("\n" + summary_text)
+    write_summary_file(summary_file, summary_text)
+    print(f"\nFinal summary written to: {summary_file}")
+    return failed, mismatched, unknown
 
 
 def main():
@@ -147,9 +328,14 @@ Comparator keys:
     parser.add_argument("--store-user", help="Yaci Store username")
     parser.add_argument("--store-password", help="Yaci Store password")
     parser.add_argument("--store-schema", help="Yaci Store schema name")
-    parser.add_argument("--quiet", action="store_true", help="Pass --quiet to each child script")
+    parser.add_argument("--quiet", action="store_true", help="Suppress child output and print only compare_all progress/summary")
     parser.add_argument("--max-mismatches", type=int, default=None,
                         help="Limit mismatches printed per epoch in each child script")
+    parser.add_argument(
+        "--summary-file",
+        metavar="FILE",
+        help="Write the final summary to this file (default: logs/compare_all_summary_<timestamp>.log)",
+    )
 
     args = parser.parse_args()
 
@@ -165,39 +351,32 @@ Comparator keys:
     reward_types = [t.strip() for t in args.reward_types.split(",") if t.strip()]
 
     started_at = datetime.now()
-    results = []  # list of (label, returncode, duration_seconds)
+    command = shlex.join([sys.executable] + sys.argv)
+    epoch_scope = format_epoch_scope(args)
+    summary_file = resolve_summary_file(args.summary_file) if args.summary_file else default_summary_file(started_at)
+    results = []
 
     for key, script in selected:
         if key == "reward_rest":
             for rtype in reward_types:
                 label = f"reward_rest (type={rtype})"
-                rc, dur = run_one(label, script, ["--reward-type", rtype], args)
-                results.append((label, rc, dur))
+                results.append(run_one(label, script, ["--reward-type", rtype], args))
         else:
-            rc, dur = run_one(key, script, [], args)
-            results.append((key, rc, dur))
+            results.append(run_one(key, script, [], args))
 
-    total_duration = (datetime.now() - started_at).total_seconds()
+    finished_at = datetime.now()
+    total_duration = (finished_at - started_at).total_seconds()
 
-    print("\n" + "=" * 60)
-    print("OVERALL SUMMARY (compare_all)")
-    print("=" * 60)
-    print(f"  Total runtime : {total_duration:.1f}s")
-    print(f"  Comparators   : {len(results)}")
-    print()
-    print(f"  {'Comparator':<40} {'RC':>4} {'Time(s)':>10}")
-    print(f"  {'-'*40} {'-'*4} {'-'*10}")
-    failed = 0
-    for label, rc, dur in results:
-        status = "OK" if rc == 0 else f"RC={rc}"
-        if rc != 0:
-            failed += 1
-        print(f"  {label:<40} {status:>4} {dur:>10.1f}")
-    print()
-    print(f"  Failures      : {failed}/{len(results)}")
-    print("=" * 60)
-
-    sys.exit(1 if failed else 0)
+    failed, mismatched, unknown = print_overall_summary(
+        results,
+        total_duration,
+        started_at,
+        finished_at,
+        command,
+        epoch_scope,
+        summary_file,
+    )
+    sys.exit(1 if failed or mismatched or unknown else 0)
 
 
 if __name__ == "__main__":

--- a/scripts/compare/compare_all.py
+++ b/scripts/compare/compare_all.py
@@ -14,7 +14,7 @@ USAGE:
     python3 compare_all.py --epoch 800 --config config.json
 
     # Epoch range
-    python3 compare_all.py --start-epoch 740 --end-epoch 902 --config config.json
+    python3 compare_all.py --start-epoch 740 --end-epoch 902
 
     # Skip specific comparators
     python3 compare_all.py --epoch 800 --skip epoch_stake,reward_rest

--- a/scripts/compare/compare_all.py
+++ b/scripts/compare/compare_all.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_all.py - Run every comparator in scripts/compare/ in one go
+================================================================================
+
+Runs each individual compare_*.py script sequentially against the same epoch
+(or epoch range) and prints a combined summary at the end. Each child script
+still writes its own timestamped log under logs/.
+
+USAGE:
+------
+    # Single epoch
+    python3 compare_all.py --epoch 800 --config config.json
+
+    # Epoch range
+    python3 compare_all.py --start-epoch 740 --end-epoch 902 --config config.json
+
+    # Skip specific comparators
+    python3 compare_all.py --epoch 800 --skip epoch_stake,reward_rest
+
+    # Run only a subset
+    python3 compare_all.py --epoch 800 --only adapot,drep_amount
+
+    # Pick reward_rest types to run (default: all three)
+    python3 compare_all.py --epoch 1075 --reward-types treasury,reserves
+================================================================================
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# (key, script filename, extra args builder)
+COMPARATORS = [
+    ("adapot",                   "compare_adapot.py"),
+    ("epoch_stake",              "compare_epoch_stake.py"),
+    ("reward_rest",              "compare_reward_rest.py"),
+    ("drep_amount",              "compare_drep_amount.py"),
+    ("drep_active_until",        "compare_drep_active_until.py"),
+    ("gov_action_proposal_status", "compare_gov_action_proposal_status.py"),
+]
+
+REWARD_TYPES_DEFAULT = ["treasury", "reserves", "proposal_refund"]
+
+
+def build_epoch_args(args):
+    if args.epoch is not None:
+        return ["--epoch", str(args.epoch)]
+    return ["--start-epoch", str(args.start_epoch), "--end-epoch", str(args.end_epoch)]
+
+
+def build_passthrough_args(args):
+    """Forward CLI flags that every child script understands."""
+    out = []
+    if args.config:
+        out += ["--config", args.config]
+    if args.dbsync_url:
+        out += ["--dbsync-url", args.dbsync_url]
+    if args.dbsync_user:
+        out += ["--dbsync-user", args.dbsync_user]
+    if args.dbsync_password:
+        out += ["--dbsync-password", args.dbsync_password]
+    if args.store_url:
+        out += ["--store-url", args.store_url]
+    if args.store_user:
+        out += ["--store-user", args.store_user]
+    if args.store_password:
+        out += ["--store-password", args.store_password]
+    if args.store_schema:
+        out += ["--store-schema", args.store_schema]
+    if args.quiet:
+        out += ["--quiet"]
+    if args.max_mismatches is not None:
+        out += ["--max-mismatches", str(args.max_mismatches)]
+    return out
+
+
+def select_comparators(args):
+    keys = [k for k, _ in COMPARATORS]
+    if args.only:
+        wanted = [k.strip() for k in args.only.split(",") if k.strip()]
+        unknown = [k for k in wanted if k not in keys]
+        if unknown:
+            sys.exit(f"Unknown comparator key(s) in --only: {unknown}. Valid: {keys}")
+        return [(k, s) for k, s in COMPARATORS if k in wanted]
+    if args.skip:
+        skip = {k.strip() for k in args.skip.split(",") if k.strip()}
+        unknown = [k for k in skip if k not in keys]
+        if unknown:
+            sys.exit(f"Unknown comparator key(s) in --skip: {unknown}. Valid: {keys}")
+        return [(k, s) for k, s in COMPARATORS if k not in skip]
+    return list(COMPARATORS)
+
+
+def run_one(label, script, extra_args, args):
+    cmd = [sys.executable, os.path.join(HERE, script)]
+    cmd += build_epoch_args(args)
+    cmd += build_passthrough_args(args)
+    cmd += extra_args
+
+    print(f"\n========================================================")
+    print(f"  Running: {label}")
+    print(f"  Command: {' '.join(cmd)}")
+    print(f"========================================================")
+
+    started = datetime.now()
+    rc = subprocess.call(cmd, cwd=HERE)
+    duration = (datetime.now() - started).total_seconds()
+    return rc, duration
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run every Yaci Store ↔ DB Sync comparator in one command.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Comparator keys:
+  adapot, epoch_stake, reward_rest, drep_amount, drep_active_until,
+  gov_action_proposal_status
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--only", help="Comma-separated comparator keys to run (mutually exclusive with --skip)")
+    parser.add_argument("--skip", help="Comma-separated comparator keys to skip")
+    parser.add_argument(
+        "--reward-types",
+        default=",".join(REWARD_TYPES_DEFAULT),
+        help=f"Comma-separated reward types passed to compare_reward_rest.py (default: {','.join(REWARD_TYPES_DEFAULT)})",
+    )
+
+    # Pass-through flags (mirror common.add_common_args)
+    parser.add_argument("--config", metavar="FILE", help="Path to JSON config file")
+    parser.add_argument("--dbsync-url", help="DB Sync connection URL")
+    parser.add_argument("--dbsync-user", help="DB Sync username")
+    parser.add_argument("--dbsync-password", help="DB Sync password")
+    parser.add_argument("--store-url", help="Yaci Store connection URL")
+    parser.add_argument("--store-user", help="Yaci Store username")
+    parser.add_argument("--store-password", help="Yaci Store password")
+    parser.add_argument("--store-schema", help="Yaci Store schema name")
+    parser.add_argument("--quiet", action="store_true", help="Pass --quiet to each child script")
+    parser.add_argument("--max-mismatches", type=int, default=None,
+                        help="Limit mismatches printed per epoch in each child script")
+
+    args = parser.parse_args()
+
+    if args.only and args.skip:
+        parser.error("--only and --skip are mutually exclusive")
+    if args.epoch is None:
+        if args.start_epoch is None or args.end_epoch is None:
+            parser.error("Provide either --epoch or both --start-epoch and --end-epoch")
+        if args.end_epoch < args.start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    selected = select_comparators(args)
+    reward_types = [t.strip() for t in args.reward_types.split(",") if t.strip()]
+
+    started_at = datetime.now()
+    results = []  # list of (label, returncode, duration_seconds)
+
+    for key, script in selected:
+        if key == "reward_rest":
+            for rtype in reward_types:
+                label = f"reward_rest (type={rtype})"
+                rc, dur = run_one(label, script, ["--reward-type", rtype], args)
+                results.append((label, rc, dur))
+        else:
+            rc, dur = run_one(key, script, [], args)
+            results.append((key, rc, dur))
+
+    total_duration = (datetime.now() - started_at).total_seconds()
+
+    print("\n" + "=" * 60)
+    print("OVERALL SUMMARY (compare_all)")
+    print("=" * 60)
+    print(f"  Total runtime : {total_duration:.1f}s")
+    print(f"  Comparators   : {len(results)}")
+    print()
+    print(f"  {'Comparator':<40} {'RC':>4} {'Time(s)':>10}")
+    print(f"  {'-'*40} {'-'*4} {'-'*10}")
+    failed = 0
+    for label, rc, dur in results:
+        status = "OK" if rc == 0 else f"RC={rc}"
+        if rc != 0:
+            failed += 1
+        print(f"  {label:<40} {status:>4} {dur:>10.1f}")
+    print()
+    print(f"  Failures      : {failed}/{len(results)}")
+    print("=" * 60)
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_drep_active_until.py
+++ b/scripts/compare/compare_drep_active_until.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_drep_active_until.py - Compare drep ACTIVE_UNTIL between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_drep_active_until.py --epoch 624 --config config.json
+
+   # Compare a specific epoch
+   python3 compare_drep_active_until.py --epoch 624
+
+   # Compare an epoch range (620 to 630)
+   python3 compare_drep_active_until.py --start-epoch 620 --end-epoch 630
+   python3 compare_drep_active_until.py --start-epoch 492 --end-epoch 1055 --config config.json
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_drep_active_until.py --epoch 624 \\
+       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-user dbsync --dbsync-password dbsync \\
+       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-user yaci --store-password dbpass \\
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_drep_active_until.py --epoch 624 --quiet
+   python3 compare_drep_amount.py --start-epoch 492 --end-epoch 1052 --config config.json
+
+   # Limit the number of mismatches printed
+   python3 compare_drep_active_until.py --epoch 624 --max-mismatches 50
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config, normalize_hash
+
+
+def compare_active_until(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches):
+    dbsync_query = """
+        SELECT dh.raw, d.active_until
+        FROM drep_distr d
+        INNER JOIN drep_hash dh ON dh.id = d.hash_id
+        WHERE d.epoch_no = %s AND d.active_until IS NOT NULL
+    """
+    store_query = """
+        SELECT drep_hash, active_until
+        FROM drep_dist
+        WHERE epoch = %s AND drep_type NOT IN ('ABSTAIN', 'NO_CONFIDENCE')
+    """
+
+    dbsync_map = {}
+    store_map = {}
+
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, (epoch,))
+            for row in cur.fetchall():
+                raw, active_until = row
+                h = normalize_hash(raw)
+                if h:
+                    dbsync_map[h] = active_until
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (epoch,))
+            for row in cur.fetchall():
+                drep_hash, active_until = row
+                h = normalize_hash(drep_hash)
+                if h:
+                    store_map[h] = active_until
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    mismatch_count = 0
+    truncated = False
+
+    def check_limit():
+        nonlocal truncated
+        if max_mismatches and mismatch_count >= max_mismatches:
+            if not truncated:
+                logger.log(f"  ... (reached limit of {max_mismatches} mismatches, skipping the rest)")
+                truncated = True
+            return True
+        return False
+
+    for h, db_val in dbsync_map.items():
+        if check_limit():
+            break
+        if h in store_map:
+            store_val = store_map[h]
+            if db_val != store_val:
+                mismatch_count += 1
+                logger.log(f"  Mismatch hash: {h}")
+                logger.log(f"    DB Sync   : active_until = {db_val}")
+                logger.log(f"    Yaci Store: active_until = {store_val}")
+        else:
+            mismatch_count += 1
+            logger.log(f"  Hash {h} present in DB Sync but MISSING in Yaci Store")
+
+    for h in store_map:
+        if check_limit():
+            break
+        if h not in dbsync_map:
+            mismatch_count += 1
+            logger.log(f"  Hash {h} present in Yaci Store but MISSING in DB Sync")
+
+    return mismatch_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare drep ACTIVE_UNTIL between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 624
+  %(prog)s --epoch 624 --config config.json
+  %(prog)s --start-epoch 620 --end-epoch 630
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--max-mismatches", type=int, default=None, help="Limit mismatches printed per epoch (0 = unlimited)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch = args.epoch
+        end_epoch = args.epoch
+    else:
+        start_epoch = args.start_epoch
+        end_epoch = args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+        if end_epoch < start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"drep_compare_active_until_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log(f"===== Starting drep active_until comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epoch range: {start_epoch} -> {end_epoch}")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+    total_epochs = end_epoch - start_epoch + 1
+
+    for epoch in range(start_epoch, end_epoch + 1):
+        logger.log(f"############ Epoch {epoch} - active_until ############")
+
+        count = compare_active_until(
+            epoch, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+        )
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - All data matches between DB Sync and Yaci Store")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+    logger.log("=" * 50)
+    logger.log(f"SUMMARY (active_until):")
+    logger.log(f"  Epochs compared     : {total_epochs}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{total_epochs}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_drep_active_until.py
+++ b/scripts/compare/compare_drep_active_until.py
@@ -23,9 +23,9 @@ USAGE:
 
    # Custom database connections (CLI args override config file)
    python3 compare_drep_active_until.py --epoch 624 \\
-       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-url "postgresql://localhost:5678/cexplorer" \\
        --dbsync-user dbsync --dbsync-password dbsync \\
-       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-url "postgresql://localhost:5432/yaci_store" \\
        --store-user yaci --store-password dbpass \\
        --store-schema yaci_store
 

--- a/scripts/compare/compare_drep_active_until.py
+++ b/scripts/compare/compare_drep_active_until.py
@@ -20,7 +20,6 @@ USAGE:
 
    # Compare an epoch range (620 to 630)
    python3 compare_drep_active_until.py --start-epoch 620 --end-epoch 630
-   python3 compare_drep_active_until.py --start-epoch 492 --end-epoch 1055 --config config.json
 
    # Custom database connections (CLI args override config file)
    python3 compare_drep_active_until.py --epoch 624 \\
@@ -32,7 +31,6 @@ USAGE:
 
    # Output to log file only, suppress console output
    python3 compare_drep_active_until.py --epoch 624 --quiet
-   python3 compare_drep_amount.py --start-epoch 492 --end-epoch 1052 --config config.json
 
    # Limit the number of mismatches printed
    python3 compare_drep_active_until.py --epoch 624 --max-mismatches 50

--- a/scripts/compare/compare_drep_amount.py
+++ b/scripts/compare/compare_drep_amount.py
@@ -23,9 +23,9 @@ USAGE:
 
    # Custom database connections (CLI args override config file)
    python3 compare_drep_amount.py --epoch 515 \\
-       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-url "postgresql://localhost:5678/cexplorer" \\
        --dbsync-user dbsync --dbsync-password dbsync \\
-       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-url "postgresql://localhost:5432/yaci_store" \\
        --store-user yaci --store-password dbpass \\
        --store-schema yaci_store
 

--- a/scripts/compare/compare_drep_amount.py
+++ b/scripts/compare/compare_drep_amount.py
@@ -20,9 +20,6 @@ USAGE:
 
    # Compare an epoch range (510 to 520)
    python3 compare_drep_amount.py --start-epoch 510 --end-epoch 520
-   python3 compare_drep_amount.py --start-epoch 647 --end-epoch 1282 --config config.json
-   python3 compare_drep_amount.py --start-epoch 647 --end-epoch 981 --config config.json
-   python3 compare_drep_amount.py --start-epoch 492 --end-epoch 1055 --config config.json
 
    # Custom database connections (CLI args override config file)
    python3 compare_drep_amount.py --epoch 515 \\

--- a/scripts/compare/compare_drep_amount.py
+++ b/scripts/compare/compare_drep_amount.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_drep_amount.py - Compare drep distribution AMOUNT between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_drep_amount.py --epoch 515 --config config.json
+
+   # Compare a specific epoch
+   python3 compare_drep_amount.py --epoch 515
+
+   # Compare an epoch range (510 to 520)
+   python3 compare_drep_amount.py --start-epoch 510 --end-epoch 520
+   python3 compare_drep_amount.py --start-epoch 647 --end-epoch 1282 --config config.json
+   python3 compare_drep_amount.py --start-epoch 647 --end-epoch 981 --config config.json
+   python3 compare_drep_amount.py --start-epoch 492 --end-epoch 1055 --config config.json
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_drep_amount.py --epoch 515 \\
+       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-user dbsync --dbsync-password dbsync \\
+       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-user yaci --store-password dbpass \\
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_drep_amount.py --epoch 515 --quiet
+
+   # Limit the number of mismatches printed
+   python3 compare_drep_amount.py --epoch 515 --max-mismatches 50
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config, normalize_hash
+
+
+def compare_amount(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches):
+    dbsync_query = """
+        SELECT dh.raw, d.amount, dh.view
+        FROM drep_distr d
+        INNER JOIN drep_hash dh ON dh.id = d.hash_id
+        WHERE d.epoch_no = %s
+    """
+    store_query = """
+        SELECT drep_hash, drep_id, amount, drep_type
+        FROM drep_dist
+        WHERE epoch = %s
+    """
+
+    dbsync_results = {}
+    store_results = {}
+    drep_hash_to_id = {}
+
+    dbsync_abstain = 0
+    store_abstain = 0
+    dbsync_no_confidence = 0
+    store_no_confidence = 0
+
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, (epoch,))
+            for row in cur.fetchall():
+                raw, amount, view = row
+                h = normalize_hash(raw)
+                amt = int(amount)
+                if view and "abstain" in view:
+                    dbsync_abstain += amt
+                elif view and "no_confidence" in view:
+                    dbsync_no_confidence += amt
+                else:
+                    dbsync_results[h] = amt
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (epoch,))
+            for row in cur.fetchall():
+                drep_hash, drep_id, amount, drep_type = row
+                h = normalize_hash(drep_hash)
+                amt = int(amount)
+                if drep_type == "ABSTAIN":
+                    store_abstain = amt
+                elif drep_type == "NO_CONFIDENCE":
+                    store_no_confidence = amt
+                else:
+                    store_results[h] = amt
+                if drep_id:
+                    drep_hash_to_id[h] = drep_id
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    mismatch_count = 0
+    truncated = False
+
+    def check_limit():
+        nonlocal truncated
+        if max_mismatches and mismatch_count >= max_mismatches:
+            if not truncated:
+                logger.log(f"  ... (reached limit of {max_mismatches} mismatches, skipping the rest)")
+                truncated = True
+            return True
+        return False
+
+    for h, amt_dbsync in dbsync_results.items():
+        if check_limit():
+            break
+        if h in store_results:
+            amt_store = store_results[h]
+            if amt_dbsync != amt_store:
+                mismatch_count += 1
+                logger.log(f"  Mismatch hash: {h}")
+                logger.log(f"    DB Sync amount : {amt_dbsync}")
+                logger.log(f"    Yaci Store amt : {amt_store}")
+                if h in drep_hash_to_id:
+                    logger.log(f"    DRep ID: {drep_hash_to_id[h]}")
+        else:
+            mismatch_count += 1
+            logger.log(f"  Hash {h} present in DB Sync but MISSING in Yaci Store (amount: {amt_dbsync})")
+            if h in drep_hash_to_id:
+                logger.log(f"    DRep ID: {drep_hash_to_id[h]}")
+
+    for h in store_results:
+        if check_limit():
+            break
+        if h not in dbsync_results:
+            mismatch_count += 1
+            logger.log(f"  Hash {h} present in Yaci Store but MISSING in DB Sync (amount: {store_results[h]})")
+            if h in drep_hash_to_id:
+                logger.log(f"    DRep ID: {drep_hash_to_id[h]}")
+
+    if dbsync_abstain != store_abstain:
+        mismatch_count += 1
+        logger.log(f"  Mismatch ABSTAIN amount: DB Sync={dbsync_abstain}, Yaci Store={store_abstain}")
+
+    if dbsync_no_confidence != store_no_confidence:
+        mismatch_count += 1
+        logger.log(f"  Mismatch NO_CONFIDENCE amount: DB Sync={dbsync_no_confidence}, Yaci Store={store_no_confidence}")
+
+    return mismatch_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare drep distribution AMOUNT between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 515
+  %(prog)s --epoch 515 --config config.json
+  %(prog)s --start-epoch 510 --end-epoch 520
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--max-mismatches", type=int, default=None, help="Limit mismatches printed per epoch (0 = unlimited)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch = args.epoch
+        end_epoch = args.epoch
+    else:
+        start_epoch = args.start_epoch
+        end_epoch = args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+        if end_epoch < start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"drep_compare_amount_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log(f"===== Starting drep amount comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epoch range: {start_epoch} -> {end_epoch}")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+    total_epochs = end_epoch - start_epoch + 1
+
+    for epoch in range(start_epoch, end_epoch + 1):
+        logger.log(f"############ Epoch {epoch} - amount ############")
+
+        count = compare_amount(
+            epoch, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+        )
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - All data matches between DB Sync and Yaci Store")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+    logger.log("=" * 50)
+    logger.log(f"SUMMARY (amount):")
+    logger.log(f"  Epochs compared     : {total_epochs}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{total_epochs}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_epoch_stake.py
+++ b/scripts/compare/compare_epoch_stake.py
@@ -39,15 +39,21 @@ USAGE:
    # Limit the number of mismatches printed
    python3 compare_epoch_stake.py --epoch 800 --max-mismatches 50
 
+   # Include zero-amount rows when comparing raw table contents
+   python3 compare_epoch_stake.py --epoch 800 --include-zero-amount
+
 3. Output:
    - Prints to console (and writes to log file in logs/ directory)
    - Log file named: logs/epoch_stake_compare_<timestamp>.log
    - Compares by key: address + pool_id, value: amount
+   - By default, ignores amount=0 rows to match DB Sync's current active-stake semantics
 
 4. Notes:
    - DB Sync: epoch_stake table, epoch_no = epoch
    - Yaci Store: epoch_stake table, epoch = epoch - 2 (offset preserved from original query)
    - The script keeps this offset logic from the original Java
+   - DB Sync >= 13.7.0.3 deletes legacy amount=0 epoch_stake rows; the comparator
+     filters them by default unless --include-zero-amount is used
    - epoch_stake data can be very large; use --delay to avoid DB overload
    - Config file (JSON) provides defaults, CLI args override
 
@@ -74,30 +80,51 @@ from common import Logger, connect, add_common_args, resolve_config
 # ============================================================
 # Compare: epoch_stake
 # ============================================================
-def compare_epoch_stake(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches):
-    dbsync_query = """
+def compare_epoch_stake(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches, include_zero_amount):
+    amount_filter = "" if include_zero_amount else "AND es.amount <> 0"
+    dbsync_query = f"""
         SELECT sa.view, es.amount, encode(ph.hash_raw, 'hex') as pool_id
         FROM epoch_stake es
         INNER JOIN stake_address sa ON sa.id = es.addr_id
         INNER JOIN pool_hash ph ON ph.id = es.pool_id
         WHERE es.epoch_no = %s
+        {amount_filter}
         ORDER BY sa.view, encode(ph.hash_raw, 'hex'), amount
     """
+    dbsync_zero_count_query = """
+        SELECT count(*)
+        FROM epoch_stake es
+        WHERE es.epoch_no = %s
+          AND es.amount = 0
+    """
     # Yaci Store uses epoch - 2 (preserved offset logic from the original Java)
-    store_query = """
+    store_amount_filter = "" if include_zero_amount else "AND amount <> 0"
+    store_query = f"""
         SELECT address, amount, pool_id
         FROM epoch_stake
         WHERE epoch = %s - 2
+        {store_amount_filter}
         ORDER BY address, pool_id, amount
+    """
+    store_zero_count_query = """
+        SELECT count(*)
+        FROM epoch_stake
+        WHERE epoch = %s - 2
+          AND amount = 0
     """
 
     dbsync_map = {}
     store_map = {}
+    ignored_dbsync_zero_amount = 0
+    ignored_store_zero_amount = 0
 
     # --- Fetch DB Sync ---
     try:
         conn = connect(dbsync_url)
         with conn.cursor() as cur:
+            if not include_zero_amount:
+                cur.execute(dbsync_zero_count_query, (epoch,))
+                ignored_dbsync_zero_amount = int(cur.fetchone()[0])
             cur.execute(dbsync_query, (epoch,))
             for row in cur.fetchall():
                 address, amount, pool_id = row
@@ -112,6 +139,9 @@ def compare_epoch_stake(epoch, dbsync_url, store_url, store_schema, logger, max_
     try:
         conn = connect(store_url, store_schema)
         with conn.cursor() as cur:
+            if not include_zero_amount:
+                cur.execute(store_zero_count_query, (epoch,))
+                ignored_store_zero_amount = int(cur.fetchone()[0])
             cur.execute(store_query, (epoch,))
             for row in cur.fetchall():
                 address, amount, pool_id = row
@@ -125,6 +155,12 @@ def compare_epoch_stake(epoch, dbsync_url, store_url, store_schema, logger, max_
     # --- Compare ---
     mismatch_count = 0
     truncated = False
+
+    if ignored_dbsync_zero_amount or ignored_store_zero_amount:
+        logger.log(
+            "  Ignored zero-amount epoch_stake row(s): "
+            f"DB Sync={ignored_dbsync_zero_amount}, Yaci Store={ignored_store_zero_amount}"
+        )
 
     def check_limit():
         nonlocal truncated
@@ -184,6 +220,11 @@ Examples:
     parser.add_argument("--reverse", action="store_true", help="Iterate from high epoch to low (like the original Java)")
     parser.add_argument("--delay", type=float, default=None, help="Delay (seconds) between epochs to avoid DB overload (original Java used 5s)")
     parser.add_argument("--max-mismatches", type=int, default=None, help="Limit mismatches printed per epoch (0 = unlimited)")
+    parser.add_argument(
+        "--include-zero-amount",
+        action="store_true",
+        help="Include amount=0 rows in the comparison instead of using DB Sync's current active-stake semantics",
+    )
 
     add_common_args(parser)
 
@@ -213,6 +254,10 @@ Examples:
     logger.log(f"Epochs: {epochs[0]} -> {epochs[-1]} ({len(epochs)} epochs)")
     logger.log(f"DB Sync URL: {args.dbsync_url}")
     logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log(
+        "Zero-amount rows: "
+        + ("included" if args.include_zero_amount else "ignored (DB Sync active-stake semantics)")
+    )
     if args.delay > 0:
         logger.log(f"Delay between epochs: {args.delay}s")
     logger.log()
@@ -224,7 +269,13 @@ Examples:
         logger.log(f"############ Epoch {epoch} - epoch_stake ############")
 
         count = compare_epoch_stake(
-            epoch, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+            epoch,
+            args.dbsync_url,
+            args.store_url,
+            args.store_schema,
+            logger,
+            args.max_mismatches,
+            args.include_zero_amount,
         )
 
         if count < 0:

--- a/scripts/compare/compare_epoch_stake.py
+++ b/scripts/compare/compare_epoch_stake.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_epoch_stake.py - Compare Epoch Stake data between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_epoch_stake.py --epoch 800 --config config.json
+
+   # Compare epoch_stake for a specific epoch
+   python3 compare_epoch_stake.py --epoch 800
+
+   # Compare across an epoch range (740 to 902)
+   python3 compare_epoch_stake.py --start-epoch 740 --end-epoch 902
+
+   # Compare in descending order (high -> low, like the original Java version)
+   python3 compare_epoch_stake.py --start-epoch 902 --end-epoch 740 --reverse
+
+   # Add delay between epochs (avoid DB overload, original Java used 5s)
+   python3 compare_epoch_stake.py --start-epoch 740 --end-epoch 902 --delay 5
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_epoch_stake.py --epoch 800 \
+       --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
+       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_epoch_stake.py --epoch 800 --quiet
+
+   # Limit the number of mismatches printed
+   python3 compare_epoch_stake.py --epoch 800 --max-mismatches 50
+
+3. Output:
+   - Prints to console (and writes to log file in logs/ directory)
+   - Log file named: logs/epoch_stake_compare_<timestamp>.log
+   - Compares by key: address + pool_id, value: amount
+
+4. Notes:
+   - DB Sync: epoch_stake table, epoch_no = epoch
+   - Yaci Store: epoch_stake table, epoch = epoch - 2 (offset preserved from original query)
+   - The script keeps this offset logic from the original Java
+   - epoch_stake data can be very large; use --delay to avoid DB overload
+   - Config file (JSON) provides defaults, CLI args override
+
+PROBLEM SOLVED:
+---------------
+This script replaces EpochStakeDataComparator.java, with advantages:
+  - No build/compile needed, runs directly with Python
+  - Flexible configuration via config file or command-line arguments
+  - Supports delay between epochs (avoid DB overload)
+  - Supports descending iteration (reverse)
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config
+
+
+# ============================================================
+# Compare: epoch_stake
+# ============================================================
+def compare_epoch_stake(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches):
+    dbsync_query = """
+        SELECT sa.view, es.amount, encode(ph.hash_raw, 'hex') as pool_id
+        FROM epoch_stake es
+        INNER JOIN stake_address sa ON sa.id = es.addr_id
+        INNER JOIN pool_hash ph ON ph.id = es.pool_id
+        WHERE es.epoch_no = %s
+        ORDER BY sa.view, encode(ph.hash_raw, 'hex'), amount
+    """
+    # Yaci Store uses epoch - 2 (preserved offset logic from the original Java)
+    store_query = """
+        SELECT address, amount, pool_id
+        FROM epoch_stake
+        WHERE epoch = %s - 2
+        ORDER BY address, pool_id, amount
+    """
+
+    dbsync_map = {}
+    store_map = {}
+
+    # --- Fetch DB Sync ---
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, (epoch,))
+            for row in cur.fetchall():
+                address, amount, pool_id = row
+                key = f"{address}_{pool_id}"
+                dbsync_map[key] = {"address": address, "amount": int(amount), "pool_id": pool_id}
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    # --- Fetch Yaci Store ---
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (epoch,))
+            for row in cur.fetchall():
+                address, amount, pool_id = row
+                key = f"{address}_{pool_id}"
+                store_map[key] = {"address": address, "amount": int(amount), "pool_id": pool_id}
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    # --- Compare ---
+    mismatch_count = 0
+    truncated = False
+
+    def check_limit():
+        nonlocal truncated
+        if max_mismatches and mismatch_count >= max_mismatches:
+            if not truncated:
+                logger.log(f"  ... (reached limit of {max_mismatches} mismatches, skipping the rest)")
+                truncated = True
+            return True
+        return False
+
+    for key, db_data in dbsync_map.items():
+        if check_limit():
+            break
+        if key in store_map:
+            store_data = store_map[key]
+            if db_data["amount"] != store_data["amount"]:
+                mismatch_count += 1
+                logger.log(f"  Mismatch key: {key}")
+                logger.log(f"    DB Sync    : amount={db_data['amount']}")
+                logger.log(f"    Yaci Store : amount={store_data['amount']}")
+        else:
+            mismatch_count += 1
+            logger.log(f"  Key {key} present in DB Sync but MISSING in Yaci Store")
+
+    for key in store_map:
+        if check_limit():
+            break
+        if key not in dbsync_map:
+            mismatch_count += 1
+            logger.log(f"  Key {key} present in Yaci Store but MISSING in DB Sync")
+
+    return mismatch_count
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Epoch Stake data between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 800
+  %(prog)s --epoch 800 --config config.json
+  %(prog)s --start-epoch 740 --end-epoch 902
+  %(prog)s --start-epoch 902 --end-epoch 740 --reverse
+  %(prog)s --start-epoch 740 --end-epoch 902 --delay 5
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--reverse", action="store_true", help="Iterate from high epoch to low (like the original Java)")
+    parser.add_argument("--delay", type=float, default=None, help="Delay (seconds) between epochs to avoid DB overload (original Java used 5s)")
+    parser.add_argument("--max-mismatches", type=int, default=None, help="Limit mismatches printed per epoch (0 = unlimited)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch, end_epoch = args.epoch, args.epoch
+    else:
+        start_epoch, end_epoch = args.start_epoch, args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+
+    # Build epoch list
+    if args.reverse or start_epoch > end_epoch:
+        hi, lo = max(start_epoch, end_epoch), min(start_epoch, end_epoch)
+        epochs = list(range(hi, lo - 1, -1))
+    else:
+        epochs = list(range(start_epoch, end_epoch + 1))
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"epoch_stake_compare_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log("===== Starting Epoch Stake comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epochs: {epochs[0]} -> {epochs[-1]} ({len(epochs)} epochs)")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    if args.delay > 0:
+        logger.log(f"Delay between epochs: {args.delay}s")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+
+    for i, epoch in enumerate(epochs):
+        logger.log(f"############ Epoch {epoch} - epoch_stake ############")
+
+        count = compare_epoch_stake(
+            epoch, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+        )
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - All epoch_stake data matches")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+        # Delay between epochs (skip after last)
+        if args.delay > 0 and i < len(epochs) - 1:
+            time.sleep(args.delay)
+
+    logger.log("=" * 50)
+    logger.log("SUMMARY (epoch_stake):")
+    logger.log(f"  Epochs compared     : {len(epochs)}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{len(epochs)}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_epoch_stake.py
+++ b/scripts/compare/compare_epoch_stake.py
@@ -30,7 +30,7 @@ USAGE:
    # Custom database connections (CLI args override config file)
    python3 compare_epoch_stake.py --epoch 800 \
        --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
-       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --store-url "postgresql://yaci:dbpass@localhost:5432/yaci_store" \
        --store-schema yaci_store
 
    # Output to log file only, suppress console output

--- a/scripts/compare/compare_gov_action_proposal_status.py
+++ b/scripts/compare/compare_gov_action_proposal_status.py
@@ -21,13 +21,12 @@ USAGE:
 
    # Compare an epoch range (510 to 520)
    python3 compare_gov_action_proposal_status.py --start-epoch 510 --end-epoch 520
-   python3 compare_gov_action_proposal_status.py --start-epoch 492 --end-epoch 1048 --config config.json
 
    # Custom database connections (CLI args override config file)
    python3 compare_gov_action_proposal_status.py --epoch 515 \\
-       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-url "postgresql://localhost:5678/cexplorer" \\
        --dbsync-user dbsync --dbsync-password dbsync \\
-       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-url "postgresql://localhost:5432/yaci_store" \\
        --store-user yaci --store-password dbpass \\
        --store-schema yaci_store
 

--- a/scripts/compare/compare_gov_action_proposal_status.py
+++ b/scripts/compare/compare_gov_action_proposal_status.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_gov_action_proposal_status.py
+  Compare governance action proposal status between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_gov_action_proposal_status.py --epoch 515 --config config.json
+
+   # Compare a specific epoch
+   python3 compare_gov_action_proposal_status.py --epoch 515
+
+   # Compare an epoch range (510 to 520)
+   python3 compare_gov_action_proposal_status.py --start-epoch 510 --end-epoch 520
+   python3 compare_gov_action_proposal_status.py --start-epoch 492 --end-epoch 1048 --config config.json
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_gov_action_proposal_status.py --epoch 515 \\
+       --dbsync-url "postgresql://10.4.10.135:5678/cexplorer" \\
+       --dbsync-user dbsync --dbsync-password dbsync \\
+       --store-url "postgresql://10.4.10.112:5432/yaci_store" \\
+       --store-user yaci --store-password dbpass \\
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_gov_action_proposal_status.py --epoch 515 --quiet
+
+   # Limit the number of mismatches printed
+   python3 compare_gov_action_proposal_status.py --epoch 515 --max-mismatches 50
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config, normalize_hash
+
+
+# Yaci-Store has only 3 statuses: ACTIVE, RATIFIED, EXPIRED.
+# The gov_action_proposal_status table is a snapshot at the start of each epoch
+# (ProposalStateProcessor writes for currentEpoch = stakeSnapshotEvent.epoch + 1).
+#
+# Lifecycle of proposal P submitted at epoch X (per ProposalCollectionService logic):
+#   - epoch <= X       : no row
+#   - epoch X+1..R     : status = ACTIVE (CONTINUE)
+#   - epoch R          : status = RATIFIED or EXPIRED (only once)
+#   - epoch >= R+1     : no row (RATIFIED/EXPIRED from the prior snapshot is used
+#                        for drop calculation, not re-written)
+#
+# Meanwhile dbsync stores 1 row per proposal with epoch columns:
+#   ratified_epoch  = epoch ratified
+#   enacted_epoch   = ratified_epoch + 1 (epoch enacted)
+#   expired_epoch   = epoch expired
+#   dropped_epoch   = epoch dropped
+#
+# Mapping (same epoch, NO offset):
+#   yaci epoch E, status=RATIFIED  <->  ratified_epoch == E
+#   yaci epoch E, status=EXPIRED   <->  expired_epoch  == E
+#   yaci epoch E, status=ACTIVE    <->  submit_epoch < E and every end column > E or NULL
+#   yaci has no row at epoch E     <->  submit_epoch >= E, or
+#                                       (any end column <= E - 1 with RATIFIED/EXPIRED),
+#                                       or dropped_epoch <= E, or enacted_epoch <= E
+def derive_dbsync_status(epoch, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch):
+    """
+    Return ("STATUS", note) for yaci-store epoch E.
+    None -> yaci-store should not have a row at this epoch.
+    """
+    if expired_epoch is not None and epoch == expired_epoch:
+        return ("EXPIRED", f"expired_epoch={expired_epoch}")
+    if ratified_epoch is not None and epoch == ratified_epoch:
+        return ("RATIFIED", f"ratified_epoch={ratified_epoch}")
+
+    # Already ended before this epoch -> yaci should have no row
+    if expired_epoch is not None and epoch > expired_epoch:
+        return (None, f"already expired at {expired_epoch}")
+    if ratified_epoch is not None and epoch > ratified_epoch:
+        return (None, f"already ratified at {ratified_epoch} (enacted at {enacted_epoch})")
+    if enacted_epoch is not None and epoch >= enacted_epoch:
+        return (None, f"already enacted at {enacted_epoch}")
+    if dropped_epoch is not None and epoch >= dropped_epoch:
+        return (None, f"dropped at {dropped_epoch}")
+
+    return ("ACTIVE", None)
+
+
+def compare_proposal_status(epoch, dbsync_url, store_url, store_schema, logger, max_mismatches):
+    # Fetch every proposal that YACI-STORE COULD have a row for at epoch E:
+    #   - submit_epoch < E (first row appears at submit+1)
+    #   - not ended before E:
+    #       expired_epoch  IS NULL OR expired_epoch  >= E
+    #       ratified_epoch IS NULL OR ratified_epoch >= E   (still RATIFIED at E, not after)
+    #       enacted_epoch  IS NULL OR enacted_epoch  >  E   (enacted_epoch=E means already enacted)
+    #       dropped_epoch  IS NULL OR dropped_epoch  >  E
+    dbsync_query = """
+        SELECT encode(tx.hash, 'hex') AS tx_hash,
+               gap.index,
+               gap.type::text,
+               gap.ratified_epoch,
+               gap.enacted_epoch,
+               gap.dropped_epoch,
+               gap.expired_epoch,
+               gap.expiration,
+               b.epoch_no AS submit_epoch
+        FROM gov_action_proposal gap
+        JOIN tx ON tx.id = gap.tx_id
+        JOIN block b ON b.id = tx.block_id
+        WHERE b.epoch_no < %(epoch)s
+          AND COALESCE(gap.expired_epoch,  2147483647) >= %(epoch)s
+          AND COALESCE(gap.ratified_epoch, 2147483647) >= %(epoch)s
+          AND COALESCE(gap.enacted_epoch,  2147483647) >  %(epoch)s
+          AND COALESCE(gap.dropped_epoch,  2147483647) >  %(epoch)s
+    """
+
+    store_query = """
+        SELECT gov_action_tx_hash, gov_action_index, type, status
+        FROM gov_action_proposal_status
+        WHERE epoch = %s
+    """
+
+    dbsync_results = {}  # (tx_hash, index) -> dict
+    store_results = {}   # (tx_hash, index) -> dict
+
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, {"epoch": epoch})
+            for row in cur.fetchall():
+                (tx_hash, index, gtype, ratified_epoch, enacted_epoch,
+                 dropped_epoch, expired_epoch, expiration, submit_epoch) = row
+                h = normalize_hash(tx_hash)
+                status, note = derive_dbsync_status(
+                    epoch, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch
+                )
+                dbsync_results[(h, int(index))] = {
+                    "type": gtype,
+                    "status": status,
+                    "note": note,
+                    "ratified_epoch": ratified_epoch,
+                    "enacted_epoch": enacted_epoch,
+                    "dropped_epoch": dropped_epoch,
+                    "expired_epoch": expired_epoch,
+                    "expiration": expiration,
+                    "submit_epoch": submit_epoch,
+                }
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (epoch,))
+            for row in cur.fetchall():
+                tx_hash, gov_index, gtype, status = row
+                h = normalize_hash(tx_hash)
+                store_results[(h, int(gov_index))] = {
+                    "type": str(gtype) if gtype is not None else None,
+                    "status": str(status) if status is not None else None,
+                }
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    mismatch_count = 0
+    truncated = False
+
+    def check_limit():
+        nonlocal truncated
+        if max_mismatches and mismatch_count >= max_mismatches:
+            if not truncated:
+                logger.log(f"  ... (reached limit of {max_mismatches} mismatches, skipping the rest)")
+                truncated = True
+            return True
+        return False
+
+    # 1) Iterate dbsync -> find missing / wrong status in yaci-store
+    for key, dbs in dbsync_results.items():
+        if check_limit():
+            break
+        tx_hash, index = key
+        expected_status = dbs["status"]
+
+        if expected_status is None:
+            # Proposal already ended before this epoch - yaci-store should not have a row.
+            if key in store_results:
+                mismatch_count += 1
+                logger.log(f"  Proposal present in Yaci Store but DB Sync shows it has ended ({dbs['note']})")
+                logger.log(f"    tx_hash={tx_hash}, index={index}, type={dbs['type']}")
+                logger.log(f"    Yaci Store status : {store_results[key]['status']}")
+                logger.log(f"    DB Sync epochs    : ratified={dbs['ratified_epoch']}, enacted={dbs['enacted_epoch']}, "
+                           f"dropped={dbs['dropped_epoch']}, expired={dbs['expired_epoch']}")
+            continue
+
+        if key not in store_results:
+            mismatch_count += 1
+            logger.log(f"  Proposal present in DB Sync but MISSING in Yaci Store")
+            logger.log(f"    tx_hash={tx_hash}, index={index}, type={dbs['type']}")
+            logger.log(f"    DB Sync status    : {expected_status} ({dbs['note'] or 'derived'})")
+            logger.log(f"    DB Sync epochs    : submit={dbs['submit_epoch']}, ratified={dbs['ratified_epoch']}, "
+                       f"enacted={dbs['enacted_epoch']}, dropped={dbs['dropped_epoch']}, "
+                       f"expired={dbs['expired_epoch']}, expiration={dbs['expiration']}")
+            continue
+
+        store_status = store_results[key]["status"]
+        if store_status != expected_status:
+            mismatch_count += 1
+            logger.log(f"  Mismatch status proposal tx_hash={tx_hash}, index={index}, type={dbs['type']}")
+            logger.log(f"    DB Sync status    : {expected_status} ({dbs['note'] or 'derived'})")
+            logger.log(f"    Yaci Store status : {store_status}")
+            logger.log(f"    DB Sync epochs    : ratified={dbs['ratified_epoch']}, enacted={dbs['enacted_epoch']}, "
+                       f"dropped={dbs['dropped_epoch']}, expired={dbs['expired_epoch']}")
+
+    # 2) Iterate yaci-store -> find rows extra to dbsync
+    for key, sres in store_results.items():
+        if check_limit():
+            break
+        if key in dbsync_results:
+            continue
+        tx_hash, index = key
+        mismatch_count += 1
+        logger.log(f"  Proposal present in Yaci Store but MISSING in DB Sync")
+        logger.log(f"    tx_hash={tx_hash}, index={index}, type={sres['type']}")
+        logger.log(f"    Yaci Store status : {sres['status']}")
+
+    return mismatch_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare governance action proposal status between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 515
+  %(prog)s --epoch 515 --config config.json
+  %(prog)s --start-epoch 510 --end-epoch 520
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--max-mismatches", type=int, default=None,
+                        help="Limit mismatches printed per epoch (0 = unlimited)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch = args.epoch
+        end_epoch = args.epoch
+    else:
+        start_epoch = args.start_epoch
+        end_epoch = args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+        if end_epoch < start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"gov_action_proposal_status_compare_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log(f"===== Starting gov action proposal status comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epoch range: {start_epoch} -> {end_epoch}")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+    total_epochs = end_epoch - start_epoch + 1
+
+    for epoch in range(start_epoch, end_epoch + 1):
+        logger.log(f"############ Epoch {epoch} - gov action proposal status ############")
+
+        count = compare_proposal_status(
+            epoch, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+        )
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - All data matches between DB Sync and Yaci Store")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+    logger.log("=" * 50)
+    logger.log(f"SUMMARY (gov action proposal status):")
+    logger.log(f"  Epochs compared     : {total_epochs}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{total_epochs}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_reward_rest.py
+++ b/scripts/compare/compare_reward_rest.py
@@ -28,8 +28,8 @@ USAGE:
 
    # Custom database connections (CLI args override config file)
    python3 compare_reward_rest.py --epoch 1075 \
-       --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
-       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --dbsync-url "postgresql://dbsync:dbsync@localhost:5678/cexplorer" \
+       --store-url "postgresql://yaci:dbpass@localhost:5432/yaci_store" \
        --store-schema yaci_store
 
    # Output to log file only, suppress console output

--- a/scripts/compare/compare_reward_rest.py
+++ b/scripts/compare/compare_reward_rest.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+  compare_reward_rest.py - Compare Reward Rest data between DB Sync and Yaci Store
+================================================================================
+
+USAGE:
+------
+
+1. Install required dependencies:
+   pip3 install psycopg2-binary
+
+2. Run the script:
+
+   # Using a config file
+   python3 compare_reward_rest.py --epoch 1075 --config config.json
+
+   # Compare reward_rest for a single epoch, default type = proposal_refund
+   python3 compare_reward_rest.py --epoch 1075
+
+   # Compare with a specific reward type
+   python3 compare_reward_rest.py --epoch 1075 --reward-type treasury
+   python3 compare_reward_rest.py --epoch 1075 --reward-type reserves
+   python3 compare_reward_rest.py --epoch 1075 --reward-type proposal_refund
+
+   # Compare across an epoch range
+   python3 compare_reward_rest.py --start-epoch 1075 --end-epoch 1080
+   python3 compare_reward_rest.py --start-epoch 492 --end-epoch 1044 --config config.json
+
+   # Custom database connections (CLI args override config file)
+   python3 compare_reward_rest.py --epoch 1075 \
+       --dbsync-url "postgresql://dbsync:dbsync@10.4.10.135:5678/cexplorer" \
+       --store-url "postgresql://yaci:dbpass@10.4.10.112:5432/yaci_store" \
+       --store-schema yaci_store
+
+   # Output to log file only, suppress console output
+   python3 compare_reward_rest.py --epoch 1075 --quiet
+
+   # Limit the number of mismatches printed
+   python3 compare_reward_rest.py --epoch 1075 --max-mismatches 50
+
+3. Output:
+   - Prints to console (and writes to log file in logs/ directory)
+   - Log file named: logs/reward_rest_compare_<type>_<timestamp>.log
+   - Compares using multiset: (address, type, earned_epoch, amount, spendable_epoch)
+   - Includes cases where a record appears multiple times (count mismatch)
+
+4. Notes:
+   - DB Sync: reward_rest table, joined with stake_address to get view (bech32 address)
+   - Yaci Store: reward_rest table, address field is already bech32
+   - Valid reward types: treasury, reserves, proposal_refund
+   - Uses multiset comparison (counts occurrences), not just presence/absence
+   - Config file (JSON) provides defaults, CLI args override
+
+PROBLEM SOLVED:
+---------------
+This script replaces RewardRestDataComparator.java, with advantages:
+  - No build/compile needed, runs directly with Python
+  - Flexible configuration via config file or command-line arguments
+  - Pass reward type via --reward-type instead of modifying code
+================================================================================
+"""
+
+import argparse
+import os
+import sys
+from collections import Counter
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import Logger, connect, add_common_args, resolve_config
+
+
+# ============================================================
+# Compare: reward_rest
+# ============================================================
+def compare_reward_rest(epoch, reward_type, dbsync_url, store_url, store_schema, logger, max_mismatches):
+    dbsync_query = """
+        SELECT sa.view, rr.type, rr.earned_epoch, rr.amount, rr.spendable_epoch
+        FROM reward_rest rr
+        INNER JOIN stake_address sa ON sa.id = rr.addr_id
+        WHERE rr.type = %s::rewardtype AND rr.earned_epoch = %s
+        ORDER BY rr.earned_epoch, sa.view, rr.amount
+    """
+    store_query = """
+        SELECT address, type, earned_epoch, amount, spendable_epoch
+        FROM reward_rest
+        WHERE type = %s AND earned_epoch = %s
+        ORDER BY earned_epoch, address, amount
+    """
+
+    dbsync_counter = Counter()
+    store_counter = Counter()
+
+    # --- Fetch DB Sync ---
+    try:
+        conn = connect(dbsync_url)
+        with conn.cursor() as cur:
+            cur.execute(dbsync_query, (reward_type, epoch))
+            for row in cur.fetchall():
+                address, rtype, earned_epoch, amount, spendable_epoch = row
+                key = (address, rtype, int(earned_epoch), int(amount), int(spendable_epoch) if spendable_epoch is not None else None)
+                dbsync_counter[key] += 1
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB Sync query error for epoch {epoch}", e)
+        return -1
+
+    # --- Fetch Yaci Store ---
+    try:
+        conn = connect(store_url, store_schema)
+        with conn.cursor() as cur:
+            cur.execute(store_query, (reward_type, epoch))
+            for row in cur.fetchall():
+                address, rtype, earned_epoch, amount, spendable_epoch = row
+                key = (address, rtype, int(earned_epoch), int(amount), int(spendable_epoch) if spendable_epoch is not None else None)
+                store_counter[key] += 1
+        conn.close()
+    except Exception as e:
+        logger.error(f"Yaci Store query error for epoch {epoch}", e)
+        return -1
+
+    # --- Compare ---
+    mismatch_count = 0
+    truncated = False
+
+    def fmt_entry(entry):
+        return f"address={entry[0]}, type={entry[1]}, earned_epoch={entry[2]}, amount={entry[3]}, spendable_epoch={entry[4]}"
+
+    def check_limit():
+        nonlocal truncated
+        if max_mismatches and mismatch_count >= max_mismatches:
+            if not truncated:
+                logger.log(f"  ... (reached limit of {max_mismatches} mismatches, skipping the rest)")
+                truncated = True
+            return True
+        return False
+
+    for entry, db_count in dbsync_counter.items():
+        if check_limit():
+            break
+        store_count = store_counter.get(entry)
+        if store_count is None:
+            mismatch_count += 1
+            logger.log(f"  Only in DB Sync: {fmt_entry(entry)} (count={db_count})")
+        elif store_count != db_count:
+            mismatch_count += 1
+            logger.log(f"  Count mismatch: {fmt_entry(entry)}")
+            logger.log(f"    DB Sync count={db_count}, Yaci Store count={store_count}")
+
+    for entry, store_count in store_counter.items():
+        if check_limit():
+            break
+        if entry not in dbsync_counter:
+            mismatch_count += 1
+            logger.log(f"  Only in Yaci Store: {fmt_entry(entry)} (count={store_count})")
+
+    return mismatch_count
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Reward Rest data between DB Sync and Yaci Store.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --epoch 1075
+  %(prog)s --epoch 1075 --config config.json
+  %(prog)s --epoch 1075 --reward-type treasury
+  %(prog)s --start-epoch 1075 --end-epoch 1080
+        """,
+    )
+
+    epoch_group = parser.add_mutually_exclusive_group(required=True)
+    epoch_group.add_argument("--epoch", type=int, help="Single epoch to compare")
+    epoch_group.add_argument("--start-epoch", type=int, help="Start epoch (use with --end-epoch)")
+    parser.add_argument("--end-epoch", type=int, help="End epoch (use with --start-epoch)")
+
+    parser.add_argument("--reward-type", default="proposal_refund",
+                        help="Reward type to compare: treasury, reserves, proposal_refund (default: proposal_refund)")
+    parser.add_argument("--max-mismatches", type=int, default=None, help="Limit mismatches printed per epoch (0 = unlimited)")
+
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args = resolve_config(args)
+
+    if args.epoch is not None:
+        start_epoch, end_epoch = args.epoch, args.epoch
+    else:
+        start_epoch, end_epoch = args.start_epoch, args.end_epoch
+        if end_epoch is None:
+            parser.error("--end-epoch is required when using --start-epoch")
+        if end_epoch < start_epoch:
+            parser.error("--end-epoch must be >= --start-epoch")
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = os.path.join("logs", f"reward_rest_compare_{args.reward_type}_{ts}.log")
+    logger = Logger(log_file, quiet=args.quiet)
+
+    logger.log("===== Starting Reward Rest comparison =====")
+    logger.log(f"Log file: {os.path.abspath(log_file)}")
+    logger.log(f"Epoch range: {start_epoch} -> {end_epoch}")
+    logger.log(f"Reward type: {args.reward_type}")
+    logger.log(f"DB Sync URL: {args.dbsync_url}")
+    logger.log(f"Yaci Store URL: {args.store_url} (schema: {args.store_schema})")
+    logger.log()
+
+    total_mismatches = 0
+    epochs_with_mismatch = 0
+    total_epochs = end_epoch - start_epoch + 1
+
+    for epoch in range(start_epoch, end_epoch + 1):
+        logger.log(f"############ Epoch {epoch} - reward_rest (type={args.reward_type}) ############")
+
+        count = compare_reward_rest(
+            epoch, args.reward_type, args.dbsync_url, args.store_url, args.store_schema, logger, args.max_mismatches
+        )
+
+        if count < 0:
+            logger.log(f"  Database connection error, skipping epoch {epoch}")
+        elif count == 0:
+            logger.log(f"  OK - All reward_rest data matches")
+        else:
+            epochs_with_mismatch += 1
+            total_mismatches += count
+            logger.log(f"  MISMATCH: {count} mismatch(es)")
+
+        logger.log()
+
+    logger.log("=" * 50)
+    logger.log(f"SUMMARY (reward_rest, type={args.reward_type}):")
+    logger.log(f"  Epochs compared     : {total_epochs}")
+    logger.log(f"  Epochs w/ mismatch  : {epochs_with_mismatch}/{total_epochs}")
+    logger.log(f"  Total mismatches    : {total_mismatches}")
+    logger.log("=" * 50)
+
+    if total_mismatches > 0:
+        logger.log(f"\nSee details at: {os.path.abspath(log_file)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare/compare_reward_rest.py
+++ b/scripts/compare/compare_reward_rest.py
@@ -25,7 +25,6 @@ USAGE:
 
    # Compare across an epoch range
    python3 compare_reward_rest.py --start-epoch 1075 --end-epoch 1080
-   python3 compare_reward_rest.py --start-epoch 492 --end-epoch 1044 --config config.json
 
    # Custom database connections (CLI args override config file)
    python3 compare_reward_rest.py --epoch 1075 \

--- a/scripts/compare/config.example.json
+++ b/scripts/compare/config.example.json
@@ -1,0 +1,12 @@
+{
+  "dbsync_url": "postgresql://10.4.10.135:5678/cexplorer",
+  "dbsync_user": "dbsync",
+  "dbsync_password": "dbsync",
+  "store_url": "postgresql://10.4.10.112:5432/yaci_store",
+  "store_user": "yaci",
+  "store_password": "dbpass",
+  "store_schema": "yaci_store",
+  "quiet": false,
+  "max_mismatches": 0,
+  "delay": 0
+}

--- a/scripts/compare/config.example.json
+++ b/scripts/compare/config.example.json
@@ -1,8 +1,8 @@
 {
-  "dbsync_url": "postgresql://10.4.10.135:5678/cexplorer",
+  "dbsync_url": "postgresql://localhost:5678/cexplorer",
   "dbsync_user": "dbsync",
   "dbsync_password": "dbsync",
-  "store_url": "postgresql://10.4.10.112:5432/yaci_store",
+  "store_url": "postgresql://localhost:5432/yaci_store",
   "store_user": "yaci",
   "store_password": "dbpass",
   "store_schema": "yaci_store",


### PR DESCRIPTION
Python-based comparators that replace the older Java *DataComparator utilities. Each script compares one slice of data (adapot, epoch_stake, reward_rest, drep amount/active_until, gov action proposal status) for a single epoch or epoch range, with a shared common.py for config loading and DB access. compare_all.py runs every comparator in one command and emits a combined summary; results are written to timestamped logs/.