### PR TITLE
 Fix: Add drep_pv9_stale_clear_event tables to admin-cli rollback config

### DIFF
--- a/components/dbutils/src/main/resources/rollback-ledger-state.yml
+++ b/components/dbutils/src/main/resources/rollback-ledger-state.yml
@@ -80,3 +80,17 @@ rollback:
         type: "epoch"
         column: "epoch"
         operator: ">="
+
+    - name: "drep_pv9_stale_clear_event_cache"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "pv9_max_epoch"
+        operator: ">="
+
+    - name: "drep_pv9_stale_clear_event"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "pv9_max_epoch"
+        operator: ">="

--- a/components/dbutils/src/main/resources/rollback.yml
+++ b/components/dbutils/src/main/resources/rollback.yml
@@ -329,3 +329,17 @@ rollback:
         type: "epoch"
         column: "epoch"
         operator: ">="
+
+    - name: "drep_pv9_stale_clear_event_cache"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "pv9_max_epoch"
+        operator: ">="
+
+    - name: "drep_pv9_stale_clear_event"
+      operation: "DELETE"
+      condition:
+        type: "epoch"
+        column: "pv9_max_epoch"
+        operator: ">="

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/RollbackServiceTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/RollbackServiceTest.java
@@ -78,6 +78,8 @@ class RollbackServiceTest {
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM gov_action_proposal_status WHERE epoch >= :epoch"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM gov_epoch_activity WHERE epoch >= :epoch"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM committee_state WHERE epoch >= :epoch"), any(SqlParameterSource.class));
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM drep_pv9_stale_clear_event_cache WHERE pv9_max_epoch >= :epoch"), any(SqlParameterSource.class));
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM drep_pv9_stale_clear_event WHERE pv9_max_epoch >= :epoch"), any(SqlParameterSource.class));
 
         verify(plainJdbcTemplate, times(1)).update(contains("TRUNCATE TABLE cursor_"));
         verify(jdbcTemplate, times(1)).update(contains("INSERT INTO cursor_"), any(SqlParameterSource.class));
@@ -213,6 +215,31 @@ class RollbackServiceTest {
         // Verify cursor_ and account_config were NOT modified
         verify(jdbcTemplate, never()).getJdbcTemplate();
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM assets WHERE slot > :slot"), any(SqlParameterSource.class));
+    }
+
+    @Test
+    void testExecuteRollback_WithLedgerStateYamlConfig_ShouldIncludeDrepPv9Tables() {
+        String configFilePath = "rollback-ledger-state.yml";
+        RollbackContext context = RollbackContext.builder()
+                .epoch(100)
+                .eventPublisherId(1L)
+                .rollbackLedgerState(true)
+                .build();
+
+        when(databaseUtils.tableExists(anyString())).thenReturn(true);
+        when(jdbcTemplate.queryForObject(anyString(), any(SqlParameterSource.class), any(RowMapper.class))).thenReturn(
+                createMockRollbackBlock(100, 1000L, "block_hash_123", 2000L, 50, 5)
+        );
+        when(jdbcTemplate.update(anyString(), any(SqlParameterSource.class))).thenReturn(1);
+
+        RollbackConfig config = configLoader.loadRollbackConfig(configFilePath);
+        Pair<List<TableRollbackAction>, Boolean> result = rollbackService.executeRollback(config, context);
+
+        assertNotNull(result);
+        assertTrue(result.getSecond());
+
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM drep_pv9_stale_clear_event_cache WHERE pv9_max_epoch >= :epoch"), any(SqlParameterSource.class));
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM drep_pv9_stale_clear_event WHERE pv9_max_epoch >= :epoch"), any(SqlParameterSource.class));
     }
 
     @Test

--- a/docs/pages/admin-cli/rollback.mdx
+++ b/docs/pages/admin-cli/rollback.mdx
@@ -103,6 +103,7 @@ rollback-ledger-state-data --epoch 500
 - `gov_action_proposal_status`: Governance proposal statuses
 - `epoch_param`: Epoch parameters
 - `gov_epoch_activity`, `committee_state`: Governance data
+- `drep_pv9_stale_clear_event_cache`, `drep_pv9_stale_clear_event`: DRep PV9 stale delegation cache
 
 <Callout type="info">
 This command safely rolls back ledger state without affecting core blockchain data. It updates `adapot_jobs` status to allow re-processing.


### PR DESCRIPTION
#943 
### Summary

  The `drep_pv9_stale_clear_event` and `drep_pv9_stale_clear_event_cache` tables were not included in the admin-cli rollback YAML configuration, causing stale cache data to persist after manual rollback.
  
  ### Problem

  When performing rollback via admin-cli (`rollback-data --epoch N` or `rollback-ledger-state-data --epoch N`), these two tables were skipped. The event-driven rollback (during sync) works correctly via
  `DRepPv9ClearEventCacheService.handleRollbackEvent()`, but admin-cli uses direct SQL from YAML config and does not trigger Spring events.

  After rollback, `ensureCacheReady()` sees the stale marker in `drep_pv9_stale_clear_event_cache` and skips rebuild, leading to incorrect DRep distribution snapshots.

  ### Changes
  
  - Add `drep_pv9_stale_clear_event_cache` and `drep_pv9_stale_clear_event` to `rollback.yml`
  - Add same entries to `rollback-ledger-state.yml`
  - Add test verifications for both YAML configs
  - Update admin-cli rollback docs


  ### Testing

  - `./gradlew :components:dbutils:test` — all tests pass
  - New test `testExecuteRollback_WithLedgerStateYamlConfig_ShouldIncludeDrepPv9Tables` verifies ledger-state YAML generates correct SQL

  ### Generated SQL
  
  ```sql
  DELETE FROM drep_pv9_stale_clear_event_cache WHERE pv9_max_epoch >= :epoch
  DELETE FROM drep_pv9_stale_clear_event WHERE pv9_max_epoch >= :epoch
```
