### PR TITLE
 feat(epoch-nonce): opt-in flag + TPraos extra-entropy fix + docs

### DIFF
--- a/aggregates/epoch-nonce/EPOCH_NONCE_ALGORITHM.md
+++ b/aggregates/epoch-nonce/EPOCH_NONCE_ALGORITHM.md
@@ -42,13 +42,21 @@ When transitioning from epoch N to epoch N+1:
 # 1. Process all blocks from completed epoch N (updates evolving, candidate, labNonce)
 
 # 2. Compute the new epoch nonce using the ⭒ (star/combine) operator:
-epochNonce = candidateNonce ⭒ ticknPrevHashNonce
+if new epoch era <= Alonzo (TPraos):
+    epochNonce = (candidateNonce ⭒ ticknPrevHashNonce) ⭒ extraEntropy
+if new epoch era >= Babbage (Praos):
+    epochNonce = candidateNonce ⭒ ticknPrevHashNonce
 
-# 3. Carry forward the labNonce for the NEXT epoch's TICKN:
+# 3. Carry forward the completed epoch's labNonce for the NEXT epoch's TICKN:
 ticknPrevHashNonce' = labNonce
 
 # 4. evolving/candidate are NOT reset — they continue into the next epoch
 ```
+
+For TPraos, `extraEntropy` is read from the new epoch's protocol parameters.
+`null`, missing, or neutral `extraEntropy` is treated as `NeutralNonce`, so it does not change the result.
+For example, mainnet epoch 259 has non-neutral `extraEntropy` and must include it in the TICKN result.
+Praos/Babbage and later do not use `extraEntropy`.
 
 ### The ⭒ (star) operator
 
@@ -85,9 +93,9 @@ Whitespace and formatting matter — the file must be byte-for-byte identical to
 
 The stability window used for the candidate nonce freeze cutoff changed at the Conway hard fork:
 
-| Era | Haskell function | Formula | Value (k=2160, f=0.05) |
+| Era | Source/config | Formula | Value (k=2160, f=0.05) |
 |-----|---------|---------|------------------------|
-| Shelley through Babbage | `computeStabilityWindow` | `floor(3k/f)` | 129,600 (36h) |
+| Shelley through Babbage | `computeStabilityWindow` | `3k/f` | 129,600 (36h) |
 | Conway+ | `computeRandomnessStabilisationWindow` | `ceiling(4k/f)` | 172,800 (48h) |
 
 This change was introduced in **ouroboros-consensus v0.15.0.0** (backwards-incompatible), which set
@@ -96,6 +104,8 @@ instead of the previous `computeStabilityWindow` (3k/f). See also **cardano-ledg
 
 For pre-Conway eras, the consensus layer's `PraosParams.praosRandomnessStabilisationWindow` field was
 populated with `computeStabilityWindow` (3k/f) despite the naming suggesting otherwise.
+The current implementation uses `floor(3k/f)` for this value; for the supported Cardano network parameters
+`3k/f` is an integer, so this matches the ledger value.
 
 ## State Model
 
@@ -107,7 +117,7 @@ The `EpochNonce` record stores:
 | `evolvingNonce` | Post-processing evolving nonce (continuous, never reset) |
 | `candidateNonce` | Post-processing candidate nonce (continuous, never reset) |
 | `labNonce` | prevHash of the last block in the completed epoch |
-| `lastEpochBlockNonce` | The `ticknPrevHashNonce` — labNonce from the previous epoch, used in TICKN |
+| `lastEpochBlockNonce` | The completed epoch's `labNonce`, persisted so the next epoch can restore it as `ticknPrevHashNonce` |
 
 ## Haskell Reference Code
 
@@ -119,7 +129,9 @@ The implementation follows these Haskell modules in the Cardano codebase:
 
 - **Praos VRF nonce** (era >= 6): [ouroboros-consensus/.../Protocol/Praos.hs](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs) and [Praos/VRF.hs](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/VRF.hs)
 
-- **TICKN state machine**: [cardano-ledger/.../Shelley/Rules/Tick.hs](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs) — `TICKN` rule applies `candidateNonce ⭒ prevHashNonce`
+- **TPraos TICKN state machine**: [cardano-ledger/.../Shelley/Rules/Tickn.hs](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tickn.hs) — `TICKN` rule applies `candidateNonce ⭒ prevHashNonce ⭒ extraEntropy`
+
+- **Praos epoch transition**: [ouroboros-consensus/.../Protocol/Praos.hs](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs) — Praos applies `candidateNonce ⭒ prevHashNonce` without `extraEntropy`
 
 - **Nonce combine (⭒)**: [cardano-ledger/.../BaseTypes.hs](https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs) — `Nonce` type and `(⭒)` operator
 
@@ -131,3 +143,6 @@ The implementation follows these Haskell modules in the Cardano codebase:
 
 Epoch nonce values have been empirically verified against Cardano dbsync for preprod epochs 4–163+
 (spanning pre-Conway and Conway eras).
+
+Extra entropy handling has been verified against the Cardano ledger rule and mainnet epoch-param data, where epoch 259 is the only
+mainnet epoch with non-neutral `extraEntropy`.

--- a/aggregates/epoch-nonce/build.gradle
+++ b/aggregates/epoch-nonce/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api project(':components:events')
     api project(":components:core")
     api project(":stores:blocks")
+    implementation project(":stores:epoch")
 
     //Test dependencies
     testCompileOnly 'org.projectlombok:lombok'
@@ -12,6 +13,7 @@ dependencies {
 
     testImplementation project(':starters:spring-boot-starter')
     testImplementation project(':starters:blocks-spring-boot-starter')
+    testImplementation project(':starters:epoch-spring-boot-starter')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/processor/EpochNonceProcessor.java
+++ b/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/processor/EpochNonceProcessor.java
@@ -35,7 +35,7 @@ public class EpochNonceProcessor {
             return;
         }
 
-        epochNonceService.computeEpochNonce(event.getEpoch(), event.getPreviousEpoch(), event.getMetadata());
+        epochNonceService.computeEpochNonce(event.getEpoch(), event.getPreviousEpoch(), event.getMetadata(), event.getEra());
     }
 
     @EventListener

--- a/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceService.java
+++ b/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceService.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.yaci.store.blocks.domain.Block;
 import com.bloxbean.cardano.yaci.store.blocks.domain.Vrf;
 import com.bloxbean.cardano.yaci.store.blocks.storage.BlockStorageReader;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
 import com.bloxbean.cardano.yaci.store.common.util.StringUtil;
 import com.bloxbean.cardano.yaci.store.epochnonce.domain.EpochNonce;
 import com.bloxbean.cardano.yaci.store.epochnonce.storage.EpochNonceStorage;
@@ -13,6 +14,8 @@ import com.bloxbean.cardano.yaci.store.epochnonce.util.EpochNonceConfig;
 import com.bloxbean.cardano.yaci.store.epochnonce.util.NonceUtil;
 import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.EraMapper;
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 @RequiredArgsConstructor
@@ -37,8 +42,14 @@ public class EpochNonceService {
     private final EpochNonceConfig epochNonceConfig;
     private final StoreProperties storeProperties;
     private final ResourceLoader resourceLoader;
+    private final Optional<EpochParamStorage> epochParamStorage;
+    private final AtomicBoolean missingEpochParamStorageWarned = new AtomicBoolean(false);
 
     public void computeEpochNonce(int newEpoch, Integer completedEpoch, EventMetadata metadata) {
+        computeEpochNonce(newEpoch, completedEpoch, metadata, metadata != null ? metadata.getEra() : null);
+    }
+
+    public void computeEpochNonce(int newEpoch, Integer completedEpoch, EventMetadata metadata, Era newEpochEra) {
         // For the very first Shelley epoch (completedEpoch is null or 0 for custom networks),
         // initialize from genesis
         EpochNonce prevState;
@@ -58,17 +69,19 @@ public class EpochNonceService {
         // used in the TICKN formula for the CURRENT epoch tick.
         byte[] ticknPrevHashNonce = decode(prevState.getLastEpochBlockNonce());
 
+        Era completedEpochEra = newEpochEra;
+
         // Query all blocks of completed epoch, sorted by slot
         if (completedEpoch != null) {
             List<Block> blocks = blockStorageReader.findBlocksByEpoch(completedEpoch);
             blocks.sort(Comparator.comparingLong(Block::getSlot));
 
             // Determine epoch era from first block to select the correct stability window
-            Era epochEra = (!blocks.isEmpty() && blocks.get(0).getEra() != null)
-                    ? EraMapper.intToEra(blocks.get(0).getEra())
-                    : null;
+            if (!blocks.isEmpty() && blocks.get(0).getEra() != null) {
+                completedEpochEra = EraMapper.intToEra(blocks.get(0).getEra());
+            }
 
-            long stabilityWindow = epochNonceConfig.getStabilityWindow(epochEra);
+            long stabilityWindow = epochNonceConfig.getStabilityWindow(completedEpochEra);
             long epochLength = epochNonceConfig.getEpochLength();
 
             // Compute first slot of next epoch once (same for all blocks in this epoch)
@@ -76,7 +89,7 @@ public class EpochNonceService {
                     ? (blocks.get(0).getSlot() - blocks.get(0).getEpochSlot()) + epochLength
                     : 0;
 
-            log.debug("Epoch {} era={}, stabilityWindow={}", completedEpoch, epochEra, stabilityWindow);
+            log.debug("Epoch {} era={}, stabilityWindow={}", completedEpoch, completedEpochEra, stabilityWindow);
 
             // Process each block — evolving/candidate update continuously
             for (Block block : blocks) {
@@ -103,8 +116,13 @@ public class EpochNonceService {
             }
         }
 
-        // TICKN: epochNonce = candidateNonce ⭒ ticknPrevHashNonce
+        // TICKN/Praos: epochNonce = candidateNonce ⭒ ticknPrevHashNonce
+        // TICKN/TPraos: epochNonce = candidateNonce ⭒ ticknPrevHashNonce ⭒ extraEntropy
         byte[] newEpochNonce = NonceUtil.combineNonces(candidateNonce, ticknPrevHashNonce);
+        Era extraEntropyEra = newEpochEra != null ? newEpochEra : completedEpochEra;
+        byte[] extraEntropy = getExtraEntropy(newEpoch, extraEntropyEra);
+        newEpochNonce = NonceUtil.combineNonces(newEpochNonce, extraEntropy);
+
         // Update ticknPrevHashNonce for the next epoch tick
         byte[] newTicknPrevHashNonce = labNonce;
 
@@ -142,6 +160,31 @@ public class EpochNonceService {
             return null;
         }
         return HexUtil.decodeHexString(vrf.getOutput());
+    }
+
+    private byte[] getExtraEntropy(int epoch, Era era) {
+        if (!usesTPraosExtraEntropy(era)) {
+            return null;
+        }
+
+        if (epochParamStorage.isEmpty()) {
+            if (missingEpochParamStorageWarned.compareAndSet(false, true)) {
+                log.warn("EpochParamStorage is not available. TPraos extra entropy will be treated as NeutralNonce. "
+                        + "Enable the epoch store for correct Shelley-Alonzo nonce calculation, including mainnet epoch 259.");
+            }
+            return null;
+        }
+
+        return epochParamStorage
+                .flatMap(storage -> storage.getProtocolParams(epoch))
+                .map(EpochParam::getParams)
+                .map(ProtocolParams::getExtraEntropy)
+                .map(NonceUtil::extraEntropyToNonce)
+                .orElse(null);
+    }
+
+    private boolean usesTPraosExtraEntropy(Era era) {
+        return era == null || era.getValue() < Era.Babbage.getValue();
     }
 
     private EpochNonce initializeGenesisNonce() {

--- a/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/util/NonceUtil.java
+++ b/aggregates/epoch-nonce/src/main/java/com/bloxbean/cardano/yaci/store/epochnonce/util/NonceUtil.java
@@ -89,4 +89,50 @@ public class NonceUtil {
         }
         return HexUtil.decodeHexString(prevHashHex);
     }
+
+    /**
+     * Converts the stored protocol-parameter extra entropy value to a nonce.
+     * <p>
+     * The stored value follows the update nonce encoding: {@code 0,} for
+     * {@code NeutralNonce}, or {@code 1,<32-byte hex>} for {@code Nonce}.
+     *
+     * @param extraEntropy stored extra entropy value, or null
+     * @return nonce bytes, or null for {@code NeutralNonce}
+     */
+    public static byte[] extraEntropyToNonce(String extraEntropy) {
+        if (extraEntropy == null || extraEntropy.isBlank()) {
+            return null;
+        }
+
+        String[] parts = extraEntropy.split(",", 2);
+        int tag;
+        try {
+            tag = Integer.parseInt(parts[0].trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid extra entropy tag: " + extraEntropy, e);
+        }
+
+        if (tag == 0) {
+            return null;
+        }
+
+        if (tag != 1) {
+            throw new IllegalArgumentException("Unsupported extra entropy tag: " + tag);
+        }
+
+        if (parts.length < 2 || parts[1].isBlank()) {
+            throw new IllegalArgumentException("Missing extra entropy nonce value");
+        }
+
+        String hex = parts[1].trim();
+        if (hex.startsWith("0x") || hex.startsWith("0X") || hex.startsWith("\\x") || hex.startsWith("\\X")) {
+            hex = hex.substring(2);
+        }
+
+        if (hex.length() != 64) {
+            throw new IllegalArgumentException("Extra entropy nonce must be 32 bytes");
+        }
+
+        return HexUtil.decodeHexString(hex);
+    }
 }

--- a/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/processor/EpochNonceProcessorTest.java
+++ b/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/processor/EpochNonceProcessorTest.java
@@ -70,7 +70,7 @@ class EpochNonceProcessorTest {
 
         epochNonceProcessor.handleEpochTransition(event);
 
-        verify(epochNonceService).computeEpochNonce(211, 210, metadata);
+        verify(epochNonceService).computeEpochNonce(211, 210, metadata, Era.Shelley);
     }
 
     @Test
@@ -91,7 +91,7 @@ class EpochNonceProcessorTest {
 
         epochNonceProcessor.handleEpochTransition(event);
 
-        verify(epochNonceService).computeEpochNonce(366, 365, metadata);
+        verify(epochNonceService).computeEpochNonce(366, 365, metadata, Era.Babbage);
     }
 
     @Test
@@ -112,7 +112,7 @@ class EpochNonceProcessorTest {
 
         epochNonceProcessor.handleEpochTransition(event);
 
-        verify(epochNonceService).computeEpochNonce(0, null, metadata);
+        verify(epochNonceService).computeEpochNonce(0, null, metadata, Era.Shelley);
     }
 
     @Test

--- a/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceServiceIT.java
+++ b/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceServiceIT.java
@@ -2,7 +2,11 @@ package com.bloxbean.cardano.yaci.store.epochnonce.service;
 
 import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.store.blocks.storage.BlockStorageReader;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
 import com.bloxbean.cardano.yaci.store.epochnonce.domain.EpochNonce;
 import com.bloxbean.cardano.yaci.store.epochnonce.storage.EpochNonceStorage;
 import com.bloxbean.cardano.yaci.store.epochnonce.storage.EpochNonceStorageReader;
@@ -38,6 +42,9 @@ class EpochNonceServiceIT {
     @Autowired
     private BlockStorageReader blockStorageReader;
 
+    @Autowired
+    private EpochParamStorage epochParamStorage;
+
     @Test
     @SqlGroup({
             @Sql(value = "classpath:scripts/epoch_blocks_data.sql", executionPhase = BEFORE_TEST_METHOD)
@@ -68,6 +75,50 @@ class EpochNonceServiceIT {
         assertThat(nonce.getSlot()).isEqualTo(139003495);
         assertThat(nonce.getBlock()).isEqualTo(11043370);
         assertThat(nonce.getBlockTime()).isEqualTo(1730569786);
+    }
+
+    @Test
+    void computeEpochNonce_withStoredTPraosExtraEntropy_shouldIncludeEntropyFromEpochParamStorage() {
+        int completedEpoch = 258;
+        int newEpoch = 259;
+        String candidateNonce = "1111111111111111111111111111111111111111111111111111111111111111";
+        String previousLabNonce = "2222222222222222222222222222222222222222222222222222222222222222";
+        String extraEntropy = "d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa";
+
+        epochNonceStorage.save(EpochNonce.builder()
+                .epoch(completedEpoch)
+                .nonce(candidateNonce)
+                .evolvingNonce(candidateNonce)
+                .candidateNonce(candidateNonce)
+                .labNonce(null)
+                .lastEpochBlockNonce(previousLabNonce)
+                .build());
+
+        epochParamStorage.save(EpochParam.builder()
+                .epoch(newEpoch)
+                .params(ProtocolParams.builder()
+                        .extraEntropy("1," + extraEntropy)
+                        .build())
+                .slot(1L)
+                .blockNumber(1L)
+                .blockTime(1L)
+                .build());
+
+        EventMetadata metadata = EventMetadata.builder()
+                .era(Era.Shelley)
+                .slot(2)
+                .block(2)
+                .blockTime(2)
+                .epochNumber(newEpoch)
+                .build();
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata, Era.Shelley);
+
+        EpochNonce result = epochNonceStorageReader.findByEpoch(newEpoch).orElseThrow();
+        String expected = HexUtil.encodeHexString(NonceUtil.combineNonces(
+                NonceUtil.combineNonces(HexUtil.decodeHexString(candidateNonce), HexUtil.decodeHexString(previousLabNonce)),
+                HexUtil.decodeHexString(extraEntropy)));
+        assertThat(result.getNonce()).isEqualTo(expected);
     }
 
     @Test

--- a/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceServiceTest.java
+++ b/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/service/EpochNonceServiceTest.java
@@ -1,0 +1,219 @@
+package com.bloxbean.cardano.yaci.store.epochnonce.service;
+
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.blocks.domain.Block;
+import com.bloxbean.cardano.yaci.store.blocks.storage.BlockStorageReader;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import com.bloxbean.cardano.yaci.store.epochnonce.domain.EpochNonce;
+import com.bloxbean.cardano.yaci.store.epochnonce.storage.EpochNonceStorage;
+import com.bloxbean.cardano.yaci.store.epochnonce.util.EpochNonceConfig;
+import com.bloxbean.cardano.yaci.store.epochnonce.util.NonceUtil;
+import com.bloxbean.cardano.yaci.store.events.EventMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ResourceLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EpochNonceServiceTest {
+    private static final String CANDIDATE_NONCE = "1111111111111111111111111111111111111111111111111111111111111111";
+    private static final String EVOLVING_NONCE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String LAB_NONCE = "3333333333333333333333333333333333333333333333333333333333333333";
+    private static final String PREVIOUS_LAB_NONCE = "2222222222222222222222222222222222222222222222222222222222222222";
+    private static final String EXTRA_ENTROPY = "d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa";
+
+    @Mock
+    private BlockStorageReader blockStorageReader;
+
+    @Mock
+    private EpochNonceStorage epochNonceStorage;
+
+    @Mock
+    private EpochNonceConfig epochNonceConfig;
+
+    @Mock
+    private StoreProperties storeProperties;
+
+    @Mock
+    private ResourceLoader resourceLoader;
+
+    @Mock
+    private EpochParamStorage epochParamStorage;
+
+    @Captor
+    private ArgumentCaptor<EpochNonce> epochNonceCaptor;
+
+    private EpochNonceService epochNonceService;
+
+    @BeforeEach
+    void setUp() {
+        epochNonceService = new EpochNonceService(
+                blockStorageReader,
+                epochNonceStorage,
+                epochNonceConfig,
+                storeProperties,
+                resourceLoader,
+                Optional.of(epochParamStorage));
+    }
+
+    @Test
+    void computeEpochNonce_tPraosNonNeutralExtraEntropy_combinesAfterCandidateAndPreviousLabNonce() {
+        int newEpoch = 259;
+        int completedEpoch = 258;
+        stubPreviousNonceState(completedEpoch);
+        when(epochParamStorage.getProtocolParams(newEpoch)).thenReturn(epochParam(newEpoch, "1," + EXTRA_ENTROPY));
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Shelley));
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        String expected = encode(NonceUtil.combineNonces(
+                NonceUtil.combineNonces(decode(CANDIDATE_NONCE), decode(PREVIOUS_LAB_NONCE)),
+                decode(EXTRA_ENTROPY)));
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(expected);
+    }
+
+    @Test
+    void computeEpochNonce_tPraosNeutralExtraEntropy_matchesExistingFormula() {
+        int newEpoch = 260;
+        int completedEpoch = 259;
+        stubPreviousNonceState(completedEpoch);
+        when(epochParamStorage.getProtocolParams(newEpoch)).thenReturn(epochParam(newEpoch, "0,"));
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Shelley));
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(existingFormulaNonce());
+    }
+
+    @Test
+    void computeEpochNonce_tPraosMissingEpochParam_matchesExistingFormula() {
+        int newEpoch = 258;
+        int completedEpoch = 257;
+        stubPreviousNonceState(completedEpoch);
+        when(epochParamStorage.getProtocolParams(newEpoch)).thenReturn(Optional.empty());
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Shelley));
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(existingFormulaNonce());
+    }
+
+    @Test
+    void computeEpochNonce_tPraosMissingEpochParamStorage_matchesExistingFormula() {
+        int newEpoch = 258;
+        int completedEpoch = 257;
+        epochNonceService = new EpochNonceService(
+                blockStorageReader,
+                epochNonceStorage,
+                epochNonceConfig,
+                storeProperties,
+                resourceLoader,
+                Optional.empty());
+        stubPreviousNonceState(completedEpoch);
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Shelley));
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(existingFormulaNonce());
+        verify(epochParamStorage, never()).getProtocolParams(any(Integer.class));
+    }
+
+    @Test
+    void computeEpochNonce_babbageEra_doesNotReadOrApplyExtraEntropy() {
+        int newEpoch = 366;
+        int completedEpoch = 365;
+        stubPreviousNonceState(completedEpoch);
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Babbage));
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(existingFormulaNonce());
+        verify(epochParamStorage, never()).getProtocolParams(any(Integer.class));
+    }
+
+    @Test
+    void computeEpochNonce_babbageNewEpochAfterTPraosCompletedEpoch_doesNotReadOrApplyExtraEntropy() {
+        int newEpoch = 366;
+        int completedEpoch = 365;
+        stubPreviousNonceState(completedEpoch, List.of(
+                Block.builder()
+                        .slot(1L)
+                        .epochSlot(1)
+                        .era(Era.Alonzo.getValue())
+                        .build()));
+
+        epochNonceService.computeEpochNonce(newEpoch, completedEpoch, metadata(Era.Babbage), Era.Babbage);
+
+        verify(epochNonceStorage).save(epochNonceCaptor.capture());
+        assertThat(epochNonceCaptor.getValue().getNonce()).isEqualTo(existingFormulaNonce());
+        verify(epochParamStorage, never()).getProtocolParams(any(Integer.class));
+    }
+
+    private void stubPreviousNonceState(int completedEpoch) {
+        stubPreviousNonceState(completedEpoch, List.of());
+    }
+
+    private void stubPreviousNonceState(int completedEpoch, List<Block> blocks) {
+        EpochNonce prevState = EpochNonce.builder()
+                .epoch(completedEpoch)
+                .nonce(CANDIDATE_NONCE)
+                .evolvingNonce(EVOLVING_NONCE)
+                .candidateNonce(CANDIDATE_NONCE)
+                .labNonce(LAB_NONCE)
+                .lastEpochBlockNonce(PREVIOUS_LAB_NONCE)
+                .build();
+
+        when(epochNonceStorage.findByEpoch(completedEpoch)).thenReturn(Optional.of(prevState));
+        when(blockStorageReader.findBlocksByEpoch(completedEpoch)).thenReturn(new ArrayList<>(blocks));
+        when(epochNonceConfig.getStabilityWindow(any())).thenReturn(129600L);
+        when(epochNonceConfig.getEpochLength()).thenReturn(432000L);
+    }
+
+    private Optional<EpochParam> epochParam(int epoch, String extraEntropy) {
+        return Optional.of(EpochParam.builder()
+                .epoch(epoch)
+                .params(ProtocolParams.builder()
+                        .extraEntropy(extraEntropy)
+                        .build())
+                .build());
+    }
+
+    private EventMetadata metadata(Era era) {
+        return EventMetadata.builder()
+                .era(era)
+                .slot(1000)
+                .block(100)
+                .blockTime(1000000)
+                .build();
+    }
+
+    private String existingFormulaNonce() {
+        return encode(NonceUtil.combineNonces(decode(CANDIDATE_NONCE), decode(PREVIOUS_LAB_NONCE)));
+    }
+
+    private byte[] decode(String hex) {
+        return HexUtil.decodeHexString(hex);
+    }
+
+    private String encode(byte[] bytes) {
+        return HexUtil.encodeHexString(bytes);
+    }
+}

--- a/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/util/NonceUtilTest.java
+++ b/aggregates/epoch-nonce/src/test/java/com/bloxbean/cardano/yaci/store/epochnonce/util/NonceUtilTest.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.client.util.HexUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NonceUtilTest {
 
@@ -194,6 +195,44 @@ class NonceUtilTest {
 
         // Result should NOT equal the hashed value — it's raw bytes
         assertThat(result).isNotEqualTo(hashed);
+    }
+
+    // --- extraEntropyToNonce tests ---
+
+    @Test
+    void extraEntropyToNonce_nullInput_returnsNull() {
+        assertThat(NonceUtil.extraEntropyToNonce(null)).isNull();
+    }
+
+    @Test
+    void extraEntropyToNonce_neutralNonce_returnsNull() {
+        assertThat(NonceUtil.extraEntropyToNonce("0,")).isNull();
+    }
+
+    @Test
+    void extraEntropyToNonce_nonNeutralNonce_returnsDecodedBytes() {
+        String entropy = "d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa";
+
+        byte[] result = NonceUtil.extraEntropyToNonce("1," + entropy);
+
+        assertThat(result).isEqualTo(HexUtil.decodeHexString(entropy));
+        assertThat(result).hasSize(32);
+    }
+
+    @Test
+    void extraEntropyToNonce_nonNeutralNonceWithHexPrefix_returnsDecodedBytes() {
+        String entropy = "d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa";
+
+        byte[] result = NonceUtil.extraEntropyToNonce("1,0x" + entropy);
+
+        assertThat(result).isEqualTo(HexUtil.decodeHexString(entropy));
+    }
+
+    @Test
+    void extraEntropyToNonce_invalidNonceLength_throwsException() {
+        assertThatThrownBy(() -> NonceUtil.extraEntropyToNonce("1,abcd"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("32 bytes");
     }
 
     // --- Integration: nonce evolution sequence ---

--- a/config/application.properties
+++ b/config/application.properties
@@ -199,6 +199,7 @@ store.auto-index-management=true
 #store.transaction.enabled=true
 #store.utxo.enabled=true
 #store.governance.enabled=true
+#store.epoch-nonce.enabled=true
 
 ############################################################
 # Flags to disable api/controllers for a store

--- a/docker/config/application.properties
+++ b/docker/config/application.properties
@@ -190,6 +190,7 @@ store.auto-index-management=true
 #store.transaction.enabled=true
 #store.utxo.enabled=true
 #store.governance.enabled=true
+#store.epoch-nonce.enabled=true
 
 ############################################################
 # Flags to disable api/controllers for a store

--- a/docs/app/docs/v2/advanced-configuration/_meta.js
+++ b/docs/app/docs/v2/advanced-configuration/_meta.js
@@ -2,5 +2,6 @@ export default {
   "pruning": "Pruning",
   "auto-restart": "Auto-Restart",
   "auto-recovery": "Auto-Recovery",
-  "auto-sync-off": "Auto-Sync Off"
+  "auto-sync-off": "Auto-Sync Off",
+  "epoch-nonce": "Epoch Nonce"
 }

--- a/docs/app/docs/v2/advanced-configuration/epoch-nonce/page.mdx
+++ b/docs/app/docs/v2/advanced-configuration/epoch-nonce/page.mdx
@@ -1,0 +1,64 @@
+import { Callout } from 'nextra/components'
+
+# Epoch Nonce
+
+<Callout type="info">
+Available since **v2.1.0-pre4**.
+</Callout>
+
+The **epoch-nonce** module is an optional store that computes and persists Cardano epoch nonces by processing VRF outputs from block headers.
+The epoch nonce is the protocol value used in the leader-election process for each epoch.
+
+At each epoch transition, the module processes the blocks of the just-completed epoch and writes one row to the `epoch_nonce` table for the
+**new** epoch — including the final nonce and the intermediate values required to keep nonce computation continuous across epoch boundaries.
+
+## Enabling the Module
+
+<Callout type="warning">
+The epoch-nonce module is **disabled by default**. After enabling it you must **resync from the genesis block** so the module can compute
+nonces for all historical epochs. Enabling it on an already-synced database will leave a gap and break nonce-state continuity across epochs.
+</Callout>
+
+To enable the module, add the following to your `application.properties` file:
+
+```properties
+store.epoch-nonce.enabled=true
+```
+
+<Callout type="warning">
+For correct Shelley-Alonzo nonce calculation, the epoch store must also be enabled and synced so epoch protocol parameters are available.
+This is required for TPraos epochs with non-neutral `extra_entropy`, such as mainnet epoch 259.
+</Callout>
+
+## Calculation
+
+The epoch nonce formula depends on the era:
+
+- Shelley-Alonzo (TPraos): `(candidate_nonce ⭒ previous_epoch_last_block_nonce) ⭒ extra_entropy`
+- Babbage and later (Praos): `candidate_nonce ⭒ previous_epoch_last_block_nonce`
+
+Missing, null, or neutral extra entropy is treated as `NeutralNonce`, so it does not change the result.
+
+## What Gets Stored
+
+Each row represents one epoch's nonce state and is written at the corresponding epoch transition, after processing the previous (completed) epoch's blocks:
+
+| Column | Description |
+|--------|-------------|
+| `epoch` | Epoch number that this row's `nonce` applies to (primary key) |
+| `nonce` | Final epoch nonce for this epoch — the primary protocol output. Computed from `candidate_nonce`, the previous epoch's last block nonce, and TPraos `extra_entropy` when applicable |
+| `evolving_nonce` | Running hash of VRF outputs, continuous across epochs — restored from the previous row and updated by every block of the completed epoch |
+| `candidate_nonce` | Snapshot of `evolving_nonce` taken before the stability-window cutoff in the completed epoch |
+| `lab_nonce` | `prevHash` of the last block in the completed epoch |
+| `last_epoch_block_nonce` | `lab_nonce` snapshot stored for use by the **next** epoch's TICKN step (combined there with that epoch's `candidate_nonce` to form its `nonce`) |
+| `slot` / `block` / `block_time` | Position metadata used for rollback handling and auditing |
+
+The intermediate values are persisted for two reasons:
+
+- **Computation continuity** — Nonce state is continuous across epochs and never resets. Each epoch's computation restores the previous epoch's
+  `evolving_nonce` and `candidate_nonce` as its starting point.
+- **Debugging** — When a computed nonce doesn't match expectations, the intermediate fields make it possible to pinpoint exactly where the divergence occurred.
+
+<Callout>
+This module does not expose any REST endpoints. Consumers read epoch nonces directly from the `epoch_nonce` table.
+</Callout>

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
 ## Summary

  - Add `store.epoch-nonce.enabled` property (default `false`) so the epoch-nonce module is opt-in. Enabling it requires a resync from genesis.
  - Fix epoch nonce computation for TPraos eras (Shelley–Alonzo) by including the protocol-parameter `extraEntropy` in the TICKN transition, matching the Cardano Haskell node.
  Without this, mainnet epoch 259 (and any other TPraos epoch with non-neutral entropy) produced an incorrect nonce.
  - Add a docsite page under `Advanced Configuration → Epoch Nonce` describing the module, enable flag, resync caveat, formula, and stored fields.

  ## Details

  ### TICKN fix
  - Service now computes:
    - Praos / Babbage+: `candidate ⭒ prevLab`
    - TPraos / Shelley–Alonzo: `(candidate ⭒ prevLab) ⭒ extraEntropy`
  - Reads `extraEntropy` from `epoch_param` for the new epoch via `EpochParamStorage`.
  - Parses stored entropy format (`0,` → NeutralNonce; `1,<32-byte hex>` → real nonce; tolerant of `0x` / `\x` prefixes).
  - New-epoch era is now passed from `EpochNonceProcessor` so Babbage epochs after Alonzo do not accidentally apply TPraos entropy at the era boundary.
  - Logs a one-time WARN if `EpochParamStorage` is unavailable while running TPraos epochs.

  ### Dependencies
  - `aggregates/epoch-nonce` now depends on `stores:epoch` (main) and `starters:epoch-spring-boot-starter` (test).