### PR TITLE
 feat: Add Scalus-backed transaction evaluation

### DIFF
--- a/adr/0002-scalus-transaction-evaluation.md
+++ b/adr/0002-scalus-transaction-evaluation.md
@@ -25,18 +25,18 @@ script supplier, and a correct `SlotConfig`.
 
 ## Decision
 
-Add Scalus as an alternative transaction evaluator in the submit module.
+Add Scalus as the default local transaction evaluator in the submit module.
 
 Evaluation backend selection will be controlled by:
 
 ```properties
-store.submit.tx-evaluator-mode=ogmios
+store.submit.tx-evaluator-mode=scalus
 ```
 
 Supported values:
 
-- `ogmios`: default; preserve current behavior.
-- `scalus`: use Scalus even if `store.cardano.ogmios-url` is configured.
+- `scalus`: default; evaluate with local Yaci Store data and Scalus.
+- `ogmios`: delegate to Ogmios when `store.cardano.ogmios-url` is configured.
 
 Bind this property as an enum-backed Spring `@ConfigurationProperties` value so
 unknown values fail during application startup instead of surfacing as a
@@ -266,8 +266,8 @@ store.submit.tx-evaluator-mode=scalus
 
 ## Final Position
 
-Scalus should be added as an explicit alternative transaction evaluator, not as a
-hidden fallback only. The release-safe design is to keep the submit module
-decoupled, use existing or minimal client interfaces for ledger context, pass an
-explicit `SlotConfig`, and perform evaluator selection at runtime for native
+Scalus should be the default local transaction evaluator, with Ogmios available
+as an explicit external evaluator. The release-safe design is to keep the submit
+module decoupled, use existing or minimal client interfaces for ledger context,
+pass an explicit `SlotConfig`, and perform evaluator selection at runtime for native
 image compatibility.

--- a/adr/0002-scalus-transaction-evaluation.md
+++ b/adr/0002-scalus-transaction-evaluation.md
@@ -1,0 +1,273 @@
+# ADR 0002: Scalus Transaction Evaluation
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-13
+
+## Context
+
+Yaci Store currently exposes a Blockfrost-compatible transaction evaluation
+endpoint at `/utils/txs/evaluate`. The endpoint is enabled only when
+`OgmiosService` is available, which requires `store.cardano.ogmios-url`.
+
+This makes transaction evaluation dependent on an external Ogmios instance even
+when Yaci Store already has the local indexed data needed to resolve UTxOs,
+protocol parameters, and reference scripts.
+
+Scalus exposes `scalus.bloxbean.ScalusTransactionEvaluator`, an implementation
+of Cardano Client Lib's `TransactionEvaluator`. It can evaluate Plutus scripts
+from a transaction CBOR when given protocol parameters, a UTxO supplier, a
+script supplier, and a correct `SlotConfig`.
+
+## Decision
+
+Add Scalus as an alternative transaction evaluator in the submit module.
+
+Evaluation backend selection will be controlled by:
+
+```properties
+store.submit.tx-evaluator-mode=ogmios
+```
+
+Supported values:
+
+- `ogmios`: default; preserve current behavior.
+- `scalus`: use Scalus even if `store.cardano.ogmios-url` is configured.
+
+Bind this property as an enum-backed Spring `@ConfigurationProperties` value so
+unknown values fail during application startup instead of surfacing as a
+request-time transaction evaluation error.
+
+The existing endpoint paths and Blockfrost-compatible response shape will remain
+unchanged.
+
+## Implementation Notes
+
+Add Scalus `0.17.0` to `gradle/libs.versions.toml` and reference it from
+`components/submit/build.gradle`. Scalus must be used with the repository
+managed Cardano Client Lib version; do not bump CCL as part of this change
+unless compilation or runtime validation proves it is required. Exclude
+transitive Cardano Client Lib dependencies from Scalus if they conflict with the
+repository-managed CCL version.
+
+Do not make the submit module depend directly on epoch, UTxO, or script store
+modules. Use client interfaces:
+
+- `UtxoClient` for UTxO lookup.
+- new minimal `EpochParamClient` for latest protocol parameters.
+
+`EpochParamClient` returns Cardano Client Lib `ProtocolParams`, because Scalus'
+Java-facing evaluator consumes CCL protocol params directly. The local
+implementation lives in `stores:epoch` as `EpochParamClientImpl`, is enabled by
+default when that module is on the classpath, and maps Yaci Store
+domain `ProtocolParams` to CCL. Do not add a remote epoch parameter client or
+`store.epoch-param-client-url` for the initial release because there is no
+current deployment use case for it.
+
+Do not add a `ScriptClient` for the initial implementation. Reference scripts
+are stored on UTxO outputs as `AddressUtxo.scriptRef` with
+`referenceScriptHash`, and the UTxO APIs already return those fields.
+
+However, Scalus' CCL interop cannot read `AddressUtxo.scriptRef` directly
+because Cardano Client Lib's `Utxo` model only carries `referenceScriptHash`.
+Scalus resolves reference scripts by calling the supplied
+`scalus.bloxbean.ScriptSupplier` with that hash. Therefore, implement a custom
+`ScriptSupplier` backed by resolved `AddressUtxo.scriptRef` values and pass it
+to `ScalusTransactionEvaluator`. Do not use Scalus' `NoScriptSupplier` for
+transactions that may contain reference scripts.
+
+The Scalus UTxO supplier should bridge both concerns: when it resolves an
+`AddressUtxo`, it should map the output to a CCL `Utxo` and register any
+`scriptRef` on the custom `ScriptSupplier`, keyed by `referenceScriptHash`.
+The script supplier can deserialize the stored script reference using
+`ScriptReferenceUtil.deserializeScriptRef(...)` from `components:common` and
+return the resulting CCL Plutus script. Add a separate `ScriptClient` later only
+if there is a concrete evaluation case where required scripts are not reachable
+through transaction witnesses or resolved UTxOs.
+
+Protocol parameter mapping from Yaci Store domain objects to Cardano Client Lib
+`ProtocolParams` is part of the implementation. This mapping must include cost
+models by language version, including Plutus V1, V2, and V3 where present.
+Cost model arrays should be exposed to CCL as numeric string keys (`"0"`,
+`"1"`, ...) to preserve ledger array order.
+
+Scalus must be run in `EvaluatorMode.EVALUATE_AND_COMPUTE_COST` for this
+endpoint. `EvaluatorMode.VALIDATE` is not the target behavior because the
+Blockfrost-compatible endpoint is expected to compute script execution units.
+
+Scalus `EvaluationResult` values must be mapped to the same purpose labels that
+the current Ogmios JSON-RPC path passes through for the v5-compatible formatter:
+
+- `Spend` -> `spend`
+- `Mint` -> `mint`
+- `Cert` -> `publish`
+- `Reward` -> `withdraw`
+- `Voting` -> `vote`
+- `Proposing` -> `propose`
+
+Do not add a separate purpose mapping to the Ogmios path. The existing Ogmios
+path should continue to lower-case the purpose returned by Ogmios and use that
+value in the Blockfrost-compatible response key.
+
+The `evaluate/utxos` request's `additionalUtxoSet` should be honored in the
+Scalus path by passing the supplied UTxOs into
+`ScalusTransactionEvaluator.evaluateTx(byte[], Set<Utxo>)`. The existing Ogmios
+path can remain unchanged for compatibility, but the API documentation should be
+updated so the "additional UTxOs are ignored" note applies only to Ogmios mode,
+not to Scalus mode.
+
+Do not model `additionalUtxoSet` as an unstructured `Object`. The
+Blockfrost-compatible endpoint documents this value as an array of `[TxIn,
+TxOut]` tuples, and the Blockfrost SDK references the Ogmios additional UTxO set
+format. Use a typed `OgmiosUtxo` request object that can parse the tuple shape
+and normalize both common value encodings:
+
+- Blockfrost SDK shape: `TxIn={txId,index}` and
+  `TxOut.value={coins,assets}`.
+- Ogmios schema/docs shape: transaction reference fields such as
+  `transaction.id` plus `index`/`output.index`, and
+  `TxOut.value={ada:{lovelace}, <policyId>:{<assetName>: quantity}}`.
+
+Keep parsing mode-aware. Ogmios mode ignores `additionalUtxoSet` today, so the
+controller should keep the raw JSON payload and only parse/validate it when
+Scalus mode is selected. Missing required `TxIn`/`TxOut` fields in Scalus mode
+must fail fast as request validation errors, not become null CCL `Utxo` fields.
+
+If `TxOut.script` contains a Plutus reference script, derive the script hash,
+register the script in the per-evaluation `ScriptSupplier`, and put the derived
+hash on the CCL `Utxo`. Native reference scripts may be ignored by this
+Plutus-focused supplier unless a concrete Scalus evaluation case proves they are
+required.
+
+The Scalus UTxO supplier is intended for transaction-input lookup by tx hash and
+output index. Address-page lookup should be treated as unsupported for
+transaction evaluation unless a real Scalus evaluator path needs it later,
+because address-page responses do not currently carry enough script reference
+material to populate the custom `ScriptSupplier`.
+
+The controller should not remain conditional on `OgmiosService`. It should be
+available when the submit component is enabled and delegate to
+`TxEvaluationService`, which performs runtime backend selection. If
+`store.submit.tx-evaluator-mode=ogmios` is selected without
+`store.cardano.ogmios-url`, evaluation should fail with a clear configuration
+error rather than hiding the Scalus implementation from native images.
+
+## SlotConfig
+
+Scalus must be constructed with an explicit network-aware `SlotConfig`. The
+constructors that default to `SlotConfig.mainnet` must not be used.
+
+Use Yaci Store's existing era and genesis logic:
+
+```text
+zeroSlot   = EraService.getFirstNonByronSlot()
+zeroTime   = EraService.shelleyEraStartTime() * 1000
+slotLength = GenesisConfig.slotDuration(Era.Shelley) * 1000
+```
+
+This matters because Shelley genesis `systemStart` is not sufficient for all
+networks. For mainnet, Yaci's bundled Shelley genesis has `systemStart` at Byron
+start time, while Scalus needs the Shelley transition time.
+
+Expected known values include:
+
+- mainnet: `zeroSlot=4492800`, `zeroTime=1596059091000`, `slotLength=1000`
+- preview: `zeroSlot=0`, `zeroTime=1666656000000`, `slotLength=1000`
+- preprod: `zeroSlot=86400`, `zeroTime=1655769600000`, `slotLength=1000`
+
+The derived `SlotConfig` may be cached per application instance because these
+values are network constants for the running store.
+
+## Native Image Considerations
+
+The evaluator selection should be runtime-native-image friendly.
+
+Avoid property-conditional bean registration for Scalus-only beans. In Spring
+AOT/native builds, property conditions may be evaluated during image generation,
+which can make runtime property switching unreliable.
+
+Instead, create the required evaluator components so they are reachable in the
+native image, and choose the backend at runtime inside a delegating
+`TxEvaluationService`.
+
+Add native hints only if Scalus, Scala, or Jackson reflection failures appear
+during native testing.
+
+## Consequences
+
+### Positive
+
+- Transaction evaluation no longer requires Ogmios.
+- Operators can explicitly choose Ogmios or Scalus.
+- Existing public API paths remain stable.
+- The submit module remains decoupled from store implementation modules.
+- Native image runtime switching is preserved.
+
+### Negative
+
+- Scalus evaluation depends on correctly indexed UTxOs, protocol params,
+  reference scripts embedded in UTxOs, and era data.
+- A new client abstraction is required for protocol params.
+- Native image validation is required because Scalus brings Scala dependencies.
+- Evaluation behavior must be compared carefully against Ogmios for compatibility.
+- The submit artifact includes Scalus and Scala dependencies even for
+  Ogmios-only deployments so that runtime evaluator switching remains reachable
+  in native images.
+
+## Validation Plan
+
+Add tests for:
+
+- evaluator mode selection;
+- Ogmios mode preserving current behavior;
+- Scalus mode winning even when Ogmios URL exists;
+- invalid evaluator mode failing during configuration binding;
+- `SlotConfig` derivation for mainnet, preview, and preprod;
+- assertions that derived `SlotConfig` values match the known constants listed
+  above for bundled mainnet, preview, and preprod genesis data;
+- UTxO mapping from Yaci domain objects to CCL UTxOs;
+- `additionalUtxoSet` handling in Scalus mode;
+- typed parsing of Blockfrost/Ogmios `[TxIn, TxOut]` additional UTxO tuples,
+  including lovelace, native assets, inline datum, and Plutus reference scripts;
+- compatibility check that Ogmios mode still ignores malformed
+  `additionalUtxoSet` payloads;
+- 400 response mapping for malformed Scalus-mode `additionalUtxoSet` payloads;
+- protocol parameter mapping to CCL `ProtocolParams`, spot-validated against a
+  real epoch parameter dump with Plutus cost models;
+- reference script resolution through the custom `ScriptSupplier` populated from
+  `AddressUtxo.scriptRef`, without a separate `ScriptClient`;
+- Scalus `EvaluationResult` mapping to the existing Blockfrost-compatible v5
+  response, including non-spend redeemer purpose names;
+- explicit failure for unsupported address-page UTxO lookup in the Scalus
+  supplier.
+
+Run:
+
+```bash
+./gradlew :components:client:test
+./gradlew :components:submit:test
+./gradlew :stores:epoch:compileJava
+./gradlew :stores-api:epoch-api:compileJava
+./gradlew :starters:spring-boot-starter:compileJava
+./gradlew :starters:submit-spring-boot-starter:compileJava
+./gradlew :applications:all:compileJava
+./gradlew :applications:utxo-indexer:compileJava
+```
+
+Also build and run a native image with:
+
+```properties
+store.submit.tx-evaluator-mode=scalus
+```
+
+## Final Position
+
+Scalus should be added as an explicit alternative transaction evaluator, not as a
+hidden fallback only. The release-safe design is to keep the submit module
+decoupled, use existing or minimal client interfaces for ledger context, pass an
+explicit `SlotConfig`, and perform evaluator selection at runtime for native
+image compatibility.

--- a/components/client/build.gradle
+++ b/components/client/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':components:events')
     implementation project(':components:common')
 
-    implementation libs.cardano.client.lib
+    api libs.cardano.client.lib
 }
 
 publishing {

--- a/components/client/src/main/java/com/bloxbean/cardano/yaci/store/client/epoch/EpochParamClient.java
+++ b/components/client/src/main/java/com/bloxbean/cardano/yaci/store/client/epoch/EpochParamClient.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.client.epoch;
+
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+
+import java.util.Optional;
+
+/**
+ * Inter-module client interface for reading the latest protocol parameters in
+ * Cardano Client Lib format.
+ */
+public interface EpochParamClient {
+
+    /**
+     * Returns the latest available protocol parameters.
+     *
+     * @return latest protocol parameters, or {@link Optional#empty()} when they are not available yet
+     */
+    Optional<ProtocolParams> getLatestProtocolParams();
+}

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/ccl/CclProtocolParamsMapper.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/ccl/CclProtocolParamsMapper.java
@@ -1,0 +1,173 @@
+package com.bloxbean.cardano.yaci.store.common.ccl;
+
+import com.bloxbean.cardano.yaci.store.common.domain.DrepVoteThresholds;
+import com.bloxbean.cardano.yaci.store.common.domain.PoolVotingThresholds;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.bloxbean.cardano.yaci.store.common.util.UnitIntervalUtil.safeRatio;
+
+/**
+ * Utility methods for converting Yaci Store protocol parameter domain objects to
+ * Cardano Client Lib protocol parameter objects.
+ */
+public final class CclProtocolParamsMapper {
+    private CclProtocolParamsMapper() {
+    }
+
+    /**
+     * Converts a Yaci Store {@link ProtocolParams} instance to the CCL
+     * {@link com.bloxbean.cardano.client.api.model.ProtocolParams} model.
+     *
+     * @param protocolParams protocol parameters from Yaci Store
+     * @return the equivalent CCL protocol parameters, or {@code null} when the input is {@code null}
+     */
+    public static com.bloxbean.cardano.client.api.model.ProtocolParams toCclProtocolParams(ProtocolParams protocolParams) {
+        if (protocolParams == null)
+            return null;
+
+        var cclProtocolParams = new com.bloxbean.cardano.client.api.model.ProtocolParams();
+        cclProtocolParams.setMinFeeA(protocolParams.getMinFeeA());
+        cclProtocolParams.setMinFeeB(protocolParams.getMinFeeB());
+        cclProtocolParams.setMaxBlockSize(protocolParams.getMaxBlockSize());
+        cclProtocolParams.setMaxTxSize(protocolParams.getMaxTxSize());
+        cclProtocolParams.setMaxBlockHeaderSize(protocolParams.getMaxBlockHeaderSize());
+        cclProtocolParams.setKeyDeposit(toString(protocolParams.getKeyDeposit()));
+        cclProtocolParams.setPoolDeposit(toString(protocolParams.getPoolDeposit()));
+        cclProtocolParams.setEMax(protocolParams.getMaxEpoch());
+        cclProtocolParams.setNOpt(protocolParams.getNOpt());
+        cclProtocolParams.setA0(safeRatio(protocolParams.getPoolPledgeInfluence()));
+        cclProtocolParams.setRho(safeRatio(protocolParams.getExpansionRate()));
+        cclProtocolParams.setTau(safeRatio(protocolParams.getTreasuryGrowthRate()));
+        cclProtocolParams.setDecentralisationParam(safeRatio(protocolParams.getDecentralisationParam()));
+        cclProtocolParams.setExtraEntropy(protocolParams.getExtraEntropy());
+        cclProtocolParams.setProtocolMajorVer(protocolParams.getProtocolMajorVer());
+        cclProtocolParams.setProtocolMinorVer(protocolParams.getProtocolMinorVer());
+        cclProtocolParams.setMinUtxo(toString(protocolParams.getMinUtxo()));
+        cclProtocolParams.setMinPoolCost(toString(protocolParams.getMinPoolCost()));
+        cclProtocolParams.setCostModels(costModelsFromRaw(protocolParams.getCostModels()));
+        cclProtocolParams.setPriceMem(safeRatio(protocolParams.getPriceMem()));
+        cclProtocolParams.setPriceStep(safeRatio(protocolParams.getPriceStep()));
+        cclProtocolParams.setMaxTxExMem(toString(protocolParams.getMaxTxExMem()));
+        cclProtocolParams.setMaxTxExSteps(toString(protocolParams.getMaxTxExSteps()));
+        cclProtocolParams.setMaxBlockExMem(toString(protocolParams.getMaxBlockExMem()));
+        cclProtocolParams.setMaxBlockExSteps(toString(protocolParams.getMaxBlockExSteps()));
+        cclProtocolParams.setMaxValSize(toString(protocolParams.getMaxValSize()));
+        cclProtocolParams.setCollateralPercent(toBigDecimal(protocolParams.getCollateralPercent()));
+        cclProtocolParams.setMaxCollateralInputs(protocolParams.getMaxCollateralInputs());
+        cclProtocolParams.setCoinsPerUtxoSize(toString(protocolParams.getAdaPerUtxoByte()));
+        cclProtocolParams.setCoinsPerUtxoWord(toString(protocolParams.getAdaPerUtxoByte()));
+
+        setVotingThresholds(cclProtocolParams, protocolParams.getPoolVotingThresholds(), protocolParams.getDrepVotingThresholds());
+
+        cclProtocolParams.setCommitteeMinSize(protocolParams.getCommitteeMinSize());
+        cclProtocolParams.setCommitteeMaxTermLength(protocolParams.getCommitteeMaxTermLength());
+        cclProtocolParams.setGovActionLifetime(protocolParams.getGovActionLifetime());
+        cclProtocolParams.setGovActionDeposit(protocolParams.getGovActionDeposit());
+        cclProtocolParams.setDrepDeposit(protocolParams.getDrepDeposit());
+        cclProtocolParams.setDrepActivity(protocolParams.getDrepActivity());
+        cclProtocolParams.setMinFeeRefScriptCostPerByte(safeRatio(protocolParams.getMinFeeRefScriptCostPerByte()));
+
+        return cclProtocolParams;
+    }
+
+    /**
+     * Converts raw cost model arrays to the CCL map shape. The language names are
+     * kept unchanged and array indexes become string keys, preserving cost order.
+     *
+     * @param costModels raw cost model arrays keyed by language
+     * @return CCL-compatible cost model map, or {@code null} when the input is {@code null}
+     */
+    public static LinkedHashMap<String, LinkedHashMap<String, Long>> costModelsFromRaw(Map<String, long[]> costModels) {
+        if (costModels == null)
+            return null;
+
+        var result = new LinkedHashMap<String, LinkedHashMap<String, Long>>();
+        costModels.forEach((language, costs) -> result.put(language, costArrayToMap(costs)));
+        return result;
+    }
+
+    /**
+     * Converts a JSON object containing raw cost model arrays to the CCL map
+     * shape. Non-array language entries are ignored.
+     *
+     * @param costModelsRawNode JSON object from {@code cost_models_raw}
+     * @return CCL-compatible cost model map, or {@code null} when the input is not an object
+     */
+    public static LinkedHashMap<String, LinkedHashMap<String, Long>> costModelsFromRawJson(JsonNode costModelsRawNode) {
+        if (costModelsRawNode == null || !costModelsRawNode.isObject())
+            return null;
+
+        var result = new LinkedHashMap<String, LinkedHashMap<String, Long>>();
+        Iterator<Map.Entry<String, JsonNode>> fields = costModelsRawNode.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            JsonNode costsNode = entry.getValue();
+            if (!costsNode.isArray())
+                continue;
+
+            var costs = new long[costsNode.size()];
+            for (int i = 0; i < costsNode.size(); i++) {
+                costs[i] = costsNode.get(i).asLong();
+            }
+            result.put(entry.getKey(), costArrayToMap(costs));
+        }
+
+        return result;
+    }
+
+    private static void setVotingThresholds(com.bloxbean.cardano.client.api.model.ProtocolParams cclProtocolParams,
+                                            PoolVotingThresholds poolVotingThresholds,
+                                            DrepVoteThresholds drepVotingThresholds) {
+        if (poolVotingThresholds != null) {
+            cclProtocolParams.setPvtMotionNoConfidence(safeRatio(poolVotingThresholds.getPvtMotionNoConfidence()));
+            cclProtocolParams.setPvtCommitteeNormal(safeRatio(poolVotingThresholds.getPvtCommitteeNormal()));
+            cclProtocolParams.setPvtCommitteeNoConfidence(safeRatio(poolVotingThresholds.getPvtCommitteeNoConfidence()));
+            cclProtocolParams.setPvtHardForkInitiation(safeRatio(poolVotingThresholds.getPvtHardForkInitiation()));
+            cclProtocolParams.setPvtPPSecurityGroup(safeRatio(poolVotingThresholds.getPvtPPSecurityGroup()));
+        }
+
+        if (drepVotingThresholds != null) {
+            cclProtocolParams.setDvtMotionNoConfidence(safeRatio(drepVotingThresholds.getDvtMotionNoConfidence()));
+            cclProtocolParams.setDvtCommitteeNormal(safeRatio(drepVotingThresholds.getDvtCommitteeNormal()));
+            cclProtocolParams.setDvtCommitteeNoConfidence(safeRatio(drepVotingThresholds.getDvtCommitteeNoConfidence()));
+            cclProtocolParams.setDvtUpdateToConstitution(safeRatio(drepVotingThresholds.getDvtUpdateToConstitution()));
+            cclProtocolParams.setDvtHardForkInitiation(safeRatio(drepVotingThresholds.getDvtHardForkInitiation()));
+            cclProtocolParams.setDvtPPNetworkGroup(safeRatio(drepVotingThresholds.getDvtPPNetworkGroup()));
+            cclProtocolParams.setDvtPPEconomicGroup(safeRatio(drepVotingThresholds.getDvtPPEconomicGroup()));
+            cclProtocolParams.setDvtPPTechnicalGroup(safeRatio(drepVotingThresholds.getDvtPPTechnicalGroup()));
+            cclProtocolParams.setDvtPPGovGroup(safeRatio(drepVotingThresholds.getDvtPPGovGroup()));
+            cclProtocolParams.setDvtTreasuryWithdrawal(safeRatio(drepVotingThresholds.getDvtTreasuryWithdrawal()));
+        }
+    }
+
+    private static LinkedHashMap<String, Long> costArrayToMap(long[] costs) {
+        var costMap = new LinkedHashMap<String, Long>();
+        if (costs == null)
+            return costMap;
+
+        for (int i = 0; i < costs.length; i++) {
+            costMap.put(String.valueOf(i), costs[i]);
+        }
+
+        return costMap;
+    }
+
+    private static String toString(BigInteger value) {
+        return value != null ? value.toString() : null;
+    }
+
+    private static String toString(Long value) {
+        return value != null ? value.toString() : null;
+    }
+
+    private static BigDecimal toBigDecimal(Integer value) {
+        return value != null ? BigDecimal.valueOf(value) : null;
+    }
+}

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/ccl/CclUtxoMapper.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/ccl/CclUtxoMapper.java
@@ -1,0 +1,97 @@
+package com.bloxbean.cardano.yaci.store.common.ccl;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility methods for converting Yaci Store UTxO domain objects to Cardano
+ * Client Lib {@link Utxo} objects.
+ * <p>.
+ */
+public final class CclUtxoMapper {
+    private CclUtxoMapper() {
+    }
+
+    /**
+     * Converts an address UTxO returned by the local UTxO client to CCL's
+     * {@link Utxo} model.
+     *
+     * @param addressUtxo Yaci Store address UTxO
+     * @return the equivalent CCL UTxO, or {@code null} when the input is {@code null}
+     */
+    public static Utxo fromAddressUtxo(AddressUtxo addressUtxo) {
+        if (addressUtxo == null)
+            return null;
+
+        return Utxo.builder()
+                .txHash(addressUtxo.getTxHash())
+                .outputIndex(addressUtxo.getOutputIndex() != null ? addressUtxo.getOutputIndex() : 0)
+                .address(addressUtxo.getOwnerAddr())
+                .amount(fromAmounts(addressUtxo.getLovelaceAmount(), addressUtxo.getAmounts()))
+                .dataHash(addressUtxo.getDataHash())
+                .inlineDatum(addressUtxo.getInlineDatum())
+                .referenceScriptHash(addressUtxo.getReferenceScriptHash())
+                .build();
+    }
+
+    /**
+     * Converts the API-facing Yaci Store UTxO model to CCL's {@link Utxo}
+     * model.
+     *
+     * @param utxo Yaci Store UTxO
+     * @return the equivalent CCL UTxO, or {@code null} when the input is {@code null}
+     */
+    public static Utxo fromStoreUtxo(com.bloxbean.cardano.yaci.store.common.domain.Utxo utxo) {
+        if (utxo == null)
+            return null;
+
+        return Utxo.builder()
+                .txHash(utxo.getTxHash())
+                .outputIndex(utxo.getOutputIndex())
+                .address(utxo.getAddress())
+                .amount(fromStoreAmounts(utxo.getAmount()))
+                .dataHash(utxo.getDataHash())
+                .inlineDatum(utxo.getInlineDatum())
+                .referenceScriptHash(utxo.getReferenceScriptHash())
+                .build();
+    }
+
+    private static List<Amount> fromAmounts(BigInteger lovelaceAmount, List<Amt> amounts) {
+        List<Amount> result = new ArrayList<>();
+        if (lovelaceAmount != null)
+            result.add(Amount.lovelace(lovelaceAmount));
+
+        if (amounts == null)
+            return result;
+
+        for (Amt amt : amounts) {
+            if (amt == null)
+                continue;
+
+            String unit = amt.getUnit();
+            if (unit == null && amt.getPolicyId() != null)
+                unit = amt.getPolicyId() + (amt.getAssetName() != null ? amt.getAssetName() : "");
+
+            if (unit != null && amt.getQuantity() != null)
+                result.add(Amount.asset(unit, amt.getQuantity()));
+        }
+
+        return result;
+    }
+
+    private static List<Amount> fromStoreAmounts(List<com.bloxbean.cardano.yaci.store.common.domain.Utxo.Amount> amounts) {
+        if (amounts == null)
+            return Collections.emptyList();
+
+        return amounts.stream()
+                .map(amount -> new Amount(amount.getUnit(), amount.getQuantity()))
+                .toList();
+    }
+}

--- a/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/ccl/CclProtocolParamsMapperTest.java
+++ b/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/ccl/CclProtocolParamsMapperTest.java
@@ -1,0 +1,55 @@
+package com.bloxbean.cardano.yaci.store.common.ccl;
+
+import com.bloxbean.cardano.yaci.core.types.NonNegativeInterval;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CclProtocolParamsMapperTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void toCclProtocolParamsUsesNumericCostModelKeysToPreserveArrayOrder() {
+        ProtocolParams protocolParams = ProtocolParams.builder()
+                .minFeeA(44)
+                .minFeeB(155381)
+                .keyDeposit(BigInteger.valueOf(2_000_000))
+                .maxEpoch(18)
+                .adaPerUtxoByte(BigInteger.valueOf(4310))
+                .priceMem(new NonNegativeInterval(BigInteger.valueOf(577), BigInteger.valueOf(10_000)))
+                .costModels(Map.of("PlutusV3", new long[]{100, 200, -1}))
+                .build();
+
+        var cclProtocolParams = CclProtocolParamsMapper.toCclProtocolParams(protocolParams);
+
+        assertThat(cclProtocolParams.getMinFeeA()).isEqualTo(44);
+        assertThat(cclProtocolParams.getKeyDeposit()).isEqualTo("2000000");
+        assertThat(cclProtocolParams.getEMax()).isEqualTo(18);
+        assertThat(cclProtocolParams.getCoinsPerUtxoSize()).isEqualTo("4310");
+        assertThat(cclProtocolParams.getPriceMem()).isEqualByComparingTo("0.0577");
+        assertThat(cclProtocolParams.getCostModels().get("PlutusV3"))
+                .containsEntry("0", 100L)
+                .containsEntry("1", 200L)
+                .containsEntry("2", -1L);
+    }
+
+    @Test
+    void costModelsFromRawJsonUsesRawCostModelArray() throws Exception {
+        var json = objectMapper.readTree("""
+                {
+                  "PlutusV1": [10, 20],
+                  "PlutusV2": [30]
+                }
+                """);
+
+        var costModels = CclProtocolParamsMapper.costModelsFromRawJson(json);
+
+        assertThat(costModels.get("PlutusV1")).containsEntry("0", 10L).containsEntry("1", 20L);
+        assertThat(costModels.get("PlutusV2")).containsEntry("0", 30L);
+    }
+}

--- a/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/ccl/CclUtxoMapperTest.java
+++ b/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/ccl/CclUtxoMapperTest.java
@@ -1,0 +1,78 @@
+package com.bloxbean.cardano.yaci.store.common.ccl;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.common.domain.Utxo;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CclUtxoMapperTest {
+
+    @Test
+    void fromAddressUtxoMapsLovelaceAssetsDatumAndReferenceScriptHash() {
+        AddressUtxo addressUtxo = AddressUtxo.builder()
+                .txHash("tx1")
+                .outputIndex(2)
+                .ownerAddr("addr_test1...")
+                .lovelaceAmount(BigInteger.valueOf(5_000_000))
+                .amounts(List.of(Amt.builder()
+                        .unit("policyasset")
+                        .quantity(BigInteger.valueOf(7))
+                        .build()))
+                .dataHash("datum-hash")
+                .inlineDatum("d87980")
+                .referenceScriptHash("script-hash")
+                .build();
+
+        var cclUtxo = CclUtxoMapper.fromAddressUtxo(addressUtxo);
+
+        assertThat(cclUtxo.getTxHash()).isEqualTo("tx1");
+        assertThat(cclUtxo.getOutputIndex()).isEqualTo(2);
+        assertThat(cclUtxo.getAddress()).isEqualTo("addr_test1...");
+        assertThat(cclUtxo.getDataHash()).isEqualTo("datum-hash");
+        assertThat(cclUtxo.getInlineDatum()).isEqualTo("d87980");
+        assertThat(cclUtxo.getReferenceScriptHash()).isEqualTo("script-hash");
+        assertThat(cclUtxo.getAmount())
+                .anySatisfy(amount -> {
+                    assertThat(amount.getUnit()).isEqualTo("lovelace");
+                    assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(5_000_000));
+                })
+                .anySatisfy(amount -> {
+                    assertThat(amount.getUnit()).isEqualTo("policyasset");
+                    assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(7));
+                });
+    }
+
+    @Test
+    void fromStoreUtxoMapsApiUtxoShape() {
+        Utxo storeUtxo = Utxo.builder()
+                .txHash("tx2")
+                .outputIndex(1)
+                .address("addr_test1...")
+                .amount(List.of(Utxo.Amount.builder()
+                        .unit("lovelace")
+                        .quantity(BigInteger.valueOf(2_000_000))
+                        .build()))
+                .dataHash("datum-hash")
+                .inlineDatum("d87980")
+                .referenceScriptHash("script-hash")
+                .build();
+
+        var cclUtxo = CclUtxoMapper.fromStoreUtxo(storeUtxo);
+
+        assertThat(cclUtxo.getTxHash()).isEqualTo("tx2");
+        assertThat(cclUtxo.getOutputIndex()).isEqualTo(1);
+        assertThat(cclUtxo.getAddress()).isEqualTo("addr_test1...");
+        assertThat(cclUtxo.getDataHash()).isEqualTo("datum-hash");
+        assertThat(cclUtxo.getInlineDatum()).isEqualTo("d87980");
+        assertThat(cclUtxo.getReferenceScriptHash()).isEqualTo("script-hash");
+        assertThat(cclUtxo.getAmount()).singleElement().satisfies(amount -> {
+            assertThat(amount.getUnit()).isEqualTo("lovelace");
+            assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(2_000_000));
+        });
+    }
+}

--- a/components/submit/build.gradle
+++ b/components/submit/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
     api project(":components:common")
     api project(":components:core")
+    api project(":components:client")
     implementation libs.cardano.client.backend.ogmios
+    implementation(libs.scalus.bloxbean.cardano.client.lib) {
+        exclude group: "com.bloxbean.cardano"
+    }
 
     implementation(libs.vavr)
 }

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/SubmitStoreConfiguration.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/SubmitStoreConfiguration.java
@@ -1,7 +1,9 @@
 package com.bloxbean.cardano.yaci.store.submit;
 
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -18,5 +20,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableJpaRepositories( basePackages = {"com.bloxbean.cardano.yaci.store.submit"})
 @EntityScan(basePackages = {"com.bloxbean.cardano.yaci.store.submit"})
 @EnableTransactionManagement
+@EnableConfigurationProperties(TxEvaluationProperties.class)
 public class SubmitStoreConfiguration {
 }

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/controller/TxUtilController.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/controller/TxUtilController.java
@@ -2,8 +2,9 @@ package com.bloxbean.cardano.yaci.store.submit.controller;
 
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.yaci.store.common.util.JsonUtil;
-import com.bloxbean.cardano.yaci.store.submit.service.OgmiosService;
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,23 +12,19 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Collections;
-import java.util.Set;
 
 @Tag(name = "Utilities")
 @RestController
 @RequestMapping("${apiPrefix}/utils/txs")
 @RequiredArgsConstructor
-@ConditionalOnBean(OgmiosService.class)
 @Slf4j
 public class TxUtilController {
 
-    private final OgmiosService ogmiosService;
+    private final TxEvaluationService txEvaluationService;
 
     @PostMapping(value = "evaluate", consumes = {MediaType.APPLICATION_CBOR_VALUE})
     @Operation(description = "Evaluate a CBOR encoded transaction. Returns the evaluation result")
@@ -37,15 +34,15 @@ public class TxUtilController {
                                              int version) {
         EvaluateRequest evaluateRequest = new EvaluateRequest();
         evaluateRequest.setCbor(cborTx);
-        evaluateRequest.setAdditionalUtxoSet(Collections.emptySet());
+        evaluateRequest.setAdditionalUtxoSet(NullNode.getInstance());
         return doEvaluateTx(evaluateRequest, version);
     }
 
     @PostMapping(value = "evaluate/utxos",
             consumes = {MediaType.APPLICATION_JSON_VALUE})
     @Operation(description = "Evaluate a CBOR encoded transaction. Returns the evaluation result. " +
-            "Though additional utxos can be provided, it is not currently used in the implementation. " +
-            "It is there for compatibility with the Blockfrost API")
+            "additionalUtxoSet must use the Blockfrost/Ogmios [TxIn, TxOut] tuple format and is honored when the Scalus evaluator is configured. " +
+            "The Ogmios evaluator keeps the existing behavior and ignores additional utxos.")
     public ResponseEntity<?> evaluateTx(@RequestBody EvaluateRequest evaluateRequest,
                                              @RequestParam(value = "version",defaultValue = "5")
                                              @Parameter(description = "Optional parameter to specify the version of the Ogmios service to use. Default is 5. Set to 6 to use Ogmios version 6.")
@@ -59,16 +56,16 @@ public class TxUtilController {
                 log.debug("Evaluating tx : " + evaluateRequest);
 
             var cborBytes = HexUtil.decodeHexString(evaluateRequest.cbor);
-            var response = ogmiosService.evaluateTx(cborBytes, Collections.emptySet());
+            var response = txEvaluationService.evaluateTx(cborBytes, evaluateRequest.additionalUtxoSet);
 
             if (log.isDebugEnabled()) {
-                log.debug("Original EvaluteTx reponse from Ogmios : " + response);
+                log.debug("Original EvaluateTx response : " + response);
             }
 
             if (response.isRight()) {
                 JsonNode successRes = null;
                 if (version == 0 || version == 5) {
-                    successRes = ogmiosService.transformTxEvaluationSuccessResultToV5BFFormat(response.get());
+                    successRes = txEvaluationService.transformTxEvaluationSuccessResultToV5BFFormat(response.get());
                 } else {
                     successRes = response.get();
                 }
@@ -79,7 +76,7 @@ public class TxUtilController {
             } else if (response.isLeft()) {
                 JsonNode failureRes = null;
                 if (version == 0 || version == 5) {
-                    failureRes = ogmiosService.transformTxEvaluationErrorToV5BFFormat(response.getLeft());
+                    failureRes = txEvaluationService.transformTxEvaluationErrorToV5BFFormat(response.getLeft());
                 } else {
                     failureRes = response.getLeft();
                 }
@@ -91,6 +88,12 @@ public class TxUtilController {
                         .body("Error evaluating tx");
             }
 
+        } catch (IllegalArgumentException e) {
+            if (log.isDebugEnabled()) {
+                log.error("Invalid tx evaluation request: ", e);
+            }
+            TxErrorResponse errorResponse = new TxErrorResponse(400, "Bad Request", e.getMessage());
+            return ResponseEntity.badRequest().body(errorResponse);
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.error("Error evaluating tx: ", e);
@@ -98,6 +101,14 @@ public class TxUtilController {
             TxErrorResponse errorResponse = new TxErrorResponse(500, "Internal Server Error", e.getMessage());
             return ResponseEntity.status(500).body(errorResponse);
         }
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<TxErrorResponse> handleBadRequest(Exception e) {
+        if (log.isDebugEnabled())
+            log.error("Invalid request", e);
+        TxErrorResponse errorResponse = new TxErrorResponse(400, "Bad Request", e.getMessage());
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)
@@ -108,10 +119,22 @@ public class TxUtilController {
         return ResponseEntity.status(500).body(errorResponse);
     }
 
+    /**
+     * Request body for the Blockfrost-compatible transaction evaluation endpoint.
+     */
     @Data
     @NoArgsConstructor
     public static class EvaluateRequest {
+        /**
+         * Hex-encoded CBOR transaction.
+         */
         private String cbor;
-        private Set additionalUtxoSet;
+
+        /**
+         * Optional additional UTxO set used by the Scalus evaluator. The value is
+         * kept as JSON so the Ogmios/Blockfrost tuple shape can be parsed only by
+         * the evaluator path that supports it.
+         */
+        private JsonNode additionalUtxoSet = NullNode.getInstance();
     }
 }

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/domain/OgmiosUtxo.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/domain/OgmiosUtxo.java
@@ -1,0 +1,199 @@
+package com.bloxbean.cardano.yaci.store.submit.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parsed representation of an {@code additionalUtxoSet} entry accepted by the
+ * transaction evaluation endpoint.
+ * <p>
+ * The parser accepts the Blockfrost documented {@code [TxIn, TxOut]} tuple
+ * shape and the flat Ogmios UTxO object shape used by Ogmios schemas.
+ */
+@Getter
+@NoArgsConstructor
+public class OgmiosUtxo {
+    private TxIn txIn;
+    private TxOut txOut;
+
+    /**
+     * Creates an additional UTxO from a transaction input and output.
+     *
+     * @param txIn transaction input
+     * @param txOut transaction output
+     */
+    public OgmiosUtxo(TxIn txIn, TxOut txOut) {
+        this.txIn = txIn;
+        this.txOut = txOut;
+    }
+
+    /**
+     * Parses an {@code additionalUtxoSet} JSON array.
+     *
+     * @param node additional UTxO set JSON node
+     * @return parsed additional UTxOs, or an empty list when the node is {@code null}
+     * @throws IllegalArgumentException when the JSON shape is not supported
+     */
+    public static List<OgmiosUtxo> fromAdditionalUtxoSet(JsonNode node) {
+        if (node == null || node.isNull())
+            return Collections.emptyList();
+
+        if (!(node instanceof ArrayNode arrayNode))
+            throw new IllegalArgumentException("additionalUtxoSet must be an array");
+
+        List<OgmiosUtxo> additionalUtxos = new ArrayList<>();
+        for (JsonNode item : arrayNode) {
+            additionalUtxos.add(from(item));
+        }
+
+        return additionalUtxos;
+    }
+
+    /**
+     * Parses a single additional UTxO entry.
+     *
+     * @param node tuple or flat UTxO JSON node
+     * @return parsed additional UTxO
+     * @throws IllegalArgumentException when required fields are missing
+     */
+    public static OgmiosUtxo from(JsonNode node) {
+        if (node == null || node.isNull())
+            throw new IllegalArgumentException("additionalUtxoSet entry is required");
+
+        // Blockfrost documents additionalUtxoSet as [TxIn, TxOut] tuples.
+        // Ogmios schemas have also exposed a flat UTxO object, so accept both
+        // typed forms instead of falling back to unstructured request objects.
+        if (node.isArray()) {
+            if (node.size() != 2)
+                throw new IllegalArgumentException("additionalUtxoSet entries must be [TxIn, TxOut] tuples");
+
+            return new OgmiosUtxo(TxIn.from(node.get(0)), TxOut.from(node.get(1)));
+        } else if (node.isObject()) {
+            return new OgmiosUtxo(TxIn.from(node), TxOut.from(node));
+        } else {
+            throw new IllegalArgumentException("additionalUtxoSet entries must be objects or [TxIn, TxOut] tuples");
+        }
+    }
+
+    /**
+     * Transaction input portion of an additional UTxO entry.
+     */
+    @Getter
+    @NoArgsConstructor
+    public static class TxIn {
+        private String txId;
+        private Integer index;
+
+        /**
+         * Creates a transaction input reference.
+         *
+         * @param txId transaction id
+         * @param index output index within the transaction
+         */
+        public TxIn(String txId, Integer index) {
+            this.txId = txId;
+            this.index = index;
+        }
+
+        private static TxIn from(JsonNode node) {
+            String txId = text(node, "txId", "tx_id");
+            if (txId == null)
+                txId = text(child(node, "transaction"), "id");
+
+            Integer index = intValue(node, "index", "outputIndex", "output_index");
+            if (index == null)
+                index = intValue(child(node, "output"), "index");
+
+            if (isBlank(txId))
+                throw new IllegalArgumentException("additionalUtxoSet TxIn transaction id is required");
+            if (index == null)
+                throw new IllegalArgumentException("additionalUtxoSet TxIn index is required");
+
+            return new TxIn(txId, index);
+        }
+    }
+
+    /**
+     * Transaction output portion of an additional UTxO entry.
+     */
+    @Getter
+    @NoArgsConstructor
+    public static class TxOut {
+        private String address;
+        private JsonNode value;
+        private String datumHash;
+        private JsonNode datum;
+        private JsonNode script;
+        private String referenceScriptHash;
+
+        /**
+         * Creates a transaction output for an additional UTxO entry.
+         *
+         * @param address output address
+         * @param value output value in Ogmios or Blockfrost-compatible JSON shape
+         * @param datumHash datum hash, when present
+         * @param datum inline datum, when present
+         * @param script reference script JSON, when present
+         * @param referenceScriptHash reference script hash, when present
+         */
+        public TxOut(String address, JsonNode value, String datumHash, JsonNode datum, JsonNode script, String referenceScriptHash) {
+            this.address = address;
+            this.value = value;
+            this.datumHash = datumHash;
+            this.datum = datum;
+            this.script = script;
+            this.referenceScriptHash = referenceScriptHash;
+        }
+
+        private static TxOut from(JsonNode node) {
+            String address = text(node, "address", "ownerAddr", "owner_addr");
+            JsonNode value = child(node, "value");
+            if (isBlank(address))
+                throw new IllegalArgumentException("additionalUtxoSet TxOut address is required");
+            if (value == null)
+                throw new IllegalArgumentException("additionalUtxoSet TxOut value is required");
+
+            return new TxOut(
+                    address,
+                    value,
+                    text(node, "datumHash", "datum_hash", "dataHash", "data_hash"),
+                    child(node, "datum", "inlineDatum", "inline_datum"),
+                    child(node, "script"),
+                    text(node, "referenceScriptHash", "reference_script_hash")
+            );
+        }
+    }
+
+    private static JsonNode child(JsonNode node, String... names) {
+        if (node == null || node.isNull())
+            return null;
+
+        for (String name : names) {
+            JsonNode value = node.get(name);
+            if (value != null && !value.isNull())
+                return value;
+        }
+
+        return null;
+    }
+
+    private static String text(JsonNode node, String... names) {
+        JsonNode value = child(node, names);
+        return value != null ? value.asText() : null;
+    }
+
+    private static Integer intValue(JsonNode node, String... names) {
+        JsonNode value = child(node, names);
+        return value != null ? value.asInt() : null;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationProperties.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationProperties.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.store.submit.service;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for submit transaction evaluation.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "store.submit")
+public class TxEvaluationProperties {
+    /**
+     * Backend used by the Blockfrost-compatible transaction evaluation endpoint.
+     */
+    private TxEvaluatorMode txEvaluatorMode = TxEvaluatorMode.OGMIOS;
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationProperties.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationProperties.java
@@ -14,5 +14,5 @@ public class TxEvaluationProperties {
     /**
      * Backend used by the Blockfrost-compatible transaction evaluation endpoint.
      */
-    private TxEvaluatorMode txEvaluatorMode = TxEvaluatorMode.OGMIOS;
+    private TxEvaluatorMode txEvaluatorMode = TxEvaluatorMode.SCALUS;
 }

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationService.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationService.java
@@ -1,0 +1,130 @@
+package com.bloxbean.cardano.yaci.store.submit.service;
+
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.yaci.store.submit.service.scalus.ScalusTxEvaluationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vavr.control.Either;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+/**
+ * Facade for transaction evaluation. It selects the configured evaluator and
+ * normalizes evaluator responses to the Blockfrost-compatible v5 response
+ * shape used by the submit endpoint.
+ */
+@Service
+@RequiredArgsConstructor
+public class TxEvaluationService {
+    private final TxEvaluationProperties properties;
+    private final ObjectProvider<OgmiosService> ogmiosService;
+    private final ScalusTxEvaluationService scalusTxEvaluationService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Evaluates a CBOR transaction with the configured evaluator.
+     *
+     * @param cborTx transaction CBOR bytes
+     * @param additionalUtxoSet optional additional UTxO set for Scalus evaluation
+     * @return either evaluator error JSON or evaluator success JSON
+     * @throws ApiException when the configured evaluator cannot be used
+     */
+    public Either<JsonNode, JsonNode> evaluateTx(byte[] cborTx, JsonNode additionalUtxoSet) throws ApiException {
+        return switch (mode()) {
+            case OGMIOS -> evaluateWithOgmios(cborTx);
+            case SCALUS -> scalusTxEvaluationService.evaluateTx(cborTx, additionalUtxoSet);
+        };
+    }
+
+    /**
+     * Converts evaluator success JSON to the Blockfrost-compatible v5 Ogmios
+     * response wrapper.
+     *
+     * @param jsonNode evaluator success JSON
+     * @return v5-compatible success response
+     */
+    public JsonNode transformTxEvaluationSuccessResultToV5BFFormat(JsonNode jsonNode) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("type", "jsonwsp/response");
+        response.put("version", "1.0");
+        response.put("servicename", "ogmios");
+        response.put("methodname", "EvaluateTx");
+
+        ObjectNode resultNode = objectMapper.createObjectNode();
+        ObjectNode evaluationResultsNode = objectMapper.createObjectNode();
+        resultNode.set("EvaluationResult", evaluationResultsNode);
+
+        JsonNode resultNodeFromEvaluator = jsonNode.get("result");
+        if (resultNodeFromEvaluator instanceof ArrayNode result) {
+            for (int i = 0; i < result.size(); i++) {
+                JsonNode validatorResult = result.get(i);
+                var validatorNode = validatorResult.get("validator");
+                if (validatorNode == null)
+                    continue;
+
+                var index = validatorNode.get("index").asInt();
+                var purpose = validatorNode.get("purpose").asText();
+
+                var budgetNode = validatorResult.get("budget");
+                if (budgetNode == null)
+                    continue;
+
+                var memory = budgetNode.get("memory").asLong();
+                var cpu = budgetNode.get("cpu").asLong();
+
+                ObjectNode cost = objectMapper.createObjectNode();
+                cost.put("memory", memory);
+                cost.put("steps", cpu);
+
+                var tagIndex = purpose.toLowerCase() + ":" + index;
+                evaluationResultsNode.set(tagIndex, cost);
+            }
+        }
+
+        response.set("result", resultNode);
+
+        return response;
+    }
+
+    /**
+     * Converts evaluator error JSON to the Blockfrost-compatible v5 Ogmios
+     * response wrapper.
+     *
+     * @param jsonNode evaluator error JSON
+     * @return v5-compatible error response
+     */
+    public JsonNode transformTxEvaluationErrorToV5BFFormat(JsonNode jsonNode) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("type", "jsonwsp/response");
+        response.put("version", "1.0");
+        response.put("servicename", "ogmios");
+        response.put("methodname", "EvaluateTx");
+
+        ObjectNode resultNode = objectMapper.createObjectNode();
+
+        JsonNode errorNode = jsonNode.get("error");
+        resultNode.set("EvaluationFailure", errorNode != null ? errorNode : jsonNode);
+
+        response.set("result", resultNode);
+
+        return response;
+    }
+
+    private Either<JsonNode, JsonNode> evaluateWithOgmios(byte[] cborTx) throws ApiException {
+        OgmiosService service = ogmiosService.getIfAvailable();
+        if (service == null) {
+            throw new ApiException("Ogmios tx evaluator requested but store.cardano.ogmios-url is not configured");
+        }
+
+        return service.evaluateTx(cborTx, Collections.emptySet());
+    }
+
+    private TxEvaluatorMode mode() {
+        return properties.getTxEvaluatorMode() != null ? properties.getTxEvaluatorMode() : TxEvaluatorMode.OGMIOS;
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationService.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationService.java
@@ -125,6 +125,6 @@ public class TxEvaluationService {
     }
 
     private TxEvaluatorMode mode() {
-        return properties.getTxEvaluatorMode() != null ? properties.getTxEvaluatorMode() : TxEvaluatorMode.OGMIOS;
+        return properties.getTxEvaluatorMode() != null ? properties.getTxEvaluatorMode() : TxEvaluatorMode.SCALUS;
     }
 }

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluatorMode.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluatorMode.java
@@ -1,0 +1,16 @@
+package com.bloxbean.cardano.yaci.store.submit.service;
+
+/**
+ * Transaction evaluation backend selected by {@code store.submit.tx-evaluator-mode}.
+ */
+public enum TxEvaluatorMode {
+    /**
+     * Delegate transaction evaluation to Ogmios.
+     */
+    OGMIOS,
+
+    /**
+     * Evaluate transactions locally with Scalus.
+     */
+    SCALUS
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ReferenceScriptSupplier.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ReferenceScriptSupplier.java
@@ -1,0 +1,60 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.spec.Script;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.util.ScriptReferenceUtil;
+import lombok.extern.slf4j.Slf4j;
+import scalus.bloxbean.ScriptSupplier;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+class ReferenceScriptSupplier implements ScriptSupplier {
+    private final Map<String, PlutusScript> scripts = new ConcurrentHashMap<>();
+
+    void register(AddressUtxo addressUtxo) {
+        if (addressUtxo == null)
+            return;
+
+        register(addressUtxo.getReferenceScriptHash(), addressUtxo.getScriptRef());
+    }
+
+    void register(String referenceScriptHash, String scriptRef) {
+        if (isBlank(referenceScriptHash) || isBlank(scriptRef))
+            return;
+
+        try {
+            Script script = ScriptReferenceUtil.deserializeScriptRef(HexUtil.decodeHexString(scriptRef));
+            if (script instanceof PlutusScript plutusScript) {
+                scripts.put(referenceScriptHash, plutusScript);
+            } else if (log.isDebugEnabled()) {
+                log.debug("Ignoring non-Plutus reference script for hash {}", referenceScriptHash);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to deserialize reference script for hash " + referenceScriptHash, e);
+        }
+    }
+
+    void register(String referenceScriptHash, PlutusScript plutusScript) {
+        if (isBlank(referenceScriptHash) || plutusScript == null)
+            return;
+
+        scripts.put(referenceScriptHash, plutusScript);
+    }
+
+    @Override
+    public PlutusScript getScript(String scriptHash) {
+        PlutusScript script = scripts.get(scriptHash);
+        if (script == null)
+            throw new IllegalArgumentException("Reference script not found for hash " + scriptHash);
+
+        return script;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusAdditionalUtxoMapper.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusAdditionalUtxoMapper.java
@@ -1,0 +1,214 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV1Script;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV3Script;
+import com.bloxbean.cardano.client.plutus.spec.serializers.PlutusDataJsonConverter;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.submit.domain.OgmiosUtxo;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class ScalusAdditionalUtxoMapper {
+    private ScalusAdditionalUtxoMapper() {
+    }
+
+    static Set<Utxo> fromAdditionalUtxoSet(List<OgmiosUtxo> additionalUtxos,
+                                           ReferenceScriptSupplier scriptSupplier) {
+        if (additionalUtxos == null || additionalUtxos.isEmpty())
+            return Collections.emptySet();
+
+        Set<Utxo> result = new HashSet<>();
+        for (OgmiosUtxo additionalUtxo : additionalUtxos) {
+            Utxo utxo = fromAdditionalUtxo(additionalUtxo, scriptSupplier);
+            if (utxo != null)
+                result.add(utxo);
+        }
+
+        return result;
+    }
+
+    private static Utxo fromAdditionalUtxo(OgmiosUtxo additionalUtxo, ReferenceScriptSupplier scriptSupplier) {
+        if (additionalUtxo == null || additionalUtxo.getTxIn() == null || additionalUtxo.getTxOut() == null)
+            return null;
+
+        var txIn = additionalUtxo.getTxIn();
+        var txOut = additionalUtxo.getTxOut();
+        String referenceScriptHash = referenceScriptHash(txOut, scriptSupplier);
+
+        return Utxo.builder()
+                .txHash(txIn.getTxId())
+                .outputIndex(txIn.getIndex())
+                .address(txOut.getAddress())
+                .amount(value(txOut.getValue()))
+                .dataHash(txOut.getDatumHash())
+                .inlineDatum(inlineDatum(txOut.getDatum()))
+                .referenceScriptHash(referenceScriptHash)
+                .build();
+    }
+
+    private static String referenceScriptHash(OgmiosUtxo.TxOut txOut, ReferenceScriptSupplier scriptSupplier) {
+        String referenceScriptHash = txOut.getReferenceScriptHash();
+        PlutusScript plutusScript = plutusScript(txOut.getScript());
+        if (plutusScript == null)
+            return referenceScriptHash;
+
+        try {
+            referenceScriptHash = HexUtil.encodeHexString(plutusScript.getScriptHash());
+            if (scriptSupplier != null)
+                scriptSupplier.register(referenceScriptHash, plutusScript);
+            return referenceScriptHash;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to derive reference script hash from additionalUtxoSet script", e);
+        }
+    }
+
+    private static List<Amount> value(JsonNode valueNode) {
+        List<Amount> amounts = new ArrayList<>();
+        if (valueNode == null || !valueNode.isObject())
+            return amounts;
+
+        // Blockfrost SDKs use {coins, assets}; Ogmios docs use
+        // {ada:{lovelace}, policy:{assetName: quantity}}. Normalize both into
+        // CCL's flat Amount list.
+        addIfPresent(amounts, "lovelace", bigInteger(valueNode, "coins", "lovelace"));
+
+        JsonNode adaNode = first(valueNode, "ada");
+        if (adaNode != null)
+            addIfPresent(amounts, "lovelace", bigInteger(adaNode, "lovelace"));
+
+        JsonNode assetsNode = first(valueNode, "assets");
+        if (assetsNode != null && assetsNode.isObject())
+            addFlatAssets(amounts, assetsNode);
+
+        Iterator<Map.Entry<String, JsonNode>> fields = valueNode.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            String policyOrUnit = field.getKey();
+            if ("ada".equals(policyOrUnit) || "coins".equals(policyOrUnit) || "lovelace".equals(policyOrUnit) || "assets".equals(policyOrUnit))
+                continue;
+
+            JsonNode assetNode = field.getValue();
+            if (assetNode.isObject()) {
+                assetNode.fields().forEachRemaining(asset -> addIfPresent(amounts, policyOrUnit + asset.getKey(), bigInteger(asset.getValue())));
+            } else {
+                addIfPresent(amounts, policyOrUnit.replace(".", ""), bigInteger(assetNode));
+            }
+        }
+
+        return amounts;
+    }
+
+    private static void addFlatAssets(List<Amount> amounts, JsonNode assetsNode) {
+        assetsNode.fields()
+                .forEachRemaining(asset -> addIfPresent(amounts, asset.getKey().replace(".", ""), bigInteger(asset.getValue())));
+    }
+
+    private static void addIfPresent(List<Amount> amounts, String unit, BigInteger quantity) {
+        if (unit == null || quantity == null)
+            return;
+
+        if ("lovelace".equals(unit)) {
+            amounts.add(Amount.lovelace(quantity));
+        } else {
+            amounts.add(Amount.asset(unit, quantity));
+        }
+    }
+
+    private static String inlineDatum(JsonNode datumNode) {
+        if (datumNode == null || datumNode.isNull())
+            return null;
+
+        if (datumNode.isTextual())
+            return datumNode.asText();
+
+        try {
+            return PlutusDataJsonConverter.toPlutusData(datumNode).serializeToHex();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("additionalUtxoSet datum must be CBOR hex or Cardano Client Lib Plutus-data JSON", e);
+        }
+    }
+
+    private static PlutusScript plutusScript(JsonNode scriptNode) {
+        if (scriptNode == null || scriptNode.isNull() || !scriptNode.isObject())
+            return null;
+
+        String language = text(scriptNode, "language");
+        String cbor = text(scriptNode, "cbor");
+        if (language == null) {
+            if (scriptNode.has("plutus:v1")) {
+                language = "plutus:v1";
+                cbor = scriptNode.get("plutus:v1").asText();
+            } else if (scriptNode.has("plutus:v2")) {
+                language = "plutus:v2";
+                cbor = scriptNode.get("plutus:v2").asText();
+            } else if (scriptNode.has("plutus:v3")) {
+                language = "plutus:v3";
+                cbor = scriptNode.get("plutus:v3").asText();
+            }
+        }
+
+        if (language == null || cbor == null || "native".equals(language))
+            return null;
+
+        // Ogmios/Blockfrost carry reference scripts in the additional UTxO output.
+        // CCL Utxo only stores the hash, so we register the decoded Plutus script
+        // with the per-evaluation ScriptSupplier and put the derived hash on Utxo.
+        return switch (language) {
+            case "plutus:v1" -> PlutusV1Script.builder().cborHex(cbor).build();
+            case "plutus:v2" -> PlutusV2Script.builder().cborHex(cbor).build();
+            case "plutus:v3" -> PlutusV3Script.builder().cborHex(cbor).build();
+            default -> throw new IllegalArgumentException("Unsupported additionalUtxoSet script language: " + language);
+        };
+    }
+
+    private static JsonNode first(JsonNode node, String... names) {
+        if (node == null)
+            return null;
+
+        for (String name : names) {
+            JsonNode value = node.get(name);
+            if (value != null && !value.isNull())
+                return value;
+        }
+
+        return null;
+    }
+
+    private static String text(JsonNode node, String... names) {
+        JsonNode value = first(node, names);
+        if (value == null)
+            return null;
+
+        return value.asText();
+    }
+
+    private static BigInteger bigInteger(JsonNode node, String... names) {
+        JsonNode value = first(node, names);
+        if (value == null)
+            return null;
+
+        return bigInteger(value);
+    }
+
+    private static BigInteger bigInteger(JsonNode value) {
+        if (value == null || value.isNull())
+            return null;
+
+        if (value.isIntegralNumber())
+            return value.bigIntegerValue();
+
+        return new BigInteger(value.asText());
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusSlotConfigProvider.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusSlotConfigProvider.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.core.service.EraService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import scalus.cardano.ledger.SlotConfig;
+
+@Component
+@RequiredArgsConstructor
+class ScalusSlotConfigProvider {
+    private final ObjectProvider<EraService> eraService;
+    private final ObjectProvider<GenesisConfig> genesisConfig;
+    private volatile SlotConfig slotConfig;
+
+    SlotConfig getSlotConfig() throws ApiException {
+        SlotConfig current = slotConfig;
+        if (current != null)
+            return current;
+
+        synchronized (this) {
+            if (slotConfig == null)
+                slotConfig = createSlotConfig();
+
+            return slotConfig;
+        }
+    }
+
+    private SlotConfig createSlotConfig() throws ApiException {
+        EraService eraService = this.eraService.getIfAvailable();
+        GenesisConfig genesisConfig = this.genesisConfig.getIfAvailable();
+        if (eraService == null || genesisConfig == null) {
+            throw new ApiException("Scalus tx evaluator requires EraService and GenesisConfig. Enable the core store configuration.");
+        }
+
+        long zeroTime = eraService.shelleyEraStartTime() * 1000;
+        long zeroSlot = eraService.getFirstNonByronSlot();
+        long slotLength = Math.round(genesisConfig.slotDuration(Era.Shelley) * 1000);
+
+        return new SlotConfig(zeroTime, zeroSlot, slotLength);
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusTxEvaluationService.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusTxEvaluationService.java
@@ -1,0 +1,132 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.EvaluationResult;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.yaci.store.client.epoch.EpochParamClient;
+import com.bloxbean.cardano.yaci.store.client.utxo.DummyUtxoClient;
+import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
+import com.bloxbean.cardano.yaci.store.submit.domain.OgmiosUtxo;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vavr.control.Either;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import scalus.bloxbean.EvaluatorMode;
+import scalus.bloxbean.ScalusTransactionEvaluator;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Scalus-backed transaction evaluator for the submit module.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScalusTxEvaluationService {
+    private final ObjectProvider<EpochParamClient> epochParamClient;
+    private final ObjectProvider<UtxoClient> utxoClient;
+    private final ScalusSlotConfigProvider slotConfigProvider;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Evaluates a CBOR transaction with Scalus using local protocol parameters,
+     * UTxO lookup and reference-script resolution.
+     *
+     * @param cborTx transaction CBOR bytes
+     * @param additionalUtxoSet optional additional UTxO set from the request body
+     * @return either evaluator error JSON or evaluator success JSON
+     * @throws ApiException when required local clients or chain parameters are unavailable
+     */
+    public Either<JsonNode, JsonNode> evaluateTx(byte[] cborTx, JsonNode additionalUtxoSet) throws ApiException {
+        if (log.isDebugEnabled())
+            log.debug("Evaluating tx with Scalus");
+
+        EpochParamClient epochParamClient = this.epochParamClient.getIfAvailable();
+        if (epochParamClient == null)
+            throw new ApiException("Scalus tx evaluator requires EpochParamClient. Enable the epoch store module locally.");
+
+        UtxoClient utxoClient = this.utxoClient.getIfAvailable();
+        if (utxoClient == null)
+            throw new ApiException("Scalus tx evaluator requires UtxoClient. Enable UTxO APIs locally or configure store.utxo-client-url.");
+        if (utxoClient instanceof DummyUtxoClient)
+            throw new ApiException("Scalus tx evaluator requires a real UtxoClient. Enable UTxO APIs locally or configure store.utxo-client-url.");
+
+        var protocolParams = epochParamClient.getLatestProtocolParams()
+                .orElseThrow(() -> new ApiException("Latest protocol parameters are not available"));
+
+        ReferenceScriptSupplier scriptSupplier = new ReferenceScriptSupplier();
+        Set<Utxo> additionalUtxos = ScalusAdditionalUtxoMapper.fromAdditionalUtxoSet(OgmiosUtxo.fromAdditionalUtxoSet(additionalUtxoSet), scriptSupplier);
+        StoreUtxoSupplier utxoSupplier = new StoreUtxoSupplier(utxoClient, scriptSupplier);
+
+        ScalusTransactionEvaluator evaluator = new ScalusTransactionEvaluator(
+                slotConfigProvider.getSlotConfig(),
+                protocolParams,
+                utxoSupplier,
+                scriptSupplier,
+                EvaluatorMode.EVALUATE_AND_COMPUTE_COST,
+                false
+        );
+
+        Result<List<EvaluationResult>> result = evaluator.evaluateTx(cborTx, additionalUtxos);
+        if (result.isSuccessful()) {
+            return Either.right(toJson(result.getValue()));
+        } else {
+            return Either.left(toErrorJson(result.getResponse()));
+        }
+    }
+
+    JsonNode toJson(List<EvaluationResult> evaluationResults) {
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode result = response.putArray("result");
+
+        if (evaluationResults == null)
+            return response;
+
+        for (EvaluationResult evaluationResult : evaluationResults) {
+            ObjectNode validatorResult = result.addObject();
+
+            ObjectNode validator = validatorResult.putObject("validator");
+            validator.put("purpose", purpose(evaluationResult.getRedeemerTag()));
+            validator.put("index", evaluationResult.getIndex());
+
+            ObjectNode budget = validatorResult.putObject("budget");
+            if (evaluationResult.getExUnits() != null) {
+                budget.put("memory", evaluationResult.getExUnits().getMem());
+                budget.put("cpu", evaluationResult.getExUnits().getSteps());
+            }
+        }
+
+        return response;
+    }
+
+    private JsonNode toErrorJson(String message) {
+        ObjectNode response = objectMapper.createObjectNode();
+        ObjectNode error = response.putObject("error");
+        error.put("message", message != null ? message : "Transaction evaluation failed");
+        return response;
+    }
+
+    String purpose(RedeemerTag redeemerTag) {
+        if (redeemerTag == null)
+            return "";
+
+        return switch (redeemerTag) {
+            case Spend -> "spend";
+            case Mint -> "mint";
+            // Ogmios' current schema uses publish/withdraw/vote/propose. Keep the
+            // Scalus JSON aligned so the shared v5 formatter returns the same keys.
+            case Cert -> "publish";
+            case Reward -> "withdraw";
+            case Voting -> "vote";
+            case Proposing -> "propose";
+        };
+    }
+}

--- a/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/StoreUtxoSupplier.java
+++ b/components/submit/src/main/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/StoreUtxoSupplier.java
@@ -1,0 +1,37 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.common.OrderEnum;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
+import com.bloxbean.cardano.yaci.store.common.ccl.CclUtxoMapper;
+import com.bloxbean.cardano.yaci.store.common.domain.UtxoKey;
+
+import java.util.List;
+import java.util.Optional;
+
+class StoreUtxoSupplier implements UtxoSupplier {
+    private final UtxoClient utxoClient;
+    private final ReferenceScriptSupplier scriptSupplier;
+
+    StoreUtxoSupplier(UtxoClient utxoClient, ReferenceScriptSupplier scriptSupplier) {
+        this.utxoClient = utxoClient;
+        this.scriptSupplier = scriptSupplier;
+    }
+
+    @Override
+    public List<Utxo> getPage(String address, Integer page, Integer count, OrderEnum order) {
+        throw new UnsupportedOperationException("Address-page UTxO lookup is not used for transaction evaluation; getTxOutput resolves inputs by transaction id.");
+    }
+
+    @Override
+    public Optional<Utxo> getTxOutput(String txHash, int outputIndex) {
+        return utxoClient.getUtxoById(new UtxoKey(txHash, outputIndex))
+                .map(addressUtxo -> {
+                    // CCL Utxo stores only the reference script hash; Scalus resolves
+                    // the script body later through ScriptSupplier during evaluation.
+                    scriptSupplier.register(addressUtxo);
+                    return CclUtxoMapper.fromAddressUtxo(addressUtxo);
+                });
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/controller/TxUtilControllerTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/controller/TxUtilControllerTest.java
@@ -1,0 +1,56 @@
+package com.bloxbean.cardano.yaci.store.submit.controller;
+
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vavr.control.Either;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TxUtilControllerTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void evaluateUtxosReturnsBadRequestForInvalidAdditionalUtxos() throws Exception {
+        TxEvaluationService txEvaluationService = mock(TxEvaluationService.class);
+        when(txEvaluationService.evaluateTx(any(), any()))
+                .thenThrow(new IllegalArgumentException("additionalUtxoSet TxOut value is required"));
+        TxUtilController controller = new TxUtilController(txEvaluationService);
+        TxUtilController.EvaluateRequest request = new TxUtilController.EvaluateRequest();
+        request.setCbor("abcd");
+        request.setAdditionalUtxoSet(objectMapper.readTree("[]"));
+
+        var response = controller.evaluateTx(request, 5);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isInstanceOfSatisfying(TxErrorResponse.class, error -> {
+            assertThat(error.error()).isEqualTo("Bad Request");
+            assertThat(error.message()).contains("additionalUtxoSet TxOut value is required");
+        });
+    }
+
+    @Test
+    void evaluateUtxosPassesAdditionalUtxosAsRawJsonForModeAwareHandling() throws Exception {
+        TxEvaluationService txEvaluationService = mock(TxEvaluationService.class);
+        JsonNode success = objectMapper.readTree("{\"result\":[]}");
+        when(txEvaluationService.evaluateTx(any(), any())).thenReturn(Either.right(success));
+        when(txEvaluationService.transformTxEvaluationSuccessResultToV5BFFormat(success)).thenReturn(success);
+        TxUtilController controller = new TxUtilController(txEvaluationService);
+        TxUtilController.EvaluateRequest request = new TxUtilController.EvaluateRequest();
+        request.setCbor("abcd");
+        request.setAdditionalUtxoSet(objectMapper.readTree("\"ignored by ogmios mode\""));
+
+        var response = controller.evaluateTx(request, 5);
+
+        ArgumentCaptor<JsonNode> additionalUtxoCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(txEvaluationService).evaluateTx(any(), additionalUtxoCaptor.capture());
+        assertThat(response.getStatusCode().value()).isEqualTo(202);
+        assertThat(additionalUtxoCaptor.getValue().asText()).isEqualTo("ignored by ogmios mode");
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationPropertiesTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationPropertiesTest.java
@@ -12,6 +12,13 @@ class TxEvaluationPropertiesTest {
             .withUserConfiguration(TestConfig.class);
 
     @Test
+    void defaultsToScalusEvaluatorMode() {
+        contextRunner
+                .run(context -> assertThat(context.getBean(TxEvaluationProperties.class).getTxEvaluatorMode())
+                        .isEqualTo(TxEvaluatorMode.SCALUS));
+    }
+
+    @Test
     void bindsScalusEvaluatorMode() {
         contextRunner
                 .withPropertyValues("store.submit.tx-evaluator-mode=scalus")

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationPropertiesTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationPropertiesTest.java
@@ -1,0 +1,38 @@
+package com.bloxbean.cardano.yaci.store.submit.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TxEvaluationPropertiesTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void bindsScalusEvaluatorMode() {
+        contextRunner
+                .withPropertyValues("store.submit.tx-evaluator-mode=scalus")
+                .run(context -> assertThat(context.getBean(TxEvaluationProperties.class).getTxEvaluatorMode())
+                        .isEqualTo(TxEvaluatorMode.SCALUS));
+    }
+
+    @Test
+    void invalidEvaluatorModeFailsAtStartup() {
+        contextRunner
+                .withPropertyValues("store.submit.tx-evaluator-mode=scalu")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasStackTraceContaining("store.submit.tx-evaluator-mode")
+                            .hasStackTraceContaining("scalu");
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(TxEvaluationProperties.class)
+    static class TestConfig {
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationServiceTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationServiceTest.java
@@ -1,0 +1,86 @@
+package com.bloxbean.cardano.yaci.store.submit.service;
+
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.yaci.store.submit.service.scalus.ScalusTxEvaluationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.vavr.control.Either;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TxEvaluationServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ObjectProvider<OgmiosService> ogmiosServiceProvider;
+    @Mock
+    private OgmiosService ogmiosService;
+    @Mock
+    private ScalusTxEvaluationService scalusTxEvaluationService;
+
+    private JsonNode success;
+
+    @BeforeEach
+    void setup() throws Exception {
+        success = objectMapper.readTree("{\"result\":[]}");
+    }
+
+    @Test
+    void defaultModeUsesOgmiosEvaluator() throws Exception {
+        byte[] cborTx = new byte[]{1, 2, 3};
+        TxEvaluationProperties properties = new TxEvaluationProperties();
+        when(ogmiosServiceProvider.getIfAvailable()).thenReturn(ogmiosService);
+        when(ogmiosService.evaluateTx(same(cborTx), anySet())).thenReturn(Either.right(success));
+
+        Either<JsonNode, JsonNode> result = service(properties).evaluateTx(cborTx, TextNode.valueOf("ignored by ogmios"));
+
+        assertThat(result.get()).isSameAs(success);
+        verify(ogmiosService).evaluateTx(same(cborTx), anySet());
+        verifyNoInteractions(scalusTxEvaluationService);
+    }
+
+    @Test
+    void scalusModeUsesScalusEvaluatorEvenWhenOgmiosExists() throws Exception {
+        byte[] cborTx = new byte[]{1, 2, 3};
+        JsonNode additionalUtxos = objectMapper.readTree("[]");
+        TxEvaluationProperties properties = new TxEvaluationProperties();
+        properties.setTxEvaluatorMode(TxEvaluatorMode.SCALUS);
+        when(scalusTxEvaluationService.evaluateTx(same(cborTx), same(additionalUtxos))).thenReturn(Either.right(success));
+
+        Either<JsonNode, JsonNode> result = service(properties).evaluateTx(cborTx, additionalUtxos);
+
+        assertThat(result.get()).isSameAs(success);
+        verify(ogmiosServiceProvider, never()).getIfAvailable();
+        verify(scalusTxEvaluationService).evaluateTx(same(cborTx), same(additionalUtxos));
+    }
+
+    @Test
+    void ogmiosModeFailsClearlyWhenOgmiosBeanIsMissing() {
+        TxEvaluationProperties properties = new TxEvaluationProperties();
+        when(ogmiosServiceProvider.getIfAvailable()).thenReturn(null);
+
+        assertThatThrownBy(() -> service(properties).evaluateTx(new byte[]{1}, null))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("Ogmios tx evaluator requested")
+                .hasMessageContaining("store.cardano.ogmios-url");
+    }
+
+    private TxEvaluationService service(TxEvaluationProperties properties) {
+        return new TxEvaluationService(properties, ogmiosServiceProvider, scalusTxEvaluationService, objectMapper);
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationServiceTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/TxEvaluationServiceTest.java
@@ -4,7 +4,6 @@ import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.yaci.store.submit.service.scalus.ScalusTxEvaluationService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.TextNode;
 import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,13 +40,29 @@ class TxEvaluationServiceTest {
     }
 
     @Test
-    void defaultModeUsesOgmiosEvaluator() throws Exception {
+    void defaultModeUsesScalusEvaluator() throws Exception {
+        byte[] cborTx = new byte[]{1, 2, 3};
+        JsonNode additionalUtxos = objectMapper.readTree("[]");
+        TxEvaluationProperties properties = new TxEvaluationProperties();
+        when(scalusTxEvaluationService.evaluateTx(same(cborTx), same(additionalUtxos))).thenReturn(Either.right(success));
+
+        Either<JsonNode, JsonNode> result = service(properties).evaluateTx(cborTx, additionalUtxos);
+
+        assertThat(result.get()).isSameAs(success);
+        verify(scalusTxEvaluationService).evaluateTx(same(cborTx), same(additionalUtxos));
+        verify(ogmiosServiceProvider, never()).getIfAvailable();
+        verifyNoInteractions(ogmiosService);
+    }
+
+    @Test
+    void ogmiosModeUsesOgmiosEvaluator() throws Exception {
         byte[] cborTx = new byte[]{1, 2, 3};
         TxEvaluationProperties properties = new TxEvaluationProperties();
+        properties.setTxEvaluatorMode(TxEvaluatorMode.OGMIOS);
         when(ogmiosServiceProvider.getIfAvailable()).thenReturn(ogmiosService);
         when(ogmiosService.evaluateTx(same(cborTx), anySet())).thenReturn(Either.right(success));
 
-        Either<JsonNode, JsonNode> result = service(properties).evaluateTx(cborTx, TextNode.valueOf("ignored by ogmios"));
+        Either<JsonNode, JsonNode> result = service(properties).evaluateTx(cborTx, objectMapper.readTree("[]"));
 
         assertThat(result.get()).isSameAs(success);
         verify(ogmiosService).evaluateTx(same(cborTx), anySet());
@@ -72,6 +87,7 @@ class TxEvaluationServiceTest {
     @Test
     void ogmiosModeFailsClearlyWhenOgmiosBeanIsMissing() {
         TxEvaluationProperties properties = new TxEvaluationProperties();
+        properties.setTxEvaluatorMode(TxEvaluatorMode.OGMIOS);
         when(ogmiosServiceProvider.getIfAvailable()).thenReturn(null);
 
         assertThatThrownBy(() -> service(properties).evaluateTx(new byte[]{1}, null))

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ReferenceScriptSupplierTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ReferenceScriptSupplierTest.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusV1Script;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
+import com.bloxbean.cardano.client.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReferenceScriptSupplierTest {
+    @Test
+    void registerStoresPlutusReferenceScript() throws Exception {
+        PlutusV1Script script = PlutusV1Script.builder()
+                .cborHex("4e4d01000033222220051200120011")
+                .build();
+        String scriptHash = HexUtil.encodeHexString(script.getScriptHash());
+        String scriptRef = HexUtil.encodeHexString(script.scriptRefBytes());
+        ReferenceScriptSupplier supplier = new ReferenceScriptSupplier();
+
+        supplier.register(scriptHash, scriptRef);
+
+        var resolved = supplier.getScript(scriptHash);
+        assertThat(resolved).isInstanceOf(PlutusV1Script.class);
+        assertThat(HexUtil.encodeHexString(resolved.getScriptHash())).isEqualTo(scriptHash);
+    }
+
+    @Test
+    void registerIgnoresNativeReferenceScript() throws Exception {
+        ScriptPubkey nativeScript = new ScriptPubkey("00000000000000000000000000000000000000000000000000000000");
+        String scriptRef = HexUtil.encodeHexString(nativeScript.scriptRefBytes());
+        ReferenceScriptSupplier supplier = new ReferenceScriptSupplier();
+
+        supplier.register("native-script-hash", scriptRef);
+
+        assertThatThrownBy(() -> supplier.getScript("native-script-hash"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Reference script not found");
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusAdditionalUtxoMapperTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusAdditionalUtxoMapperTest.java
@@ -1,0 +1,179 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.yaci.store.submit.controller.TxUtilController;
+import com.bloxbean.cardano.yaci.store.submit.domain.OgmiosUtxo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScalusAdditionalUtxoMapperTest {
+    private static final String PLUTUS_V1_CBOR = "4e4d01000033222220051200120011";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void fromAdditionalUtxoSetAcceptsBlockfrostTupleShape() throws Exception {
+        String requestJson = """
+                {
+                  "cbor": "abcd",
+                  "additionalUtxoSet": [
+                    [
+                      { "txId": "tx2", "index": 1 },
+                      {
+                        "address": "addr_test1...",
+                        "value": {
+                          "coins": "1000000",
+                          "assets": {
+                            "policyasset": "7"
+                          }
+                        },
+                        "datumHash": "datum-hash",
+                        "datum": "d87980"
+                      }
+                    ]
+                  ]
+                }
+                """;
+        TxUtilController.EvaluateRequest request = objectMapper.readValue(requestJson, TxUtilController.EvaluateRequest.class);
+
+        var cclUtxos = ScalusAdditionalUtxoMapper.fromAdditionalUtxoSet(
+                OgmiosUtxo.fromAdditionalUtxoSet(request.getAdditionalUtxoSet()), new ReferenceScriptSupplier());
+
+        assertThat(cclUtxos).singleElement().satisfies(cclUtxo -> {
+            assertThat(cclUtxo.getTxHash()).isEqualTo("tx2");
+            assertThat(cclUtxo.getOutputIndex()).isEqualTo(1);
+            assertThat(cclUtxo.getDataHash()).isEqualTo("datum-hash");
+            assertThat(cclUtxo.getInlineDatum()).isEqualTo("d87980");
+            assertThat(cclUtxo.getAmount())
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo("lovelace");
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(1_000_000));
+                    })
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo("policyasset");
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(7));
+                    });
+        });
+    }
+
+    @Test
+    void fromAdditionalUtxoSetAcceptsOgmiosTupleShapeAndRegistersPlutusScript() throws Exception {
+        String policyId = "a".repeat(56);
+        String assetName = "74657374";
+        String additionalUtxosJson = """
+                [
+                  [
+                    {
+                      "transaction": { "id": "tx3" },
+                      "output": { "index": 3 }
+                    },
+                    {
+                      "address": "addr_test1...",
+                      "value": {
+                        "ada": { "lovelace": 10000000 },
+                        "%s": { "%s": 42 }
+                      },
+                      "datum": "d87980",
+                      "script": {
+                        "language": "plutus:v1",
+                        "cbor": "%s"
+                      }
+                    }
+                  ]
+                ]
+                """.formatted(policyId, assetName, PLUTUS_V1_CBOR);
+        List<OgmiosUtxo> additionalUtxos = OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree(additionalUtxosJson));
+        ReferenceScriptSupplier scriptSupplier = new ReferenceScriptSupplier();
+
+        var cclUtxos = ScalusAdditionalUtxoMapper.fromAdditionalUtxoSet(additionalUtxos, scriptSupplier);
+
+        assertThat(cclUtxos).singleElement().satisfies(cclUtxo -> {
+            assertThat(cclUtxo.getTxHash()).isEqualTo("tx3");
+            assertThat(cclUtxo.getOutputIndex()).isEqualTo(3);
+            assertThat(cclUtxo.getInlineDatum()).isEqualTo("d87980");
+            assertThat(cclUtxo.getReferenceScriptHash()).isNotBlank();
+            assertThat(scriptSupplier.getScript(cclUtxo.getReferenceScriptHash()).getCborHex()).isEqualTo(PLUTUS_V1_CBOR);
+            assertThat(cclUtxo.getAmount())
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo("lovelace");
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(10_000_000));
+                    })
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo(policyId + assetName);
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(42));
+                    });
+        });
+    }
+
+    @Test
+    void fromAdditionalUtxoSetAcceptsFlatOgmiosUtxoShape() throws Exception {
+        String flatUtxoJson = """
+                [
+                  {
+                    "transaction": { "id": "tx5" },
+                    "index": 5,
+                    "address": "addr_test1...",
+                    "value": {
+                      "lovelace": 2000000,
+                      "policy.asset": "11"
+                    },
+                    "script": {
+                      "plutus:v1": "%s"
+                    }
+                  }
+                ]
+                """.formatted(PLUTUS_V1_CBOR);
+        List<OgmiosUtxo> additionalUtxos = OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree(flatUtxoJson));
+        ReferenceScriptSupplier scriptSupplier = new ReferenceScriptSupplier();
+
+        var cclUtxos = ScalusAdditionalUtxoMapper.fromAdditionalUtxoSet(additionalUtxos, scriptSupplier);
+
+        assertThat(cclUtxos).singleElement().satisfies(cclUtxo -> {
+            assertThat(cclUtxo.getTxHash()).isEqualTo("tx5");
+            assertThat(cclUtxo.getOutputIndex()).isEqualTo(5);
+            assertThat(cclUtxo.getReferenceScriptHash()).isNotBlank();
+            assertThat(scriptSupplier.getScript(cclUtxo.getReferenceScriptHash()).getCborHex()).isEqualTo(PLUTUS_V1_CBOR);
+            assertThat(cclUtxo.getAmount())
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo("lovelace");
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(2_000_000));
+                    })
+                    .anySatisfy(amount -> {
+                        assertThat(amount.getUnit()).isEqualTo("policyasset");
+                        assertThat(amount.getQuantity()).isEqualTo(BigInteger.valueOf(11));
+                    });
+        });
+    }
+
+    @Test
+    void fromAdditionalUtxoSetRejectsMissingRequiredFields() throws Exception {
+        assertThatThrownBy(() -> OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree("""
+                [[{"index": 0}, {"address": "addr_test1...", "value": {"coins": 1}}]]
+                """)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transaction id");
+
+        assertThatThrownBy(() -> OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree("""
+                [[{"txId": "tx4"}, {"address": "addr_test1...", "value": {"coins": 1}}]]
+                """)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("index");
+
+        assertThatThrownBy(() -> OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree("""
+                [[{"txId": "tx4", "index": 0}, {"value": {"coins": 1}}]]
+                """)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("address");
+
+        assertThatThrownBy(() -> OgmiosUtxo.fromAdditionalUtxoSet(objectMapper.readTree("""
+                [[{"txId": "tx4", "index": 0}, {"address": "addr_test1..."}]]
+                """)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("value");
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusSlotConfigProviderTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusSlotConfigProviderTest.java
@@ -1,0 +1,61 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.core.service.EraService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ScalusSlotConfigProviderTest {
+    private EraService eraService;
+    private GenesisConfig genesisConfig;
+    private ObjectProvider<EraService> eraServiceProvider;
+    private ObjectProvider<GenesisConfig> genesisConfigProvider;
+
+    @BeforeEach
+    void setup() {
+        eraService = mock(EraService.class);
+        genesisConfig = mock(GenesisConfig.class);
+        eraServiceProvider = mock(ObjectProvider.class);
+        genesisConfigProvider = mock(ObjectProvider.class);
+
+        when(eraServiceProvider.getIfAvailable()).thenReturn(eraService);
+        when(genesisConfigProvider.getIfAvailable()).thenReturn(genesisConfig);
+    }
+
+    @Test
+    void getSlotConfigDerivesMainnetCanonicalValuesFromEraAndGenesisServices() throws Exception {
+        when(eraService.shelleyEraStartTime()).thenReturn(1_596_059_091L);
+        when(eraService.getFirstNonByronSlot()).thenReturn(4_492_800L);
+        when(genesisConfig.slotDuration(Era.Shelley)).thenReturn(1.0);
+
+        var slotConfig = new ScalusSlotConfigProvider(eraServiceProvider, genesisConfigProvider).getSlotConfig();
+
+        assertThat(slotConfig.zeroTime()).isEqualTo(1_596_059_091_000L);
+        assertThat(slotConfig.zeroSlot()).isEqualTo(4_492_800L);
+        assertThat(slotConfig.slotLength()).isEqualTo(1_000L);
+    }
+
+    @Test
+    void getSlotConfigCachesDerivedValue() throws Exception {
+        when(eraService.shelleyEraStartTime()).thenReturn(1_596_059_091L);
+        when(eraService.getFirstNonByronSlot()).thenReturn(4_492_800L);
+        when(genesisConfig.slotDuration(Era.Shelley)).thenReturn(1.0);
+        var provider = new ScalusSlotConfigProvider(eraServiceProvider, genesisConfigProvider);
+
+        var first = provider.getSlotConfig();
+        var second = provider.getSlotConfig();
+
+        assertThat(second).isSameAs(first);
+        verify(eraService, times(1)).shelleyEraStartTime();
+        verify(eraService, times(1)).getFirstNonByronSlot();
+        verify(genesisConfig, times(1)).slotDuration(Era.Shelley);
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusTxEvaluationServiceTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/ScalusTxEvaluationServiceTest.java
@@ -1,0 +1,88 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.EvaluationResult;
+import com.bloxbean.cardano.client.plutus.spec.ExUnits;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.yaci.store.client.epoch.EpochParamClient;
+import com.bloxbean.cardano.yaci.store.client.utxo.DummyUtxoClient;
+import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationProperties;
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ScalusTxEvaluationServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void toJsonUsesOgmiosPurposeNamesAndTransformsToV5Shape() {
+        ScalusTxEvaluationService scalusService = new ScalusTxEvaluationService(null, null, null, objectMapper);
+        JsonNode scalusJson = scalusService.toJson(List.of(
+                result(RedeemerTag.Spend, 0, 100, 200),
+                result(RedeemerTag.Mint, 1, 101, 201),
+                result(RedeemerTag.Cert, 2, 102, 202),
+                result(RedeemerTag.Reward, 3, 103, 203),
+                result(RedeemerTag.Voting, 4, 104, 204),
+                result(RedeemerTag.Proposing, 5, 105, 205)
+        ));
+
+        JsonNode v5Json = new TxEvaluationService(new TxEvaluationProperties(), null, null, objectMapper)
+                .transformTxEvaluationSuccessResultToV5BFFormat(scalusJson);
+        JsonNode evaluationResults = v5Json.at("/result/EvaluationResult");
+
+        assertCost(evaluationResults, "spend:0", 100, 200);
+        assertCost(evaluationResults, "mint:1", 101, 201);
+        assertCost(evaluationResults, "publish:2", 102, 202);
+        assertCost(evaluationResults, "withdraw:3", 103, 203);
+        assertCost(evaluationResults, "vote:4", 104, 204);
+        assertCost(evaluationResults, "propose:5", 105, 205);
+        assertThat(evaluationResults.has("cert:2")).isFalse();
+        assertThat(evaluationResults.has("reward:3")).isFalse();
+        assertThat(evaluationResults.has("voting:4")).isFalse();
+        assertThat(evaluationResults.has("proposing:5")).isFalse();
+    }
+
+    @Test
+    void evaluateTxRejectsDummyUtxoClient() {
+        ObjectProvider<EpochParamClient> epochParamClient = mock(ObjectProvider.class);
+        ObjectProvider<UtxoClient> utxoClient = mock(ObjectProvider.class);
+        when(epochParamClient.getIfAvailable()).thenReturn(mock(EpochParamClient.class));
+        when(utxoClient.getIfAvailable()).thenReturn(new DummyUtxoClient());
+
+        ScalusTxEvaluationService scalusService = new ScalusTxEvaluationService(
+                epochParamClient, utxoClient, mock(ScalusSlotConfigProvider.class), objectMapper);
+
+        assertThatThrownBy(() -> scalusService.evaluateTx(new byte[]{1}, objectMapper.readTree("[]")))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("real UtxoClient");
+    }
+
+    private EvaluationResult result(RedeemerTag redeemerTag, int index, long memory, long steps) {
+        return EvaluationResult.builder()
+                .redeemerTag(redeemerTag)
+                .index(index)
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(memory))
+                        .steps(BigInteger.valueOf(steps))
+                        .build())
+                .build();
+    }
+
+    private void assertCost(JsonNode evaluationResults, String key, long memory, long steps) {
+        JsonNode cost = evaluationResults.get(key);
+        assertThat(cost).isNotNull();
+        assertThat(cost.get("memory").asLong()).isEqualTo(memory);
+        assertThat(cost.get("steps").asLong()).isEqualTo(steps);
+    }
+}

--- a/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/StoreUtxoSupplierTest.java
+++ b/components/submit/src/test/java/com/bloxbean/cardano/yaci/store/submit/service/scalus/StoreUtxoSupplierTest.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.submit.service.scalus;
+
+import com.bloxbean.cardano.client.api.common.OrderEnum;
+import com.bloxbean.cardano.yaci.store.client.utxo.UtxoClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class StoreUtxoSupplierTest {
+    @Test
+    void getPageIsUnsupportedForTxEvaluation() {
+        StoreUtxoSupplier supplier = new StoreUtxoSupplier(mock(UtxoClient.class), new ReferenceScriptSupplier());
+
+        assertThatThrownBy(() -> supplier.getPage("addr_test1...", 1, 100, OrderEnum.asc))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("getTxOutput");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.1"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.1"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.1"
 cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.1"
+scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0"
 
 cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.4.2"
-cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.1"
-cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.1"
-cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.1"
-cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.1"
+yaci = "com.bloxbean.cardano:yaci:0.4.3"
+cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.2"
+cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.2"
+cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.2"
+cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.2"
 scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0"
 
 cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.0"

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/client/EpochParamClientImpl.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/client/EpochParamClientImpl.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.store.epoch.client;
+
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.client.epoch.EpochParamClient;
+import com.bloxbean.cardano.yaci.store.common.ccl.CclProtocolParamsMapper;
+import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
+import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Local {@link EpochParamClient} implementation backed by epoch storage.
+ */
+@Component("epochParamClient")
+@Primary
+@RequiredArgsConstructor
+@Slf4j
+public class EpochParamClientImpl implements EpochParamClient {
+    private final EpochParamStorage epochParamStorage;
+
+    @Override
+    public Optional<ProtocolParams> getLatestProtocolParams() {
+        return epochParamStorage.getLatestEpochParam()
+                .map(EpochParam::getParams)
+                .map(CclProtocolParamsMapper::toCclProtocolParams);
+    }
+}


### PR DESCRIPTION
 **Summary**
 This PR adds a Scalus-based transaction evaluation path for the Blockfrost-compatible submit utility endpoint.

  The evaluator is selected with:

```
  store.submit.tx-evaluator-mode=ogmios # default
  store.submit.tx-evaluator-mode=scalus
```

When scalus is selected, transaction evaluation uses local Yaci Store data instead of delegating to Ogmios. It resolves protocol parameters through `EpochParamClient`, transaction inputs through `UtxoClient,` network slot configuration from genesis/era data, and reference scripts through a per-evaluation ScriptSupplier.

  **Changes**

  - Added TxEvaluatorMode and TxEvaluationProperties.
  - Added Scalus transaction evaluation service using ScalusTransactionEvaluator.
  - Added local EpochParamClient implementation backed by epoch storage.
  - Added EpochParamClient inter-module client interface.
  - Added additionalUtxoSet support for Scalus mode.
  - Kept Ogmios mode behavior unchanged; Ogmios still ignores additionalUtxoSet.
  - Added Ogmios/Blockfrost additional UTxO parsing via OgmiosUtxo.
  - Added per-evaluation reference script registration for UTxOs and additional UTxOs.
  - Added SlotConfig creation from Shelley era start time, first Shelley slot, and Shelley slot duration.
  - Added common CCL mapper utilities:
      - CclProtocolParamsMapper
      - CclUtxoMapper
  - Split submit-specific additional UTxO mapping into ScalusAdditionalUtxoMapper.
  - Added Javadocs for new public API classes/utilities.

  **Notes**

  - Default evaluator mode remains ogmios.
  - additionalUtxoSet is honored only in Scalus mode.