### PR TITLE
feat: Update AccountController endpoint openapi description + enable account api for ledger-state profile

### DIFF
--- a/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/api/account/controller/AccountController.java
+++ b/aggregates/account/src/main/java/com/bloxbean/cardano/yaci/store/api/account/controller/AccountController.java
@@ -39,7 +39,13 @@ import static com.bloxbean.cardano.yaci.core.util.Constants.LOVELACE;
 @RequestMapping("${apiPrefix}")
 @RequiredArgsConstructor
 @Slf4j
-@Tag(name = "Account API", description = "APIs for account related operations. This is an experimental module. Some apis may not be stable.")
+@Tag(name = "Account API",
+        description = "Account-related queries for Cardano addresses and stake accounts. " +
+                "Includes current and historical address balances, aggregated stake balances, live UTxO-based amounts, " +
+                "and full stake-account details (controlled ADA, withdrawable rewards, delegated pool).\n\n" +
+                "Depending on the endpoint, data is served from pre-aggregated balance tables, by live UTxO aggregation, " +
+                "or by querying the connected local Cardano node (n2c). Endpoints whose required feature flag is " +
+                "disabled return HTTP 503; see each endpoint description for specifics.")
 public class AccountController {
     private final AccountBalanceStorage accountBalanceStorage;
     private final AccountService accountService;
@@ -48,10 +54,21 @@ public class AccountController {
     private final AccountConfigService accountConfigService;
 
     @GetMapping("/addresses/{address}/balance")
-    @Operation(description = "Get current balance at an address")
+    @Operation(description =
+            "Returns the current balance (lovelace and native assets) at a payment-type address.\n\n" +
+            "Address: Bech32 payment address (`addr...`) — payment, base, enterprise, or pointer.\n\n" +
+            "Data source: pre-aggregated address balance table.\n\n" +
+            "Requires `store.account.balance-aggregation-enabled=true` AND `store.account.address-balance-enabled=true`; " +
+            "otherwise returns HTTP 503.\n\n" +
+            "Returns 404 if the address has no positive balance.")
     public Optional<AddressBalanceDto> getAddressBalance(@PathVariable @NonNull String address) {
         if (!accountStoreProperties.isBalanceAggregationEnabled())
-            throw new UnsupportedOperationException("Address balance aggregation is not enabled");
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Balance aggregation is not enabled (store.account.balance-aggregation-enabled)");
+
+        if (!accountStoreProperties.isAddressBalanceEnabled())
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Address balance aggregation is not enabled (store.account.address-balance-enabled)");
 
         var addresssBalances = accountBalanceStorage.getAddressBalance(address)
                 .stream()
@@ -67,7 +84,16 @@ public class AccountController {
     }
 
     @GetMapping("/accounts/{stakeAddress}/balance")
-    @Operation(description = "Get current balance at a stake address")
+    @Operation(description =
+            "Returns the current aggregated lovelace balance for a stake account. " +
+            "Withdrawable rewards are NOT included.\n\n" +
+            "Address: Bech32 stake address (`stake...`).\n\n" +
+            "Data source: pre-aggregated stake-address balance table.\n\n" +
+            "Requires `store.account.balance-aggregation-enabled=true` AND " +
+            "`store.account.stake-address-balance-enabled=true` " +
+            "(the latter controls whether the stake-address balance table is populated). " +
+            "If `balance-aggregation-enabled` is false, the endpoint returns HTTP 503.\n\n" +
+            "Returns an empty body when no positive balance exists for the stake address.")
     public Optional<StakeAddressBalance> getStakeAddressBalance(@PathVariable @NonNull String stakeAddress) {
         if (!accountStoreProperties.isBalanceAggregationEnabled())
             throw new UnsupportedOperationException("Address balance aggregation is not enabled");
@@ -77,10 +103,23 @@ public class AccountController {
     }
 
     @GetMapping("/addresses/{address}/{unit}/{timeInSec}/balance")
-    @Operation(description = "Get current balance at an address at a specific time. This is an experimental feature.")
+    @Operation(description =
+            "Returns the historical balance for a single asset `unit` at or before `timeInSec`.\n\n" +
+            "Address: Bech32 payment address (`addr...`).\n" +
+            "Unit: `lovelace` or hex `policyId+assetNameHex`.\n" +
+            "timeInSec: UNIX seconds.\n\n" +
+            "Data source: historical entries in the address balance table.\n\n" +
+            "Requires `store.account.balance-aggregation-enabled=true` AND `store.account.address-balance-enabled=true`; " +
+            "otherwise returns HTTP 503.\n\n" +
+            "Returns 404 if no record exists at the requested time.")
     public Optional<AddressBalanceDto> getAddressBalanceAtTime(@PathVariable String address,@PathVariable String unit,@PathVariable long timeInSec) {
         if (!accountStoreProperties.isBalanceAggregationEnabled())
-            throw new UnsupportedOperationException("Address balance aggregation is not enabled");
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Balance aggregation is not enabled (store.account.balance-aggregation-enabled)");
+
+        if (!accountStoreProperties.isAddressBalanceEnabled())
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Address balance aggregation is not enabled (store.account.address-balance-enabled)");
 
         var addressBalances = accountBalanceStorage.getAddressBalanceByTime(address, unit, timeInSec)
                 .filter(addressBalance -> addressBalance.getQuantity().compareTo(BigInteger.ZERO) > 0)
@@ -90,7 +129,17 @@ public class AccountController {
     }
 
     @GetMapping("/accounts/{stakeAddress}/{timeInSec}/balance")
-    @Operation(description = "Get current balance at a stake address at a specific time. This is an experimental feature.")
+    @Operation(description =
+            "Returns the historical aggregated lovelace balance for a stake account at or before " +
+            "`timeInSec`. Withdrawable rewards are NOT included.\n\n" +
+            "Address: Bech32 stake address (`stake...`).\n" +
+            "timeInSec: UNIX seconds.\n\n" +
+            "Data source: historical entries in the stake-address balance table.\n\n" +
+            "Requires `store.account.balance-aggregation-enabled=true` AND " +
+            "`store.account.stake-address-balance-enabled=true` " +
+            "(the latter controls whether the stake-address balance table is populated). " +
+            "If `balance-aggregation-enabled` is false, the endpoint returns HTTP 503.\n\n" +
+            "Returns 404 if no record exists at the requested time.")
     public StakeAddressBalance getStakeAddressBalanceAtTime(@PathVariable @NonNull String stakeAddress,
                                                             @PathVariable long timeInSec) {
         if (!accountStoreProperties.isBalanceAggregationEnabled())
@@ -103,10 +152,16 @@ public class AccountController {
     }
 
     @GetMapping("/accounts/{stakeAddress}")
-    @Operation(description = "Obtain information about a specific stake account." +
-            "It gets stake account balance from aggregated stake account balance if aggregation is enabled, " +
-            "otherwise it calculates the current lovelace balance by aggregating all current utxos for the stake address" +
-            "and get rewards amount directly from node.")
+    @Operation(description =
+            "Returns details for a stake account: `controlledAmount`, `withdrawableAmount`, and `poolId`.\n\n" +
+            "Address: Bech32 stake address (`stake...`). Returns 400 for any other prefix.\n\n" +
+            "`controlledAmount` = lovelace held by the stake credential + withdrawable rewards.\n\n" +
+            "Lovelace source: pre-aggregated stake-address balance table when " +
+            "`store.account.balance-aggregation-enabled=true`; otherwise computed at request time by summing all " +
+            "current UTxOs for the stake address (may be slow for accounts with many UTxOs).\n\n" +
+            "`withdrawableAmount` and `poolId`: obtained from the connected local Cardano node (n2c) via the " +
+            "`DelegationsAndRewardAccounts` query, with fallback to the AdaPot reward provider when available. " +
+            "If neither source is reachable, `poolId` is null and `withdrawableAmount` is 0.")
     public StakeAccountInfo getStakeAccountDetails(@PathVariable @NonNull String stakeAddress) {
         if (!stakeAddress.startsWith(Bech32Prefixes.STAKE_ADDR_PREFIX))
             throw new IllegalArgumentException("Invalid stake address");
@@ -140,8 +195,13 @@ public class AccountController {
     }
 
     @GetMapping("/addresses/{address}/amounts")
-    @Operation(description = "Get amounts at an address. For stake address, only lovelace is returned." +
-            "It calculates the current balance at the address by aggregating all currrent utxos for the stake address. It may be slow for addresses with too many utxos.")
+    @Operation(description =
+            "Returns the live amounts (lovelace and native assets) held at an address by summing all current UTxOs " +
+            "at request time.\n\n" +
+            "Address: any Bech32 address — payment (`addr...`) or stake (`stake...`).\n" +
+            "For stake addresses, only the lovelace entry is returned.\n\n" +
+            "Data source: live UTxO aggregation. Does NOT depend on the balance-aggregation flags, so it works even " +
+            "when address or stake balance aggregation is disabled. May be slow for addresses with very many UTxOs.")
     public List<Amount> getAddressAmounts(@PathVariable @NonNull String address) {
         List<Amount> amounts = utxoAccountService.getAmountsAtAddress(address);
         if (amounts == null || amounts.size() == 0)

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProvider.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProvider.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.adapot.service;
 
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
 import com.bloxbean.cardano.yaci.store.account.domain.StakeAccountRewardInfo;
 import com.bloxbean.cardano.yaci.store.account.service.StakeAccountRewardProvider;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
@@ -28,9 +29,18 @@ public class AdaPotStakeAccountRewardProvider implements StakeAccountRewardProvi
         }
 
         var withdrawableReward = rewardStorageReader.findWithdrawableRewardByAddress(stakeAddress);
-        var poolId = stakingCertificateStorageReader.getLatestDelegationByAddress(stakeAddress)
-                .map(delegation -> PoolUtil.getBech32PoolId(delegation.getPoolId()))
-                .orElse(null);
+
+        var latestRegistration = stakingCertificateStorageReader.getRegistrationByStakeAddress(stakeAddress, Long.MAX_VALUE);
+        boolean isDeregistered = latestRegistration
+                .map(reg -> reg.getType() == CertificateType.STAKE_DEREGISTRATION)
+                .orElse(false);
+
+        String poolId = null;
+        if (!isDeregistered) {
+            poolId = stakingCertificateStorageReader.getLatestDelegationByAddress(stakeAddress)
+                    .map(delegation -> PoolUtil.getBech32PoolId(delegation.getPoolId()))
+                    .orElse(null);
+        }
 
         return Optional.of(StakeAccountRewardInfo.builder()
                 .stakeAddress(stakeAddress)

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProvider.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProvider.java
@@ -6,6 +6,8 @@ import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
 import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
 import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorageReader;
+import com.bloxbean.cardano.yaci.store.common.util.PoolUtil;
+import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorageReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,7 @@ import java.util.Optional;
 public class AdaPotStakeAccountRewardProvider implements StakeAccountRewardProvider {
     private final RewardStorageReader rewardStorageReader;
     private final AdaPotJobStorage adaPotJobStorage;
+    private final StakingCertificateStorageReader stakingCertificateStorageReader;
 
     @Override
     public Optional<StakeAccountRewardInfo> getAccountInfo(String stakeAddress) {
@@ -25,9 +28,14 @@ public class AdaPotStakeAccountRewardProvider implements StakeAccountRewardProvi
         }
 
         var withdrawableReward = rewardStorageReader.findWithdrawableRewardByAddress(stakeAddress);
+        var poolId = stakingCertificateStorageReader.getLatestDelegationByAddress(stakeAddress)
+                .map(delegation -> PoolUtil.getBech32PoolId(delegation.getPoolId()))
+                .orElse(null);
+
         return Optional.of(StakeAccountRewardInfo.builder()
                 .stakeAddress(stakeAddress)
                 .withdrawableAmount(withdrawableReward.getWithdrawableAmount())
+                .poolId(poolId)
                 .build());
     }
 }

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProviderTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProviderTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.adapot.service;
 
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
 import com.bloxbean.cardano.yaci.store.adapot.domain.WithdrawableReward;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJob;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
@@ -7,6 +8,7 @@ import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
 import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
 import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorageReader;
 import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
+import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
 import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorageReader;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +56,11 @@ class AdaPotStakeAccountRewardProviderTest {
                         .address(STAKE_ADDRESS)
                         .withdrawableAmount(BigInteger.valueOf(40))
                         .build());
+        when(stakingCertificateStorageReader.getRegistrationByStakeAddress(STAKE_ADDRESS, Long.MAX_VALUE))
+                .thenReturn(Optional.of(StakeRegistrationDetail.builder()
+                        .address(STAKE_ADDRESS)
+                        .type(CertificateType.STAKE_REGISTRATION)
+                        .build()));
         when(stakingCertificateStorageReader.getLatestDelegationByAddress(STAKE_ADDRESS))
                 .thenReturn(Optional.of(Delegation.builder()
                         .address(STAKE_ADDRESS)
@@ -85,6 +92,11 @@ class AdaPotStakeAccountRewardProviderTest {
                         .address(STAKE_ADDRESS)
                         .withdrawableAmount(BigInteger.valueOf(40))
                         .build());
+        when(stakingCertificateStorageReader.getRegistrationByStakeAddress(STAKE_ADDRESS, Long.MAX_VALUE))
+                .thenReturn(Optional.of(StakeRegistrationDetail.builder()
+                        .address(STAKE_ADDRESS)
+                        .type(CertificateType.STAKE_REGISTRATION)
+                        .build()));
         when(stakingCertificateStorageReader.getLatestDelegationByAddress(STAKE_ADDRESS))
                 .thenReturn(Optional.empty());
         var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage, stakingCertificateStorageReader);
@@ -95,5 +107,36 @@ class AdaPotStakeAccountRewardProviderTest {
         assertThat(accountInfo.orElseThrow().getStakeAddress()).isEqualTo(STAKE_ADDRESS);
         assertThat(accountInfo.orElseThrow().getWithdrawableAmount()).isEqualTo(BigInteger.valueOf(40));
         assertThat(accountInfo.orElseThrow().getPoolId()).isNull();
+    }
+
+    @Test
+    void getAccountInfoReturnsNullPoolIdWhenStakeKeyIsDeregistered() {
+        var rewardStorageReader = mock(RewardStorageReader.class);
+        var adaPotJobStorage = mock(AdaPotJobStorage.class);
+        var stakingCertificateStorageReader = mock(StakingCertificateStorageReader.class);
+        when(adaPotJobStorage.getLatestJobByTypeAndStatus(AdaPotJobType.REWARD_CALC, AdaPotJobStatus.COMPLETED))
+                .thenReturn(Optional.of(AdaPotJob.builder()
+                        .epoch(10)
+                        .type(AdaPotJobType.REWARD_CALC)
+                        .status(AdaPotJobStatus.COMPLETED)
+                        .build()));
+        when(rewardStorageReader.findWithdrawableRewardByAddress(STAKE_ADDRESS))
+                .thenReturn(WithdrawableReward.builder()
+                        .address(STAKE_ADDRESS)
+                        .withdrawableAmount(BigInteger.valueOf(40))
+                        .build());
+        when(stakingCertificateStorageReader.getRegistrationByStakeAddress(STAKE_ADDRESS, Long.MAX_VALUE))
+                .thenReturn(Optional.of(StakeRegistrationDetail.builder()
+                        .address(STAKE_ADDRESS)
+                        .type(CertificateType.STAKE_DEREGISTRATION)
+                        .build()));
+        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage, stakingCertificateStorageReader);
+
+        var accountInfo = provider.getAccountInfo(STAKE_ADDRESS);
+
+        assertThat(accountInfo).isPresent();
+        assertThat(accountInfo.orElseThrow().getWithdrawableAmount()).isEqualTo(BigInteger.valueOf(40));
+        assertThat(accountInfo.orElseThrow().getPoolId()).isNull();
+        verify(stakingCertificateStorageReader, never()).getLatestDelegationByAddress(STAKE_ADDRESS);
     }
 }

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProviderTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/AdaPotStakeAccountRewardProviderTest.java
@@ -6,6 +6,8 @@ import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
 import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
 import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorageReader;
+import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
+import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorageReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -19,14 +21,16 @@ import static org.mockito.Mockito.when;
 
 class AdaPotStakeAccountRewardProviderTest {
     private static final String STAKE_ADDRESS = "stake_test1up97ct2wt8jqlly2cnkhuwc7tvevmjpp7h6ts3rucpksy8c8cnspn";
+    private static final String POOL_HASH = "0f292d1679c3417e1e0e60a810a3e4f3e4e8e8e8e8e8e8e8e8e8e8e8e8e8e8e8";
 
     @Test
     void getAccountInfoReturnsEmptyWhenRewardCalculationHasNotCompleted() {
         var rewardStorageReader = mock(RewardStorageReader.class);
         var adaPotJobStorage = mock(AdaPotJobStorage.class);
+        var stakingCertificateStorageReader = mock(StakingCertificateStorageReader.class);
         when(adaPotJobStorage.getLatestJobByTypeAndStatus(AdaPotJobType.REWARD_CALC, AdaPotJobStatus.COMPLETED))
                 .thenReturn(Optional.empty());
-        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage);
+        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage, stakingCertificateStorageReader);
 
         var accountInfo = provider.getAccountInfo(STAKE_ADDRESS);
 
@@ -35,9 +39,10 @@ class AdaPotStakeAccountRewardProviderTest {
     }
 
     @Test
-    void getAccountInfoReturnsWithdrawableRewardWhenRewardCalculationHasCompleted() {
+    void getAccountInfoReturnsWithdrawableRewardAndPoolIdWhenDelegationExists() {
         var rewardStorageReader = mock(RewardStorageReader.class);
         var adaPotJobStorage = mock(AdaPotJobStorage.class);
+        var stakingCertificateStorageReader = mock(StakingCertificateStorageReader.class);
         when(adaPotJobStorage.getLatestJobByTypeAndStatus(AdaPotJobType.REWARD_CALC, AdaPotJobStatus.COMPLETED))
                 .thenReturn(Optional.of(AdaPotJob.builder()
                         .epoch(10)
@@ -49,12 +54,46 @@ class AdaPotStakeAccountRewardProviderTest {
                         .address(STAKE_ADDRESS)
                         .withdrawableAmount(BigInteger.valueOf(40))
                         .build());
-        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage);
+        when(stakingCertificateStorageReader.getLatestDelegationByAddress(STAKE_ADDRESS))
+                .thenReturn(Optional.of(Delegation.builder()
+                        .address(STAKE_ADDRESS)
+                        .poolId(POOL_HASH)
+                        .build()));
+        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage, stakingCertificateStorageReader);
 
         var accountInfo = provider.getAccountInfo(STAKE_ADDRESS);
 
         assertThat(accountInfo).isPresent();
         assertThat(accountInfo.orElseThrow().getStakeAddress()).isEqualTo(STAKE_ADDRESS);
         assertThat(accountInfo.orElseThrow().getWithdrawableAmount()).isEqualTo(BigInteger.valueOf(40));
+        assertThat(accountInfo.orElseThrow().getPoolId()).startsWith("pool");
+    }
+
+    @Test
+    void getAccountInfoReturnsNullPoolIdWhenNoDelegationExists() {
+        var rewardStorageReader = mock(RewardStorageReader.class);
+        var adaPotJobStorage = mock(AdaPotJobStorage.class);
+        var stakingCertificateStorageReader = mock(StakingCertificateStorageReader.class);
+        when(adaPotJobStorage.getLatestJobByTypeAndStatus(AdaPotJobType.REWARD_CALC, AdaPotJobStatus.COMPLETED))
+                .thenReturn(Optional.of(AdaPotJob.builder()
+                        .epoch(10)
+                        .type(AdaPotJobType.REWARD_CALC)
+                        .status(AdaPotJobStatus.COMPLETED)
+                        .build()));
+        when(rewardStorageReader.findWithdrawableRewardByAddress(STAKE_ADDRESS))
+                .thenReturn(WithdrawableReward.builder()
+                        .address(STAKE_ADDRESS)
+                        .withdrawableAmount(BigInteger.valueOf(40))
+                        .build());
+        when(stakingCertificateStorageReader.getLatestDelegationByAddress(STAKE_ADDRESS))
+                .thenReturn(Optional.empty());
+        var provider = new AdaPotStakeAccountRewardProvider(rewardStorageReader, adaPotJobStorage, stakingCertificateStorageReader);
+
+        var accountInfo = provider.getAccountInfo(STAKE_ADDRESS);
+
+        assertThat(accountInfo).isPresent();
+        assertThat(accountInfo.orElseThrow().getStakeAddress()).isEqualTo(STAKE_ADDRESS);
+        assertThat(accountInfo.orElseThrow().getWithdrawableAmount()).isEqualTo(BigInteger.valueOf(40));
+        assertThat(accountInfo.orElseThrow().getPoolId()).isNull();
     }
 }

--- a/applications/all/src/main/resources/application-all.properties
+++ b/applications/all/src/main/resources/application-all.properties
@@ -1,6 +1,7 @@
 ##### Configurations for graal native image with all profile #####
 
 store.account.enabled=true
+store.account.api-enabled=true
 store.account.balance-aggregation-enabled=true
 
 store.account.address-balance-enabled=true
@@ -23,3 +24,4 @@ store.epoch-aggr.epoch-calculation-enabled=true
 store.live.enabled=true
 
 store.admin.ui.enabled=true
+store.epoch-nonce.enabled=true

--- a/applications/all/src/main/resources/application-n2c.properties
+++ b/applications/all/src/main/resources/application-n2c.properties
@@ -31,3 +31,4 @@ store.governance-aggr.enabled=true
 store.governance-aggr.api-enabled=true
 
 store.admin.ui.enabled=true
+store.epoch-nonce.enabled=true

--- a/config/application-ledger-state.properties
+++ b/config/application-ledger-state.properties
@@ -1,4 +1,5 @@
 store.account.enabled=true
+store.account.api-enabled=true
 store.account.balance-aggregation-enabled=true
 store.account.history-cleanup-enabled=false
 store.account.balance-cleanup-slot-count=43200

--- a/docker/config/application-ledger-state.properties
+++ b/docker/config/application-ledger-state.properties
@@ -1,4 +1,5 @@
 store.account.enabled=true
+store.account.api-enabled=true
 store.account.balance-aggregation-enabled=true
 store.account.history-cleanup-enabled=false
 store.account.balance-cleanup-slot-count=43200

--- a/stores-api/staking-api/src/main/java/com/bloxbean/cardano/yaci/store/api/staking/controller/StakeController.java
+++ b/stores-api/staking-api/src/main/java/com/bloxbean/cardano/yaci/store/api/staking/controller/StakeController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Account Service")
+@Tag(name = "Staking Service")
 @RequestMapping("${apiPrefix}/stake")
 @ConditionalOnExpression("${store.staking.endpoints.account.enabled:true}")
 public class StakeController {

--- a/stores-api/transaction-api/src/main/java/com/bloxbean/cardano/yaci/store/api/transaction/controller/AccountWithdrawalController.java
+++ b/stores-api/transaction-api/src/main/java/com/bloxbean/cardano/yaci/store/api/transaction/controller/AccountWithdrawalController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@Tag(name = "Account Service")
+@Tag(name = "Account API")
 @RequestMapping("${apiPrefix}/accounts")
 @ConditionalOnExpression("${store.transaction.endpoints.transaction.enabled:true}")
 @RequiredArgsConstructor

--- a/stores/blocks/src/main/resources/META-INF/native-image/yaci-store-blocks/reflect-config.json
+++ b/stores/blocks/src/main/resources/META-INF/native-image/yaci-store-blocks/reflect-config.json
@@ -4,5 +4,41 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.pojos.Block",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.pojos.BlockCbor",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.pojos.Rollback",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.records.BlockRecord",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.records.BlockCborRecord",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yaci.store.blocks.jooq.tables.records.RollbackRecord",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredMethods": true
   }
 ]

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/service/LocalEpochParamService.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/service/LocalEpochParamService.java
@@ -106,7 +106,8 @@ public class LocalEpochParamService {
         }
 
         Integer epoch = epochAndTip.get()._2;
-        Optional<LocalClientProvider> localClientProvider = localClientProviderManager.getLocalClientProvider();
+        Optional<LocalClientProvider> localClientProvider
+                = localClientProviderManager != null ? localClientProviderManager.getLocalClientProvider() : Optional.empty();
 
         try {
             var localStateQueryClient = localClientProvider.map(LocalClientProvider::getLocalStateQueryClient).orElse(null);

--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/service/LocalDRepDistrService.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/service/LocalDRepDistrService.java
@@ -95,7 +95,8 @@ public class LocalDRepDistrService {
 
         Integer epoch = epochAndTip.get()._2;
         long slot = epochAndTip.get()._1.getPoint().getSlot();
-        Optional<LocalClientProvider> localClientProvider = localClientProviderManager.getLocalClientProvider();
+        Optional<LocalClientProvider> localClientProvider
+                = localClientProviderManager != null? localClientProviderManager.getLocalClientProvider() : Optional.empty();
 
         try {
             var localStateQueryClient = localClientProvider.map(LocalClientProvider::getLocalStateQueryClient).orElse(null);

--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/service/LocalGovStateService.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/service/LocalGovStateService.java
@@ -139,7 +139,8 @@ public class LocalGovStateService {
         if (localClientProviderManager == null)
             throw new IllegalStateException("LocalClientProvider is not initialized. Please check n2c configuration.");
 
-        Optional<LocalClientProvider> localClientProvider = localClientProviderManager.getLocalClientProvider();
+        Optional<LocalClientProvider> localClientProvider
+                = localClientProviderManager != null? localClientProviderManager.getLocalClientProvider(): Optional.empty();
 
         try {
             var localStateQueryClient = localClientProvider.map(LocalClientProvider::getLocalStateQueryClient).orElse(null);

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/StakingCertificateStorageReader.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/StakingCertificateStorageReader.java
@@ -12,6 +12,8 @@ public interface StakingCertificateStorageReader {
 
     List<Delegation> findDelegations(int page, int count);
 
+    Optional<Delegation> getLatestDelegationByAddress(String stakeAddress);
+
     List<String> getRegisteredStakeAddresses(Integer epoch, int page, int count);
 
     Optional<StakeRegistrationDetail> getRegistrationByStakeAddress(String stakeAddress, Long slot);

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/StakeCertificateStorageReaderImpl.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/StakeCertificateStorageReaderImpl.java
@@ -71,6 +71,12 @@ public class StakeCertificateStorageReaderImpl implements StakingCertificateStor
     }
 
     @Override
+    public Optional<Delegation> getLatestDelegationByAddress(String stakeAddress) {
+        return delegationRepository.findLatestDelegationByAddress(stakeAddress)
+                .map(mapper::toDelegation);
+    }
+
+    @Override
     public Optional<StakeRegistrationDetail> getRegistrationByPointer(long slot, int txIndex, int certIndex) {
         return registrationRepository.findRegistrationByPointer(slot, txIndex, certIndex)
                 .map(stakeRegistrationEntity -> mapper.toStakeRegistrationDetail(stakeRegistrationEntity));

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/repository/DelegationRepository.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/repository/DelegationRepository.java
@@ -8,12 +8,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DelegationRepository
         extends JpaRepository<DelegationEntity, DelegationId> {
 
     @Query("select d from DelegationEntity d")
     Slice<DelegationEntity> findDelegations(Pageable pageable);
+
+    @Query("select d from DelegationEntity d where d.address = :stakeAddress order by d.slot desc, d.txIndex desc, d.certIndex desc limit 1")
+    Optional<DelegationEntity> findLatestDelegationByAddress(String stakeAddress);
 
     int deleteBySlotGreaterThan(Long slot);
 }


### PR DESCRIPTION
- Update openapi description for endpoints in AccountController
- Update tag of AccountWithdrawalController to "Account API"
- store.account.api-enabled=true
- StakeController's tag has been changed to "Staking Service"
- Fix: populate poolId from delegation table when N2C is disabled
- Null check for localProviderManager to avoid NPE when N2C is disabled for native image
- Add epoch-nonce=true for native image build