### PR TITLE
[Do Not Merge] docs(blockfrost-adr): add per-module gap tracking docs for all 11 BF modules

### DIFF
--- a/extensions/blockfrost/adr/2.1.0-pre4_release_readiness.md
+++ b/extensions/blockfrost/adr/2.1.0-pre4_release_readiness.md
@@ -1,0 +1,122 @@
+# Blockfrost Compatibility - 2.1.0-pre4 Release Readiness
+
+**Created:** 2026-05-22
+
+This note summarizes the release-readiness view across the Blockfrost compatibility modules for the
+`2.1.0-pre4` pre-release. It should be read together with the per-module gap files in this directory.
+
+## Release Position
+
+The pre-release does not need 100% Blockfrost parity. A documented 10-20% gap is acceptable when the
+gap is an accepted limitation, not a core correctness issue, and not expected to make common mainnet
+queries unusable.
+
+No Blockfrost compatibility endpoint has been performance-tested on mainnet yet. All announce
+recommendations below are therefore conditional on applying the required indexes and running targeted
+mainnet performance checks.
+
+## Module Recommendation
+
+| Module | PR | Status | 2.1.0-pre4 Recommendation | Notes |
+|--------|----|--------|----------------------------|-------|
+| Account | #836 | Merged | Announce conditionally | Good functional coverage. Main risk is performance on account UTxO, transaction, and total endpoints over `address_utxo`. |
+| Address | #784 | Merged | Announce conditionally | Good functional coverage. `/extended` has accepted metadata limitations. Mainnet performance still needs validation. |
+| Asset | #780 | Merged | Announce only after mainnet performance check | Functionally acceptable for pre-release, but it has the highest index/performance risk, especially `GET /assets` and asset holder queries over JSONB amounts. |
+| Block | #811 | Merged | Announce | Main gap is body-only CBOR format, accepted for pre-release. Also requires indexes on `address_utxo`, `transaction`, and `tx_input`. |
+| Epoch | #780 | Merged | Hold or mark experimental | `total_fees` mismatch is a correctness gap, not just an accepted limitation. |
+| Transaction | #818 | Merged | Announce conditionally | Acceptable for pre-release with documented CBOR/body-size limitations. Mainnet performance still needs validation. |
+| Governance | #865 | Open PR | Announce after PR is merged, depending on release timing | Many endpoints and dependencies. Release notes should clearly mention `governance-aggr`, N2C, and off-chain metadata limitations. |
+| Metadata | #872 | Open PR | Merge and announce if PR is green | Approved direction is acceptable. Duplicate rows after reconnect are considered a very rare, hard-to-reproduce edge case, not a release blocker. |
+| Network | #866 | Open PR | Announce after PR is merged and non-structural gaps are fixed, depending on release timing | `stake.live` and `supply.locked` are accepted limitations for pre-release. Other gaps should be resolved before announce. |
+| Pools | #847 | Open PR | Do not announce; defer if possible | Too many visible user-facing gaps for a release-highlight module, especially off-chain metadata and stake semantics. |
+| Scripts | #852 | Open PR | Merge and announce if PR is green | Only known gap is genesis-era script sync lag. This is acceptable for pre-release. |
+
+## Announce Candidates
+
+Recommended modules to announce for `2.1.0-pre4`, assuming index and mainnet smoke checks pass:
+
+- `account`
+- `address`
+- `block`
+- `transaction`
+- `governance`, if PR #865 is merged in time for the release window
+- `network`, if PR #866 is merged in time after resolving gaps other than `stake.live` and
+  `supply.locked`
+- `scripts`, if PR #852 is merged
+- `metadata`, if PR #872 is merged
+
+`asset` should be announced only if mainnet performance is acceptable after applying the required
+indexes. It is otherwise better to include it in the release as available but explicitly not
+performance-certified.
+
+`epoch` should not be announced as ready while the `total_fees` mismatch remains open. It can be
+included as experimental if the release notes clearly describe the AdaPot dependency and fee gap.
+
+## PR Merge Recommendation
+
+Recommended for next release:
+
+- #852 `scripts`: merge if CI/review is clean.
+- #872 `metadata`: merge if CI/review is clean. Duplicate rows after reconnect are rare and not
+  considered a release blocker.
+- #865 `governance`: merge if CI/review is clean and the release window allows it. Announce after
+  merge with prerequisites and limitations documented.
+- #866 `network`: merge if non-structural gaps are resolved and the release window allows it.
+  `stake.live` and `supply.locked` can remain as documented accepted limitations.
+
+Recommended to defer:
+
+- #847 `pools`
+
+## Index And Performance Note
+
+Required Blockfrost indexes should be treated as a release-readiness gate. They are not just a
+documentation detail.
+
+Even after sync reaches tip, creating indexes on mainnet is still a heavy operation. It scans large
+tables, consumes CPU and I/O, requires extra disk, generates WAL, and can affect API latency during
+creation. The mainnet size snapshot (snapshot at epoch 632) shows the largest risk tables are:
+
+| Table | Total Size |
+|-------|------------|
+| `address_utxo` | 333 GB |
+| `transaction` | 142 GB |
+| `tx_input` | 131 GB |
+| `transaction_metadata` | 57 GB |
+| `stake_address_balance` | 57 GB |
+| `transaction_scripts` | 30 GB |
+| `datum` | 28 GB |
+| `block` | 14 GB |
+| `assets` | 7.6 GB |
+
+Avoid applying indexes that do not provide meaningful query-plan improvement. Each proposed
+Blockfrost index should be tied to one or more high-risk endpoints and should be validated with
+`EXPLAIN (ANALYZE, BUFFERS)` or an equivalent mainnet query-plan check before it is treated as
+required. This is especially important for large tables such as `address_utxo`, `transaction`, and
+`tx_input`, where an extra low-value index still adds storage cost, write overhead, vacuum overhead,
+and operational risk during creation.
+
+Operational recommendation:
+
+- Apply Blockfrost indexes only after initial sync reaches tip.
+- Apply high-risk indexes separately, especially indexes on `address_utxo`, `transaction`, and
+  `tx_input`.
+- Do not apply speculative indexes by default. Promote an index to required only when there is a
+  concrete endpoint/query that benefits from it.
+- Monitor disk usage, WAL growth, locks, and `pg_stat_progress_create_index`.
+- Run mainnet smoke/performance checks after indexes are present.
+- Document which limitations are accepted and which modules remain experimental.
+
+## Pre-Release Readiness Checklist
+
+- Required PRs are merged and compile.
+- Blockfrost-specific indexes are available through `admin-cli`.
+- Required indexes are verified on the mainnet database.
+- Mainnet performance checks are run for high-risk endpoints:
+  - account: `/accounts/{stake_address}/utxos`, `/transactions`, `/addresses/total`
+  - address: `/addresses/{address}/transactions`, `/utxos`, `/total`
+  - asset: `/assets`, `/assets/{asset}/addresses`, `/assets/policy/{policy_id}`
+  - block: `/blocks/{hash_or_number}/addresses`, `/txs`, `/txs/cbor`
+  - transaction: `/txs/{hash}`, `/utxos`, `/redeemers`
+  - epoch: `/epochs/{number}/blocks`, `/stakes`
+- Release notes list accepted limitations and experimental modules clearly.

--- a/extensions/blockfrost/adr/account_gaps.md
+++ b/extensions/blockfrost/adr/account_gaps.md
@@ -1,0 +1,70 @@
+# Account Module — Gaps & Open Items
+
+**PR:** #836 | **Status:** ✅ Merged | **Endpoints:** 12 / 12 (118 / 120 field matches, 98.3%)
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /accounts/{stake_address}` | ✅ | |
+| `GET /accounts/{stake_address}/rewards` | ⚠️ | May lag by 1 row on live data (AdaPot timing) |
+| `GET /accounts/{stake_address}/history` | ✅ | |
+| `GET /accounts/{stake_address}/delegations` | ✅ | |
+| `GET /accounts/{stake_address}/registrations` | ✅ | |
+| `GET /accounts/{stake_address}/withdrawals` | ✅ | |
+| `GET /accounts/{stake_address}/mirs` | ✅ | |
+| `GET /accounts/{stake_address}/addresses` | ✅ | |
+| `GET /accounts/{stake_address}/addresses/assets` | ✅ | |
+| `GET /accounts/{stake_address}/addresses/total` | ✅ | |
+| `GET /accounts/{stake_address}/utxos` | ✅ | Cursor-based streaming to avoid heap pressure |
+| `GET /accounts/{stake_address}/transactions` | ✅ | |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **Reward row timing lag:** `GET /accounts/{stake_address}/rewards` may show 1 extra row vs.
+  Blockfrost during live sync because AdaPot materializes reward snapshots one epoch behind
+  Blockfrost's live reward exposure window. Inherent to AdaPot architecture, not a code bug.
+
+### Tracked Issues
+
+- **`withdrawable_amount` view (#897):** Issue #897 tracks creating an `account_rewards`
+  database view for precise `withdrawable_amount` calculation with same-slot tie-breaking.
+  Currently computed inline — may cause subtle discrepancies when withdrawal and reward rows
+  share the same slot.
+
+## Indexes
+
+```sql
+-- Already in index.yml — verify before applying:
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_stake_addr
+    ON address_utxo (owner_stake_addr);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_withdrawal_address
+    ON withdrawal (address);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_withdrawal_address_slot
+    ON withdrawal (address, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_instant_reward_address_slot
+    ON instant_reward (address, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reward_rest_address_slot
+    ON reward_rest (address, slot);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.account.enabled=true` | All account endpoints |
+| `store.account.enabled=true` | Balance fields |
+| `store.account.stake-address-balance-enabled=true` | `controlled_amount` field |
+| `store.adapot.enabled=true` | Rewards, history data |
+| `store.governance.enabled=true` | DRep delegation fields |
+
+## Release Notes
+
+No functional blockers. The reward timing lag is inherent to AdaPot architecture.
+Issue #897 (`withdrawable_amount` view) is the only outstanding tracked item.

--- a/extensions/blockfrost/adr/address_gaps.md
+++ b/extensions/blockfrost/adr/address_gaps.md
@@ -1,75 +1,85 @@
-# Address Module — Gaps & Open Items
+# Address Module — Status & Gaps
 
-**PR:** #784 | **Status:** ✅ Merged | **Endpoints:** 6 / 6
+**PR:** #784 · **Status:** ✅ Merged · **Endpoints:** 6 / 6
+Validated endpoint-by-endpoint against live Blockfrost using `scripts/compare-blockfrost`.
 
-## Endpoint Status
+## Status
 
-| Endpoint | Match | Notes |
-|----------|-------|-------|
-| `GET /addresses/{address}` | ✅ | Falls back to `address_utxo` sum when account aggregation disabled. Whale: bounded 500 (see below) |
-| `GET /addresses/{address}/extended` | ⚠️ | `decimals` and `has_nft_onchain_metadata` missing (CIP-68). Whale: bounded 500 |
-| `GET /addresses/{address}/utxos` | ✅ | Includes `tx_index`; `data_hash` derived for inline datums; ordered `(slot, tx_index, output_index)`. Whale: bounded 500 |
-| `GET /addresses/{address}/utxos/{asset}` | ✅ | Same as `/utxos` |
-| `GET /addresses/{address}/transactions` | ✅ | Two-phase paging; `from`/`to` as `block[:txIndex]`. Whale: bounded 500 |
-| `GET /addresses/{address}/total` | ✅ | JSONB aggregation by unit. Whale: bounded 500 |
+All six address endpoints are implemented and return Blockfrost-compatible responses. Two
+things to be aware of: `/extended` can't fill two CIP-68 fields, and very large ("whale")
+accounts hit a deliberate timeout. Both are explained under **Open Gaps** and **Limitations**.
 
-## Performance
+| Endpoint | Status | Notes |
+|----------|--------|-------|
+| `GET /addresses/{address}` | ✅ | Falls back to summing `address_utxo` when account aggregation is off |
+| `GET /addresses/{address}/extended` | ⚠️ | Missing `decimals` and `has_nft_onchain_metadata` (needs CIP-68) |
+| `GET /addresses/{address}/utxos` | ✅ | Ordered `(slot, tx_hash, output_index)`; `data_hash` derived for inline datums |
+| `GET /addresses/{address}/utxos/{asset}` | ✅ | Same behavior as `/utxos`, filtered by asset |
+| `GET /addresses/{address}/transactions` | ✅ | Two-phase paging; supports `from`/`to` as `block[:txIndex]` |
+| `GET /addresses/{address}/total` | ✅ | Received/sent totals aggregated by unit |
 
-Benchmarked vs official Blockfrost via `scripts/compare-blockfrost` (drift-isolated against
-live DBs). Yaci is consistently faster than Blockfrost on normal addresses (Blockfrost numbers
-are public-endpoint round-trips, shown for reference).
+## Performance (per network)
 
-| Network | `/transactions` (normal) | `/utxos` order vs BF | Yaci latency | Blockfrost latency |
-|---------|--------------------------|----------------------|--------------|--------------------|
-| mainnet | OK, 0 diffs | match (3 same-slot trigger addrs) | sub-second | ~0.4–1.4 s |
-| preprod | OK, 0 diffs | match (2 trigger addrs) | ~40–125 ms | ~0.37–1.4 s |
-| preview | OK, 0 diffs | match | ~40–65 ms | ~0.37–0.78 s |
+Benchmarked against official Blockfrost on live databases. On normal addresses Yaci is
+consistently faster (the Blockfrost figures are public-endpoint round-trips, shown only for
+reference).
 
-- **`/transactions` restructure:** two-phase paging (aggregate distinct tx hashes without the
-  `transaction` join, then join only the ≤ page rows) cut the planner cost **157M → 35M** on a
-  ~4M-UTXO mainnet whale and removed full-table seq scans over `transaction` (~51M) and
-  `tx_input` (~336M).
-- **`/utxos` ordering:** `(slot, tx_index, output_index)` via an index-only plan
-  (`idx_address_utxo_owner_addr` → `tx_input_pkey` anti-join → `transaction_pkey` join); no seq
-  scans; sub-100 ms on normal addresses.
-- **Whale ceiling:** for multi-million-UTXO addresses `/transactions`, `/utxos`, `/total` and the
-  balance endpoints exceed the query timeout and return a **bounded 500** (~15 s). The
-  full-history aggregation (`ORDER BY max(block)`) cannot be paged cheaply on the read path; the
-  timeout trades a connection-pool-exhausting hang for a fast per-request failure.
-- **Path to O(page):** a writer-maintained per-`(address, tx)` row carrying `tx_index`, indexed
-  `(address, block, tx_index)`, removes the aggregation and makes whale paging O(page). Writer-side,
-  out of read-path scope.
+| Network | Result | Yaci latency | Blockfrost latency |
+|---------|--------|--------------|--------------------|
+| mainnet | All endpoints match, 0 diffs | sub-second | ~0.4–1.4 s |
+| preprod | All endpoints match, 0 diffs | ~40–125 ms | ~0.37–1.4 s |
+| preview | All endpoints match, 0 diffs | ~40–65 ms  | ~0.37–0.78 s |
+
+Highlights:
+
+- **`/transactions` was restructured** into two-phase paging (collect the page of distinct tx
+  hashes first, then look up only those rows). On a ~4M-UTXO mainnet whale this cut the query
+  planner cost from **157M → 35M** and removed full-table scans over `transaction` and `tx_input`.
+- **`/utxos` runs index-only** (owner index → unspent anti-join) and stays under ~100 ms on
+  normal addresses.
 
 ## Open Gaps
 
-### Accepted Limitations
+- **CIP-68 fields in `/extended`** — `decimals` and `has_nft_onchain_metadata` can't be returned
+  because the indexer doesn't ingest CIP-68 metadata. No fix planned unless CIP-68 ingestion is
+  added to the store.
+- **Balance fallback when `store.account.enabled=false`** — balances are summed live from
+  `address_utxo`, so during a rollback they can differ from Blockfrost until re-indexing catches up.
 
-- **`/extended` mirrors base response:** `decimals` and `has_nft_onchain_metadata` are unavailable
-  because the indexer does not ingest CIP-68 metadata. No fix planned unless CIP-68 ingestion
-  is added to the store.
+## Limitations
 
-- **`address_utxo` fallback:** When `store.account.enabled=false`, balance fields aggregate live
-  from `address_utxo`. Values will differ from Blockfrost during rollbacks until re-indexed.
+These are intentional trade-offs, not bugs. None of them lose or duplicate data.
 
-## Indexes
+- **`/transactions` ordering at a page boundary** — pages are always complete and non-overlapping.
+  The only edge case: when one block has several of the address's transactions *and* it sits right
+  on a page boundary, the split between those two pages follows `tx_hash` instead of on-chain
+  `tx_index`, so a few transactions can appear slightly out of order across that one boundary.
+- **`/utxos` ordering within a block** — Blockfrost's order for UTXOs in the *same* block can't be
+  reproduced from the columns we store, so `tx_hash` is used as a stable tie-break. Ordering across
+  different blocks always matches Blockfrost.
+- **Whale accounts** — for multi-million-UTXO addresses, the heavier endpoints (`/transactions`,
+  `/utxos`, `/total`, balances) hit a ~15 s query timeout and return a fast `500` instead of hanging.
 
-The base migration (`V0_200_1__init.sql`) creates only `idx_address_utxo_slot` and
-`idx_reference_script_hash` on `address_utxo` — it has **no owner-based index**. The indexes the
-address endpoints rely on were **added on top of the migration** (via `index.yml`, applied by the
-dbutils index service, and some manually during testing); they are not part of the schema migration.
+**Long-term fix for all three:** store `tx_index` directly on `address_utxo` at write time, indexed
+`(owner_addr, block, tx_index, output_index)`. That gives exact on-chain ordering in a single cheap
+query and makes whale paging scale per-page.
 
-**Required for the address endpoints:**
+## Indexes Proposed
 
-| Index | Columns | Purpose | Source |
-|-------|---------|---------|--------|
-| `idx_address_utxo_owner_addr` | `owner_addr` | avoids a full table scan on every address endpoint | `index.yml` |
-| `idx_address_utxo_owner_addr_full` | `owner_addr_full` | Byron-length addresses | **manual** — not in `index.yml` (present on preprod, absent on mainnet) |
-| `idx_address_utxo_owner_stake_addr` | `owner_stake_addr` | stake-address utxo endpoints | `index.yml` |
-| `idx_address_utxo_owner_paykey_hash` / `idx_address_utxo_owner_stakekey_hash` | credential cols | payment/stake-credential endpoints | `index.yml` |
+The base migration (`V0_200_1__init.sql`) ships only `idx_address_utxo_slot` and
+`idx_reference_script_hash` — there is **no owner-based index**. The address endpoints depend on the
+owner indexes below, which are added *on top of* the migration (via `index.yml` / the dbutils index
+service). Use `CONCURRENTLY` so the live table isn't write-locked, and run each statement on its own.
+
+| Index | Columns | Why it's needed |
+|-------|---------|-----------------|
+| `idx_address_utxo_owner_addr` | `owner_addr` | avoids a full scan on every address endpoint |
+| `idx_address_utxo_owner_addr_full` | `owner_addr_full` | Byron-length addresses (apply manually — not in `index.yml`) |
+| `idx_address_utxo_owner_stake_addr` | `owner_stake_addr` | stake-address UTXO endpoints |
+| `idx_address_utxo_owner_paykey_hash` | `owner_payment_credential` | payment-credential endpoints |
+| `idx_address_utxo_owner_stakekey_hash` | `owner_stake_credential` | stake-credential endpoints |
 
 ```sql
--- Added on top of the base migration. CONCURRENTLY avoids a write lock on the live table;
--- run each statement on its own (CONCURRENTLY cannot run inside a transaction block).
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_addr
     ON address_utxo (owner_addr);
 
@@ -87,55 +97,20 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_stakekey_hash
     ON address_utxo (owner_stake_credential);
 ```
 
-The new `/utxos` and two-phase `/transactions` queries need **no additional `address_utxo`
-index** — they ride existing primary keys: `transaction_pkey (tx_hash)` for the `tx_index` join
-and `tx_input_pkey (output_index, tx_hash)` for the unspent anti-join (EXPLAIN is seq-scan-free).
+Notes:
 
-**Tested but not adopted:** `idx_address_utxo_owner_slot (owner_addr, slot)` was added during perf
-testing but no query exploits the `slot` column (EXPLAIN still prefers `owner_addr` + sort), so it
-gives no benefit — do not add it.
-
-## Known limitation: transaction ordering at page boundaries
-
-The `/addresses/{address}/transactions` endpoint returns transactions in pages. Internally it
-builds each page in two steps:
-
-1. **Pick the page** — list the address's transactions ordered by `(block, tx_hash)` and apply
-   the requested limit/offset.
-2. **Sort the page** — re-sort just those transactions by their real on-chain position
-   `(block, tx_index)`.
-
-**You never lose or see a duplicate transaction.** Because every `tx_hash` is unique, step 1
-gives a stable, well-defined order, so each page holds a distinct slice of the history — no
-gaps, no overlaps.
-
-**The one edge case:** if a single block contains several of the address's transactions, and
-that block happens to land right on a page boundary, the split between the two pages is decided
-by `tx_hash` instead of `tx_index`. Each page is still sorted correctly on its own, but the
-hand-off between the two pages may not follow the exact on-chain order.
-
-> Real example (mainnet): address `addr1q93k6…3cc3k8`, block 13520853 contains 49 of its
-> transactions, and their `tx_hash` order has no relation to their `tx_index` order. A page
-> boundary falling inside this block would reorder a few transactions across the two pages.
-
-**Why we accept it:** sorting strictly by `tx_index` first would force a `transaction` lookup
-for *every* transaction of the address — not just the 100 on the page. On large accounts that's
-measurably slower and only gets worse as the account grows, all for a rare, cosmetic ordering
-quirk.
-
-**Future fix:** store `tx_index` directly on `address_utxo` at write time, with an index on
-`(owner_addr, block, tx_index, output_index)`. Then this endpoint can return the exact on-chain
-order in a single, cheap query — and `/utxos` would no longer need a join either.
+- The `/utxos` and two-phase `/transactions` queries need **no extra `address_utxo` index** — they
+  ride existing primary keys (`tx_input_pkey`, `transaction_pkey`) and are seq-scan-free in EXPLAIN.
 
 ## Configuration
 
-| Property | Required For |
-|----------|-------------|
-| `store.extensions.blockfrost.address.enabled=true` | All address endpoints |
-| `store.account.enabled=true` | Accurate balance in `/addresses/{address}` |
-| `store.account.stake-address-balance-enabled=true` | `controlled_amount` field |
+| Property | Required for |
+|----------|--------------|
+| `store.extensions.blockfrost.address.enabled=true` | all address endpoints |
+| `store.account.enabled=true` | accurate balance in `/addresses/{address}` |
+| `store.account.stake-address-balance-enabled=true` | the `controlled_amount` field |
 
 ## Release Notes
 
-No functional blockers. The `extended` limitation is accepted (requires CIP-68 ingestion).
-Module is production-ready with correct index configuration.
+No functional blockers. The `/extended` CIP-68 gap is accepted. The module is production-ready with
+the owner indexes above in place.

--- a/extensions/blockfrost/adr/address_gaps.md
+++ b/extensions/blockfrost/adr/address_gaps.md
@@ -1,0 +1,52 @@
+# Address Module — Gaps & Open Items
+
+**PR:** #784 | **Status:** ✅ Merged | **Endpoints:** 6 / 6
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /addresses/{address}` | ✅ | Falls back to `address_utxo` sum when account aggregation disabled |
+| `GET /addresses/{address}/extended` | ⚠️ | Mirrors base response; `decimals` and `has_nft_onchain_metadata` missing |
+| `GET /addresses/{address}/utxos` | ✅ | |
+| `GET /addresses/{address}/utxos/{asset}` | ✅ | |
+| `GET /addresses/{address}/transactions` | ✅ | Supports `from`/`to` with `block[:txIndex]` format |
+| `GET /addresses/{address}/total` | ✅ | JSONB aggregation by unit |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **`/extended` mirrors base response:** `decimals` and `has_nft_onchain_metadata` are unavailable
+  because the indexer does not ingest CIP-68 metadata. No fix planned unless CIP-68 ingestion
+  is added to the store.
+
+- **`address_utxo` fallback:** When `store.account.enabled=false`, balance fields aggregate live
+  from `address_utxo`. Values will differ from Blockfrost during rollbacks until re-indexed.
+
+## Indexes
+
+```sql
+-- Prevents full table scan on address_utxo for all address endpoints
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_addr
+    ON address_utxo (owner_addr);
+
+-- Needed for Byron-length addresses
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_addr_full
+    ON address_utxo (owner_addr_full);
+```
+
+> `idx_address_utxo_owner_stake_addr` is already included in `index.yml`.
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.address.enabled=true` | All address endpoints |
+| `store.account.enabled=true` | Accurate balance in `/addresses/{address}` |
+| `store.account.stake-address-balance-enabled=true` | `controlled_amount` field |
+
+## Release Notes
+
+No functional blockers. The `extended` limitation is accepted (requires CIP-68 ingestion).
+Module is production-ready with correct index configuration.

--- a/extensions/blockfrost/adr/address_gaps.md
+++ b/extensions/blockfrost/adr/address_gaps.md
@@ -6,12 +6,39 @@
 
 | Endpoint | Match | Notes |
 |----------|-------|-------|
-| `GET /addresses/{address}` | ✅ | Falls back to `address_utxo` sum when account aggregation disabled |
-| `GET /addresses/{address}/extended` | ⚠️ | Mirrors base response; `decimals` and `has_nft_onchain_metadata` missing |
-| `GET /addresses/{address}/utxos` | ✅ | |
-| `GET /addresses/{address}/utxos/{asset}` | ✅ | |
-| `GET /addresses/{address}/transactions` | ✅ | Supports `from`/`to` with `block[:txIndex]` format |
-| `GET /addresses/{address}/total` | ✅ | JSONB aggregation by unit |
+| `GET /addresses/{address}` | ✅ | Falls back to `address_utxo` sum when account aggregation disabled. Whale: bounded 500 (see below) |
+| `GET /addresses/{address}/extended` | ⚠️ | `decimals` and `has_nft_onchain_metadata` missing (CIP-68). Whale: bounded 500 |
+| `GET /addresses/{address}/utxos` | ✅ | Includes `tx_index`; `data_hash` derived for inline datums; ordered `(slot, tx_index, output_index)`. Whale: bounded 500 |
+| `GET /addresses/{address}/utxos/{asset}` | ✅ | Same as `/utxos` |
+| `GET /addresses/{address}/transactions` | ✅ | Two-phase paging; `from`/`to` as `block[:txIndex]`. Whale: bounded 500 |
+| `GET /addresses/{address}/total` | ✅ | JSONB aggregation by unit. Whale: bounded 500 |
+
+## Performance
+
+Benchmarked vs official Blockfrost via `scripts/compare-blockfrost` (drift-isolated against
+live DBs). Yaci is consistently faster than Blockfrost on normal addresses (Blockfrost numbers
+are public-endpoint round-trips, shown for reference).
+
+| Network | `/transactions` (normal) | `/utxos` order vs BF | Yaci latency | Blockfrost latency |
+|---------|--------------------------|----------------------|--------------|--------------------|
+| mainnet | OK, 0 diffs | match (3 same-slot trigger addrs) | sub-second | ~0.4–1.4 s |
+| preprod | OK, 0 diffs | match (2 trigger addrs) | ~40–125 ms | ~0.37–1.4 s |
+| preview | OK, 0 diffs | match | ~40–65 ms | ~0.37–0.78 s |
+
+- **`/transactions` restructure:** two-phase paging (aggregate distinct tx hashes without the
+  `transaction` join, then join only the ≤ page rows) cut the planner cost **157M → 35M** on a
+  ~4M-UTXO mainnet whale and removed full-table seq scans over `transaction` (~51M) and
+  `tx_input` (~336M).
+- **`/utxos` ordering:** `(slot, tx_index, output_index)` via an index-only plan
+  (`idx_address_utxo_owner_addr` → `tx_input_pkey` anti-join → `transaction_pkey` join); no seq
+  scans; sub-100 ms on normal addresses.
+- **Whale ceiling:** for multi-million-UTXO addresses `/transactions`, `/utxos`, `/total` and the
+  balance endpoints exceed the query timeout and return a **bounded 500** (~15 s). The
+  full-history aggregation (`ORDER BY max(block)`) cannot be paged cheaply on the read path; the
+  timeout trades a connection-pool-exhausting hang for a fast per-request failure.
+- **Path to O(page):** a writer-maintained per-`(address, tx)` row carrying `tx_index`, indexed
+  `(address, block, tx_index)`, removes the aggregation and makes whale paging O(page). Writer-side,
+  out of read-path scope.
 
 ## Open Gaps
 
@@ -26,17 +53,47 @@
 
 ## Indexes
 
+The base migration (`V0_200_1__init.sql`) creates only `idx_address_utxo_slot` and
+`idx_reference_script_hash` on `address_utxo` — it has **no owner-based index**. The indexes the
+address endpoints rely on were **added on top of the migration** (via `index.yml`, applied by the
+dbutils index service, and some manually during testing); they are not part of the schema migration.
+
+**Required for the address endpoints:**
+
+| Index | Columns | Purpose | Source |
+|-------|---------|---------|--------|
+| `idx_address_utxo_owner_addr` | `owner_addr` | avoids a full table scan on every address endpoint | `index.yml` |
+| `idx_address_utxo_owner_addr_full` | `owner_addr_full` | Byron-length addresses | **manual** — not in `index.yml` (present on preprod, absent on mainnet) |
+| `idx_address_utxo_owner_stake_addr` | `owner_stake_addr` | stake-address utxo endpoints | `index.yml` |
+| `idx_address_utxo_owner_paykey_hash` / `idx_address_utxo_owner_stakekey_hash` | credential cols | payment/stake-credential endpoints | `index.yml` |
+
 ```sql
--- Prevents full table scan on address_utxo for all address endpoints
+-- Added on top of the base migration. CONCURRENTLY avoids a write lock on the live table;
+-- run each statement on its own (CONCURRENTLY cannot run inside a transaction block).
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_addr
     ON address_utxo (owner_addr);
 
--- Needed for Byron-length addresses
+-- Byron-length addresses (not in index.yml; apply manually where needed).
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_addr_full
     ON address_utxo (owner_addr_full);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_stake_addr
+    ON address_utxo (owner_stake_addr);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_paykey_hash
+    ON address_utxo (owner_payment_credential);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_owner_stakekey_hash
+    ON address_utxo (owner_stake_credential);
 ```
 
-> `idx_address_utxo_owner_stake_addr` is already included in `index.yml`.
+The new `/utxos` and two-phase `/transactions` queries need **no additional `address_utxo`
+index** — they ride existing primary keys: `transaction_pkey (tx_hash)` for the `tx_index` join
+and `tx_input_pkey (output_index, tx_hash)` for the unspent anti-join (EXPLAIN is seq-scan-free).
+
+**Tested but not adopted:** `idx_address_utxo_owner_slot (owner_addr, slot)` was added during perf
+testing but no query exploits the `slot` column (EXPLAIN still prefers `owner_addr` + sort), so it
+gives no benefit — do not add it.
 
 ## Configuration
 

--- a/extensions/blockfrost/adr/address_gaps.md
+++ b/extensions/blockfrost/adr/address_gaps.md
@@ -95,6 +95,38 @@ and `tx_input_pkey (output_index, tx_hash)` for the unspent anti-join (EXPLAIN i
 testing but no query exploits the `slot` column (EXPLAIN still prefers `owner_addr` + sort), so it
 gives no benefit — do not add it.
 
+## Known limitation: transaction ordering at page boundaries
+
+The `/addresses/{address}/transactions` endpoint returns transactions in pages. Internally it
+builds each page in two steps:
+
+1. **Pick the page** — list the address's transactions ordered by `(block, tx_hash)` and apply
+   the requested limit/offset.
+2. **Sort the page** — re-sort just those transactions by their real on-chain position
+   `(block, tx_index)`.
+
+**You never lose or see a duplicate transaction.** Because every `tx_hash` is unique, step 1
+gives a stable, well-defined order, so each page holds a distinct slice of the history — no
+gaps, no overlaps.
+
+**The one edge case:** if a single block contains several of the address's transactions, and
+that block happens to land right on a page boundary, the split between the two pages is decided
+by `tx_hash` instead of `tx_index`. Each page is still sorted correctly on its own, but the
+hand-off between the two pages may not follow the exact on-chain order.
+
+> Real example (mainnet): address `addr1q93k6…3cc3k8`, block 13520853 contains 49 of its
+> transactions, and their `tx_hash` order has no relation to their `tx_index` order. A page
+> boundary falling inside this block would reorder a few transactions across the two pages.
+
+**Why we accept it:** sorting strictly by `tx_index` first would force a `transaction` lookup
+for *every* transaction of the address — not just the 100 on the page. On large accounts that's
+measurably slower and only gets worse as the account grows, all for a rare, cosmetic ordering
+quirk.
+
+**Future fix:** store `tx_index` directly on `address_utxo` at write time, with an index on
+`(owner_addr, block, tx_index, output_index)`. Then this endpoint can return the exact on-chain
+order in a single, cheap query — and `/utxos` would no longer need a join either.
+
 ## Configuration
 
 | Property | Required For |

--- a/extensions/blockfrost/adr/asset_gaps.md
+++ b/extensions/blockfrost/adr/asset_gaps.md
@@ -6,7 +6,7 @@
 
 | Endpoint | Match | Notes |
 |----------|-------|-------|
-| `GET /assets` | ⚠️ | Pagination drift from phantom assets; slow without summary table |
+| `GET /assets` | ⚠️ | Slow without summary table |
 | `GET /assets/{asset}` | ⚠️ | `metadata` and `onchain_metadata` fields null |
 | `GET /assets/{asset}/history` | ✅ | |
 | `GET /assets/{asset}/txs` | ✅ | |
@@ -20,9 +20,6 @@
 
 - **Metadata fields null:** `metadata` and `onchain_metadata` are always `null` — no token
   registry or CIP-68 metadata ingestion is implemented. Requires a separate integration component.
-
-- **Phantom asset pagination drift:** 2 phantom assets in preprod data cause a 1-row shift
-  on paginated results. Root cause is a preprod data inconsistency, not a query bug.
 
 - **`asset_name` as hex:** Returned as hex substring of `unit` (chars 57+) to match Blockfrost
   convention. Intentional.
@@ -71,3 +68,5 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_tx_hash_tx_index
 
 No functional blockers. Performance of `GET /assets` is the main open item.
 Metadata fields gap is accepted (requires separate integration work).
+Phantom asset pagination drift (previously noted for 2 preprod assets) was resolved
+as part of the invalid-tx fix.

--- a/extensions/blockfrost/adr/asset_gaps.md
+++ b/extensions/blockfrost/adr/asset_gaps.md
@@ -1,0 +1,73 @@
+# Asset Module — Gaps & Open Items
+
+**PR:** #780 | **Status:** ✅ Merged | **Endpoints:** 7 / 7
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /assets` | ⚠️ | Pagination drift from phantom assets; slow without summary table |
+| `GET /assets/{asset}` | ⚠️ | `metadata` and `onchain_metadata` fields null |
+| `GET /assets/{asset}/history` | ✅ | |
+| `GET /assets/{asset}/txs` | ✅ | |
+| `GET /assets/{asset}/transactions` | ✅ | |
+| `GET /assets/{asset}/addresses` | ✅ | |
+| `GET /assets/policy/{policy_id}` | ✅ | |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **Metadata fields null:** `metadata` and `onchain_metadata` are always `null` — no token
+  registry or CIP-68 metadata ingestion is implemented. Requires a separate integration component.
+
+- **Phantom asset pagination drift:** 2 phantom assets in preprod data cause a 1-row shift
+  on paginated results. Root cause is a preprod data inconsistency, not a query bug.
+
+- **`asset_name` as hex:** Returned as hex substring of `unit` (chars 57+) to match Blockfrost
+  convention. Intentional.
+
+### Tracked Issues
+
+- **`GET /assets` performance:** Response time ~2.5 s warm. Proper fix is a materialized
+  `asset_first_mint` summary table to bring this under 10 ms (no issue number yet).
+
+## Indexes
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_amounts
+    ON address_utxo USING GIN (amounts);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_slot
+    ON assets (unit, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_policy
+    ON assets (unit, policy);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_qty
+    ON assets (unit, quantity);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_policy
+    ON assets (policy);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_mint_unit_slot
+    ON assets_mint (unit, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_mint_slot_tx_hash
+    ON assets_mint (slot, tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_tx_hash_tx_index
+    ON transaction (tx_hash, tx_index);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.asset.enabled=true` | All asset endpoints |
+| PostgreSQL | JSONB GIN index and lateral expansion required |
+
+## Release Notes
+
+No functional blockers. Performance of `GET /assets` is the main open item.
+Metadata fields gap is accepted (requires separate integration work).

--- a/extensions/blockfrost/adr/asset_gaps.md
+++ b/extensions/blockfrost/adr/asset_gaps.md
@@ -1,72 +1,97 @@
-# Asset Module — Gaps & Open Items
+# Blockfrost Asset Module
 
-**PR:** #780 | **Status:** ✅ Merged | **Endpoints:** 7 / 7
+**Endpoints:** 7 / 7 implemented
+**Verified:** 2026-06-10 against live Blockfrost on preprod, preview and mainnet, including extreme units
+(a 994k-event mainnet token, a 122k-event preview token, a 292k-asset policy, a 3,939-holder token).
 
-## Endpoint Status
+## Endpoint status
 
 | Endpoint | Match | Notes |
 |----------|-------|-------|
-| `GET /assets` | ⚠️ | Slow without summary table |
-| `GET /assets/{asset}` | ⚠️ | `metadata` and `onchain_metadata` fields null |
-| `GET /assets/{asset}/history` | ✅ | |
-| `GET /assets/{asset}/txs` | ✅ | |
-| `GET /assets/{asset}/transactions` | ✅ | |
-| `GET /assets/{asset}/addresses` | ✅ | |
-| `GET /assets/policy/{policy_id}` | ✅ | |
+| `GET /assets` | ✅ | Order matches Blockfrost. ~6 s at mainnet scale (15M mint rows) — summary table planned. |
+| `GET /assets/{asset}` | ⚠️ | Correct except `metadata` / `onchain_metadata` / `onchain_metadata_standard` are `null` (see Known differences). Fast: 147–282 ms on testnets, ~3.7 s on a 994k-event mainnet unit. |
+| `GET /assets/{asset}/history` | ✅ | Order and burn sign match the live API. |
+| `GET /assets/{asset}/txs` | ✅ | Matches. Deprecated upstream in the Blockfrost OpenAPI. |
+| `GET /assets/{asset}/transactions` | ✅ | Matches. |
+| `GET /assets/{asset}/addresses` | ✅ | Order matches (including the asymmetric `desc`). Slow on huge units — see Open items. |
+| `GET /assets/policy/{policy_id}` | ✅ | Matches; sub-second warm on every network, including a 292k-asset mainnet policy. |
 
-## Open Gaps
+## How ordering works
 
-### Accepted Limitations
+Blockfrost orders rows within a block by `tx_index`, so every query joins `transaction` where needed:
 
-- **Metadata fields null:** `metadata` and `onchain_metadata` are always `null` — no token
-  registry or CIP-68 metadata ingestion is implemented. Requires a separate integration component.
+- **`/history`** — events ordered by `(slot, tx_index)`.
+- **`/txs` & `/transactions`** — transactions ordered by `(slot, tx_index)`.
+- **`/addresses`** — asc keys each holder on its **earliest** unspent UTXO `(slot, tx_index, output_index)`,
+  desc on its **latest**. Because the two directions look at different UTXOs, desc is *not* asc reversed.
+  Address is the final tie-break.
+- **`/policy` & `/assets`** — assets ordered by their first mint `(slot, tx_index, unit)`.
 
-- **`asset_name` as hex:** Returned as hex substring of `unit` (chars 57+) to match Blockfrost
-  convention. Intentional.
+`tx_index` is unique within a block, so these keys are fully deterministic. The only `tx_index = NULL` rows
+in the data are genesis distribution entries, which cannot carry native assets and never enter these queries.
 
-### Tracked Issues
+On Postgres, the paginated queries use a **slot-window** plan: pick the page's slot range cheaply first, then
+join `transaction` and aggregate only for the rows in that range. This keeps deep pages as fast as page 1.
+The `/policy` query additionally exploits that `unit` is policy-prefixed, so its first-mint pass runs as a
+unit-range scan on the partial mint index.
 
-- **`GET /assets` performance:** Response time ~2.5 s warm. Proper fix is a materialized
-  `asset_first_mint` summary table to bring this under 10 ms (no issue number yet).
+## Known differences vs Blockfrost (accepted)
 
-## Indexes
+- **`metadata`, `onchain_metadata`, `onchain_metadata_standard` are `null`** — token-registry / CIP-25 / CIP-68
+  ingestion is not implemented. This is the single remaining `--strict` diff on every network.
+
+## Required indexes
 
 ```sql
+-- Unit containment for /addresses, /txs, /transactions
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_amounts
     ON address_utxo USING GIN (amounts);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_slot
-    ON assets (unit, slot);
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_policy
-    ON assets (unit, policy);
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_qty
-    ON assets (unit, quantity);
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_policy
-    ON assets (policy);
-
+-- First-mint scans for /assets and /policy
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_mint_unit_slot
-    ON assets_mint (unit, slot);
+    ON assets (unit, slot) WHERE mint_type = 'MINT';
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_mint_slot_tx_hash
-    ON assets_mint (slot, tx_hash);
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_tx_hash_tx_index
-    ON transaction (tx_hash, tx_index);
+-- Makes all per-unit assets reads index-only (/assets/{asset}, /history, quantity sums)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_assets_unit_covering
+    ON assets (unit, slot)
+    INCLUDE (tx_hash, mint_type, quantity, policy, asset_name, fingerprint);
 ```
+
+Joins rely on the table primary keys (`transaction_pkey`, `tx_input_pkey`, `address_utxo_pkey`).
+Sizes on mainnet: GIN 32 GB, partial mint 1.8 GB, covering 6.5 GB.
+
+After the covering index, `idx_assets_unit_slot`, `idx_assets_unit_policy` and `idx_assets_policy` are
+redundant for this module and can be dropped (~4.4 GB on mainnet) if nothing else uses them.
+
+## Performance (measured 2026-06-10, heaviest unit per network)
+
+| Endpoint | preview (122k ev.) | preprod (100k ev.) | mainnet (994k ev.) | Blockfrost (same units) |
+|----------|--------------------|--------------------|--------------------|--------------------------|
+| `/assets/{asset}` | 282 ms | 147 ms | 3.7 s | 0.9–2.5 s |
+| `/history` | ~400 ms | ~175 ms | ~4 s | 0.7–3.5 s |
+| `/txs` | ~1.4 s | ~200 ms | ~6.3 s | 0.3–0.7 s |
+| `/transactions` | ~1.45 s | ~200 ms | ~6.3 s | 0.5–1.6 s |
+| `/addresses` | 2.1–2.5 s | ~0.5 s | 8.8–10.8 s | 0.4–2.5 s |
+| `/policy` | 61–99 ms | 55–112 ms | 0.8–1.05 s | 0.44–3.7 s |
+
+A **normal** asset (a 2-event mainnet token) is 170–760 ms on every endpoint and beats Blockfrost on most.
+The multi-second numbers above are worst-case units only.
+
+## Open items
+
+- **Summary tables for mainnet scale.** The remaining floors are all "scan everything about a huge unit once"
+  costs that indexes cannot remove:
+  - `/assets` list (~6 s): `DISTINCT ON` over 15M mint rows → needs a per-unit / first-mint summary table.
+  - `/txs`, `/transactions` (~6 s) and `/addresses` (~9–11 s): GIN scan + per-row work over ~1M UTXOs → needs a
+    holder / per-unit-tx summary table.
+  - `/history` (~4 s): the slot-window CTE still materializes all events of the unit once per call.
+- **Asset metadata ingestion** (token registry, CIP-25, CIP-68) — separate component; removes the last
+  `--strict` diff.
 
 ## Configuration
 
-| Property | Required For |
-|----------|-------------|
-| `store.extensions.blockfrost.asset.enabled=true` | All asset endpoints |
-| PostgreSQL | JSONB GIN index and lateral expansion required |
-
-## Release Notes
-
-No functional blockers. Performance of `GET /assets` is the main open item.
-Metadata fields gap is accepted (requires separate integration work).
-Phantom asset pagination drift (previously noted for 2 preprod assets) was resolved
-as part of the invalid-tx fix.
+| Property | Required for |
+|----------|--------------|
+| `store.extensions.blockfrost.enabled=true` | **All** blockfrost endpoints — master gate; sub-modules default to on when it is set. Without it no blockfrost route is registered. |
+| `store.extensions.blockfrost.asset.enabled=true` | Asset endpoints (default on when the master gate is set). |
+| PostgreSQL | The slot-window query plans, JSONB GIN containment, and `DISTINCT ON`. Other dialects use slower fallback queries (tests only). |

--- a/extensions/blockfrost/adr/block_gaps.md
+++ b/extensions/blockfrost/adr/block_gaps.md
@@ -1,0 +1,63 @@
+# Block Module — Gaps & Open Items
+
+**PR:** #811 | **Status:** ✅ Merged | **Endpoints:** 11 / 11
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /blocks/latest` | ✅ | |
+| `GET /blocks/latest/transactions` | ✅ | |
+| `GET /blocks/{hash_or_number}` | ✅ | Accepts 64-char hash or numeric block number |
+| `GET /blocks/{hash_or_number}/next` | ✅ | |
+| `GET /blocks/{hash_or_number}/previous` | ✅ | Result list reversed to match BF ascending order |
+| `GET /blocks/{hash_or_number}/transactions` | ✅ | |
+| `GET /blocks/{hash_or_number}/addresses` | ⚠️ | JOIN may miss records if `address_utxo` is pruned |
+| `GET /blocks/{hash_or_number}/txs/cbor` | ⚠️ | Body-only CBOR (`a8xx`) — not full envelope (`84xx`) |
+| `GET /blocks/slot/{slot_number}` | ✅ | |
+| `GET /blocks/epoch/{epoch_number}/slot/{slot_number}` | ✅ | Uses `epoch_slot`, not absolute slot |
+| `GET /blocks/latest/transactions/cbor` | ⚠️ | Body-only CBOR — same root cause |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **CBOR body-only format:** CBOR endpoints return body-only CBOR (`a8xx` prefix) instead of the
+  full transaction envelope (`84xx` — body + witnesses + validity + metadata).
+  Root cause: `TransactionProcessor` stores only the body. Shared root cause with Transaction module.
+  Document as known difference.
+
+- **`output`/`fees` null on empty blocks:** Fields return `null` (not `"0"`) when a block contains
+  no transactions. This matches the Blockfrost schema where these fields are optional.
+
+- **Address transactions pruning risk:** `findBlockAddressTransactions()` JOINs `address_utxo`.
+  If UTxO records are pruned, historical address transaction counts will be incomplete.
+  Documented in OpenAPI spec. Acceptable for deployments without UTxO pruning.
+
+- **`store.transaction.saveCbor=true` requirement:** CBOR endpoints return HTTP 404 if CBOR
+  storage is disabled.
+
+## Indexes
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_block_tx_index_tx_hash
+    ON transaction (block_hash, tx_index, tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_address_utxo_block
+    ON address_utxo (block_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_input_spent_at_block_spent_tx_hash
+    ON tx_input (spent_at_block, spent_tx_hash);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.block.enabled=true` | All block endpoints |
+| `store.transaction.saveCbor=true` | CBOR endpoints (otherwise 404) |
+
+## Release Notes
+
+No functional blockers. CBOR format limitation is a shared concern with the Transaction module
+and requires an ingestion-layer change. All other gaps are accepted or have documented workarounds.

--- a/extensions/blockfrost/adr/blockfrost_indexes.md
+++ b/extensions/blockfrost/adr/blockfrost_indexes.md
@@ -11,42 +11,65 @@ index name, table, and columns are the same.
 
 ## Index Inventory
 
-| No. | Module | Table | Proposed Index Name | Proposed Columns | Notes |
-|---:|---|---|---|---|---|
-| 1 | account | `address_utxo` | `idx_address_utxo_owner_stake_addr` | `(owner_stake_addr)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
-| 2 | account | `withdrawal` | `idx_withdrawal_address` | `(address)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
-| 3 | account | `withdrawal` | `idx_withdrawal_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
-| 4 | account | `instant_reward` | `idx_instant_reward_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
-| 5 | account | `reward_rest` | `idx_reward_rest_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
-| 6 | address | `address_utxo` | `idx_address_utxo_owner_addr` | `(owner_addr)` | Proposed from `address_gaps.md`; prevents full table scans for address endpoints. |
-| 7 | address | `address_utxo` | `idx_address_utxo_owner_addr_full` | `(owner_addr_full)` | Proposed from `address_gaps.md`; needed for Byron-length addresses. |
-| 8 | asset | `address_utxo` | `idx_address_utxo_amounts` | `(amounts)` | Proposed from `asset_gaps.md`; GIN index on JSONB `amounts`. |
-| 9 | asset | `assets` | `idx_assets_unit_slot` | `(unit, slot)` | Proposed from `asset_gaps.md`. |
-| 10 | asset | `assets` | `idx_assets_unit_policy` | `(unit, policy)` | Proposed from `asset_gaps.md`. |
-| 11 | asset | `assets` | `idx_assets_unit_qty` | `(unit, quantity)` | Proposed from `asset_gaps.md`. |
-| 12 | asset | `assets` | `idx_assets_policy` | `(policy)` | Proposed from `asset_gaps.md`. |
-| 13 | asset | `assets_mint` | `idx_assets_mint_unit_slot` | `(unit, slot)` | Proposed from `asset_gaps.md`. |
-| 14 | asset | `assets_mint` | `idx_assets_mint_slot_tx_hash` | `(slot, tx_hash)` | Proposed from `asset_gaps.md`. |
-| 15 | asset, transaction | `transaction` | `idx_transaction_tx_hash_tx_index` | `(tx_hash, tx_index)` | Listed in both `asset_gaps.md` and `transaction_gaps.md`; keep as one proposed index. |
-| 16 | block | `transaction` | `idx_transaction_block_tx_index_tx_hash` | `(block_hash, tx_index, tx_hash)` | Proposed from `block_gaps.md`. |
-| 17 | block | `address_utxo` | `idx_address_utxo_block` | `(block_hash)` | Proposed from `block_gaps.md`. |
-| 18 | block | `tx_input` | `idx_tx_input_spent_at_block_spent_tx_hash` | `(spent_at_block, spent_tx_hash)` | Proposed from `block_gaps.md`. |
-| 19 | epoch | `block` | `idx_block_epoch_slot` | `(epoch, slot)` | Proposed from `epoch_gaps.md` for block query performance. |
-| 20 | governance | `drep_registration` | `idx_drep_registration_drep_hash` | `(drep_hash)` | Proposed from `governance_gaps.md`. |
-| 21 | governance | `voting_procedure` | `idx_voting_procedure_drep_hash_type` | `(drep_hash, voter_type)` | Proposed from `governance_gaps.md`. |
-| 22 | pools | `pool_registration` | `idx_pool_registration_pool_id_slot` | `(pool_id, slot)` | Proposed from `pools_gaps.md`. |
-| 23 | pools | `pool_retirement` | `idx_pool_retirement_pool_id_slot` | `(pool_id, slot)` | Proposed from `pools_gaps.md`. |
-| 24 | pools | `pool_status` | `idx_pool_status_pool_id` | `(pool_id)` | Proposed from `pools_gaps.md`. |
-| 25 | pools | `epoch_stake` | `idx_epoch_stake_pool_epoch` | `(pool_id, epoch)` | Proposed from `pools_gaps.md`. |
-| 26 | pools | `block` | `idx_block_slot_leader_epoch` | `(slot_leader, epoch)` | Proposed from `pools_gaps.md`. |
-| 27 | pools | `voting_procedure` | `idx_gov_action_pool_id` | `(pool_hash)` | Proposed from `pools_gaps.md`; index name references governance action but table is `voting_procedure`. |
-| 28 | scripts | `transaction_scripts` | `idx_transaction_scripts_purpose_not_null` | `(script_hash, slot)` | Proposed from `scripts_gaps.md`; partial index with `WHERE purpose IS NOT NULL`. |
-| 29 | transaction | `transaction_cbor` | `idx_transaction_cbor_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
-| 30 | transaction | `tx_input` | `idx_tx_input_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
-| 31 | transaction | `delegation` | `idx_delegation_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
-| 32 | transaction | `stake_registration` | `idx_stake_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
-| 33 | transaction | `pool_registration` | `idx_pool_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
-| 34 | transaction | `drep_registration` | `idx_drep_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| No. | Module | Source ADR | Table | Proposed Index Name | Proposed Columns | Condition | Existing / Coverage | Notes |
+|---:|---|---|---|---|---|---|---|---|
+| 1 | account | `account_gaps.md` | `address_utxo` | `idx_address_utxo_owner_stake_addr` | `(owner_stake_addr)` | None | `index.yml` | Already provided by `index.yml`. |
+| 2 | account | `account_gaps.md` | `withdrawal` | `idx_withdrawal_address` | `(address)` | None | `index.yml` | Already provided by `index.yml`. |
+| 3 | account | `account_gaps.md` | `withdrawal` | `idx_withdrawal_address_slot` | `(address, slot)` | None | `index.yml` | Already provided by `index.yml`. |
+| 4 | account | `account_gaps.md` | `instant_reward` | `idx_instant_reward_address_slot` | `(address, slot)` | None | `index.yml` | Already provided by `index.yml`. |
+| 5 | account | `account_gaps.md` | `reward_rest` | `idx_reward_rest_address_slot` | `(address, slot)` | None | `index.yml` | Already provided by `index.yml`. |
+| 6 | address | `address_gaps.md` | `address_utxo` | `idx_address_utxo_owner_addr` | `(owner_addr)` | None | `index.yml` | Already provided by `index.yml`. |
+| 7 | address | `address_gaps.md` | `address_utxo` | `idx_address_utxo_owner_addr_full` | `(owner_addr_full)` | None | None | Needed for Byron-length addresses. |
+| 8 | asset | `asset_gaps.md` | `address_utxo` | `idx_address_utxo_amounts` | `(amounts)` | None | `extra-index.yml` | Already provided by `extra-index.yml` as a GIN index on JSONB `amounts`. |
+| 9 | asset | `asset_gaps.md` | `assets` | `idx_assets_unit_slot` | `(unit, slot)` | None | None | Proposed from asset ADR. |
+| 10 | asset | `asset_gaps.md` | `assets` | `idx_assets_unit_policy` | `(unit, policy)` | None | None | Proposed from asset ADR. |
+| 11 | asset | `asset_gaps.md` | `assets` | `idx_assets_unit_qty` | `(unit, quantity)` | None | None | Proposed from asset ADR. |
+| 12 | asset | `asset_gaps.md` | `assets` | `idx_assets_policy` | `(policy)` | None | `index.yml` | Already provided by `index.yml`. |
+| 13 | asset | `asset_gaps.md` | `assets_mint` | `idx_assets_mint_unit_slot` | `(unit, slot)` | None | N/A | `assets_mint` is not present in the current tree; re-check when the owning module lands. |
+| 14 | asset | `asset_gaps.md` | `assets_mint` | `idx_assets_mint_slot_tx_hash` | `(slot, tx_hash)` | None | N/A | `assets_mint` is not present in the current tree; re-check when the owning module lands. |
+| 15 | asset, transaction | `asset_gaps.md`, `transaction_gaps.md` | `transaction` | `idx_transaction_tx_hash_tx_index` | `(tx_hash, tx_index)` | None | Covered by `transaction(tx_hash)` PK | Do not add unless a query-plan check proves the composite is needed. |
+| 16 | block | `block_gaps.md` | `transaction` | `idx_transaction_block_tx_index_tx_hash` | `(block_hash, tx_index, tx_hash)` | None | None | Proposed from block ADR. |
+| 17 | block | `block_gaps.md` | `address_utxo` | `idx_address_utxo_block` | `(block_hash)` | None | None | Proposed from block ADR. |
+| 18 | block | `block_gaps.md` | `tx_input` | `idx_tx_input_spent_at_block_spent_tx_hash` | `(spent_at_block, spent_tx_hash)` | None | Prefix exists: `idx_tx_input_block(spent_at_block)` | Proposed composite is not an exact duplicate. |
+| 19 | epoch | `epoch_gaps.md` | `block` | `idx_block_epoch_slot` | `(epoch, slot)` | None | Prefix exists: `idx_block_epoch(epoch)` | Proposed composite is not an exact duplicate. |
+| 20 | governance | `governance_gaps.md` | `drep_registration` | `idx_drep_registration_drep_hash` | `(drep_hash)` | None | Flyway: `idx_drep_registration_drep_hash` | Already provided by governance store migration. |
+| 21 | governance | `governance_gaps.md` | `voting_procedure` | `idx_voting_procedure_drep_hash_type` | `(drep_hash, voter_type)` | None | N/A | `drep_hash` is not present on current `voting_procedure`; re-check with governance PR/schema. |
+| 22 | pools | `pools_gaps.md` | `pool_registration` | `idx_pool_registration_pool_id_slot` | `(pool_id, slot)` | None | Prefix exists: `idx_pool_registration_pool_id(pool_id)` | Proposed from pools ADR. |
+| 23 | pools | `pools_gaps.md` | `pool_retirement` | `idx_pool_retirement_pool_id_slot` | `(pool_id, slot)` | None | Prefix exists: `idx_pool_retirement_pool_id(pool_id)` | Proposed from pools ADR. |
+| 24 | pools | `pools_gaps.md` | `pool_status` | `idx_pool_status_pool_id` | `(pool_id)` | None | N/A | `pool_status` is not present in the current tree; re-check table name before applying. |
+| 25 | pools | `pools_gaps.md` | `epoch_stake` | `idx_epoch_stake_pool_epoch` | `(pool_id, epoch)` | None | Reverse order exists: `idx_epoch_stake_epoch_pool_id(epoch, pool_id)` | Column order differs; needs query-plan validation. |
+| 26 | pools | `pools_gaps.md` | `block` | `idx_block_slot_leader_epoch` | `(slot_leader, epoch)` | None | Prefix exists: `idx_block_slot_leader(slot_leader)` | Proposed from pools ADR. |
+| 27 | pools | `pools_gaps.md` | `voting_procedure` | `idx_gov_action_pool_id` | `(pool_hash)` | None | N/A | `pool_hash` is not present on current `voting_procedure`; if later valid, prefer `idx_voting_procedure_pool_hash`. |
+| 28 | scripts | `scripts_gaps.md` | `transaction_scripts` | `idx_transaction_scripts_purpose_not_null` | `(script_hash, slot)` | `WHERE purpose IS NOT NULL` | None | Partial PostgreSQL index; runtime YAML excludes `mysql` and `h2`. |
+| 29 | transaction | `transaction_gaps.md` | `transaction_cbor` | `idx_transaction_cbor_tx_hash` | `(tx_hash)` | None | Covered by `transaction_cbor(tx_hash)` PK | Do not add as a separate index. |
+| 30 | transaction | `transaction_gaps.md` | `tx_input` | `idx_tx_input_tx_hash` | `(tx_hash)` | None | None | Current PK is `(output_index, tx_hash)`, so `tx_hash` is not the leading column. |
+| 31 | transaction | `transaction_gaps.md` | `delegation` | `idx_delegation_tx_hash` | `(tx_hash)` | None | Flyway: `idx_delegation_txhash` | Same table and column with a different existing index name. |
+| 32 | transaction | `transaction_gaps.md` | `stake_registration` | `idx_stake_registration_tx_hash` | `(tx_hash)` | None | Flyway: `idx_stake_registration_stake_txhash` | Same table and column with a different existing index name. |
+| 33 | transaction | `transaction_gaps.md` | `pool_registration` | `idx_pool_registration_tx_hash` | `(tx_hash)` | None | Flyway: `idx_pool_registration_txhash` | Same table and column with a different existing index name. |
+| 34 | transaction | `transaction_gaps.md` | `drep_registration` | `idx_drep_registration_tx_hash` | `(tx_hash)` | None | Covered by `drep_registration(tx_hash, cert_index)` PK | Do not add as a separate index. |
+
+## Existing Or Covered Indexes
+
+These proposed indexes should not be added to `blockfrost-index.yml` unless new query-plan evidence
+shows that a separate Blockfrost-specific index is still needed.
+
+| Proposed Index Name | Existing Source | Reason |
+|---|---|---|
+| `idx_address_utxo_owner_stake_addr` | `index.yml` | Exact index from `index.yml`. |
+| `idx_withdrawal_address` | `index.yml` | Exact index from `index.yml`. |
+| `idx_withdrawal_address_slot` | `index.yml` | Exact index from `index.yml`. |
+| `idx_instant_reward_address_slot` | `index.yml` | Exact index from `index.yml`. |
+| `idx_reward_rest_address_slot` | `index.yml` | Exact index from `index.yml`. |
+| `idx_address_utxo_owner_addr` | `index.yml` | Exact index from `index.yml`. |
+| `idx_address_utxo_amounts` | `extra-index.yml` | Exact optional GIN index. |
+| `idx_assets_policy` | `index.yml` | Exact index from `index.yml`. |
+| `idx_drep_registration_drep_hash` | Flyway governance migration | Exact migration index. |
+| `idx_transaction_tx_hash_tx_index` | `transaction(tx_hash)` primary key | `tx_hash` lookup is already covered. |
+| `idx_transaction_cbor_tx_hash` | `transaction_cbor(tx_hash)` primary key | `tx_hash` lookup is already covered. |
+| `idx_delegation_tx_hash` | Flyway `idx_delegation_txhash` | Same table and column with a different index name. |
+| `idx_stake_registration_tx_hash` | Flyway `idx_stake_registration_stake_txhash` | Same table and column with a different index name. |
+| `idx_pool_registration_tx_hash` | Flyway `idx_pool_registration_txhash` | Same table and column with a different index name. |
+| `idx_drep_registration_tx_hash` | `drep_registration(tx_hash, cert_index)` primary key | `tx_hash` lookup is already covered by the leading PK column. |
 
 ## Modules Without Additional Indexes
 

--- a/extensions/blockfrost/adr/blockfrost_indexes.md
+++ b/extensions/blockfrost/adr/blockfrost_indexes.md
@@ -1,0 +1,56 @@
+# Blockfrost Index Manifest
+
+**Created:** 2026-05-26
+
+## Scope
+
+This file summarizes PostgreSQL indexes referenced by the Blockfrost compatibility module ADRs.
+
+Duplicate references across module ADRs are consolidated into a single row when the proposed
+index name, table, and columns are the same.
+
+## Index Inventory
+
+| No. | Module | Table | Proposed Index Name | Proposed Columns | Notes |
+|---:|---|---|---|---|---|
+| 1 | account | `address_utxo` | `idx_address_utxo_owner_stake_addr` | `(owner_stake_addr)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
+| 2 | account | `withdrawal` | `idx_withdrawal_address` | `(address)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
+| 3 | account | `withdrawal` | `idx_withdrawal_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
+| 4 | account | `instant_reward` | `idx_instant_reward_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
+| 5 | account | `reward_rest` | `idx_reward_rest_address_slot` | `(address, slot)` | Listed in `account_gaps.md` as already in `index.yml`; verify before applying. |
+| 6 | address | `address_utxo` | `idx_address_utxo_owner_addr` | `(owner_addr)` | Proposed from `address_gaps.md`; prevents full table scans for address endpoints. |
+| 7 | address | `address_utxo` | `idx_address_utxo_owner_addr_full` | `(owner_addr_full)` | Proposed from `address_gaps.md`; needed for Byron-length addresses. |
+| 8 | asset | `address_utxo` | `idx_address_utxo_amounts` | `(amounts)` | Proposed from `asset_gaps.md`; GIN index on JSONB `amounts`. |
+| 9 | asset | `assets` | `idx_assets_unit_slot` | `(unit, slot)` | Proposed from `asset_gaps.md`. |
+| 10 | asset | `assets` | `idx_assets_unit_policy` | `(unit, policy)` | Proposed from `asset_gaps.md`. |
+| 11 | asset | `assets` | `idx_assets_unit_qty` | `(unit, quantity)` | Proposed from `asset_gaps.md`. |
+| 12 | asset | `assets` | `idx_assets_policy` | `(policy)` | Proposed from `asset_gaps.md`. |
+| 13 | asset | `assets_mint` | `idx_assets_mint_unit_slot` | `(unit, slot)` | Proposed from `asset_gaps.md`. |
+| 14 | asset | `assets_mint` | `idx_assets_mint_slot_tx_hash` | `(slot, tx_hash)` | Proposed from `asset_gaps.md`. |
+| 15 | asset, transaction | `transaction` | `idx_transaction_tx_hash_tx_index` | `(tx_hash, tx_index)` | Listed in both `asset_gaps.md` and `transaction_gaps.md`; keep as one proposed index. |
+| 16 | block | `transaction` | `idx_transaction_block_tx_index_tx_hash` | `(block_hash, tx_index, tx_hash)` | Proposed from `block_gaps.md`. |
+| 17 | block | `address_utxo` | `idx_address_utxo_block` | `(block_hash)` | Proposed from `block_gaps.md`. |
+| 18 | block | `tx_input` | `idx_tx_input_spent_at_block_spent_tx_hash` | `(spent_at_block, spent_tx_hash)` | Proposed from `block_gaps.md`. |
+| 19 | epoch | `block` | `idx_block_epoch_slot` | `(epoch, slot)` | Proposed from `epoch_gaps.md` for block query performance. |
+| 20 | governance | `drep_registration` | `idx_drep_registration_drep_hash` | `(drep_hash)` | Proposed from `governance_gaps.md`. |
+| 21 | governance | `voting_procedure` | `idx_voting_procedure_drep_hash_type` | `(drep_hash, voter_type)` | Proposed from `governance_gaps.md`. |
+| 22 | pools | `pool_registration` | `idx_pool_registration_pool_id_slot` | `(pool_id, slot)` | Proposed from `pools_gaps.md`. |
+| 23 | pools | `pool_retirement` | `idx_pool_retirement_pool_id_slot` | `(pool_id, slot)` | Proposed from `pools_gaps.md`. |
+| 24 | pools | `pool_status` | `idx_pool_status_pool_id` | `(pool_id)` | Proposed from `pools_gaps.md`. |
+| 25 | pools | `epoch_stake` | `idx_epoch_stake_pool_epoch` | `(pool_id, epoch)` | Proposed from `pools_gaps.md`. |
+| 26 | pools | `block` | `idx_block_slot_leader_epoch` | `(slot_leader, epoch)` | Proposed from `pools_gaps.md`. |
+| 27 | pools | `voting_procedure` | `idx_gov_action_pool_id` | `(pool_hash)` | Proposed from `pools_gaps.md`; index name references governance action but table is `voting_procedure`. |
+| 28 | scripts | `transaction_scripts` | `idx_transaction_scripts_purpose_not_null` | `(script_hash, slot)` | Proposed from `scripts_gaps.md`; partial index with `WHERE purpose IS NOT NULL`. |
+| 29 | transaction | `transaction_cbor` | `idx_transaction_cbor_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| 30 | transaction | `tx_input` | `idx_tx_input_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| 31 | transaction | `delegation` | `idx_delegation_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| 32 | transaction | `stake_registration` | `idx_stake_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| 33 | transaction | `pool_registration` | `idx_pool_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+| 34 | transaction | `drep_registration` | `idx_drep_registration_tx_hash` | `(tx_hash)` | Proposed from `transaction_gaps.md`. |
+
+## Modules Without Additional Indexes
+
+| Module | Notes |
+|---|---|
+| metadata | `metadata_gaps.md` states no additional indexes are required |
+| network | `network_gaps.md` states no additional indexes are required |

--- a/extensions/blockfrost/adr/epoch_gaps.md
+++ b/extensions/blockfrost/adr/epoch_gaps.md
@@ -31,6 +31,12 @@
   Correct approach: use `adapot` table for past epochs; for current epoch, `SUM` transaction fees
   from the `block` table. Caching recommended for performance.
 
+- **`/stakes` and `/stakes/{pool_id}` ordering mismatch:**
+  `GET /epochs/{number}/stakes` and `GET /epochs/{number}/stakes/{pool_id}` in Blockfrost
+  return results ordered according to cardano-db-sync's internal row ordering. Yaci Store
+  does not replicate this ordering, so paginated responses may return rows in a different
+  sequence than Blockfrost.
+
 - **`first_block_time` / `last_block_time` not the true first/last block times
   ([#973](https://github.com/bloxbean/yaci-store/issues/973)):**
   `epoch.start_time` / `epoch.end_time` (which back these fields) are computed from an

--- a/extensions/blockfrost/adr/epoch_gaps.md
+++ b/extensions/blockfrost/adr/epoch_gaps.md
@@ -31,6 +31,13 @@
   Correct approach: use `adapot` table for past epochs; for current epoch, `SUM` transaction fees
   from the `block` table. Caching recommended for performance.
 
+- **`first_block_time` / `last_block_time` not the true first/last block times
+  ([#973](https://github.com/bloxbean/yaci-store/issues/973)):**
+  `epoch.start_time` / `epoch.end_time` (which back these fields) are computed from an
+  **unordered** block query in `EpochService`, so they come from arbitrary blocks rather than
+  the chronologically first/last block — off by seconds to hours vs Blockfrost. Code currently
+  keeps reading directly from the `epoch` columns;
+  
 - **Block query performance (#791) — ✅ resolved by `idx_block_epoch_slot`:**
   `GET /epochs/{number}/blocks` was slow specifically for `order=asc` on epochs far from
   the chain tip. Without a composite index, the JDBC prepared-statement plan walks

--- a/extensions/blockfrost/adr/epoch_gaps.md
+++ b/extensions/blockfrost/adr/epoch_gaps.md
@@ -9,12 +9,12 @@
 | `GET /epochs/latest` | ✅ | |
 | `GET /epochs/{number}` | ⚠️ | `total_fees` mismatch (see #781) |
 | `GET /epochs/{number}/parameters` | ✅ | |
-| `GET /epochs/{number}/next` | ✅ | |
-| `GET /epochs/{number}/previous` | ✅ | |
+| `GET /epochs/{number}/next` | ✅ | `active_stake` query optimized — see below |
+| `GET /epochs/{number}/previous` | ✅ | `active_stake` query optimized — see below |
 | `GET /epochs/{number}/stakes` | ✅ | Requires `store.adapot.enabled=true`; returns `null` when disabled |
 | `GET /epochs/{number}/stakes/{pool_id}` | ✅ | Same adapot dependency |
-| `GET /epochs/{number}/blocks` | ⚠️ | Slow without composite index (see below) |
-| `GET /epochs/{number}/blocks/{pool_id}` | ⚠️ | Same performance issue |
+| `GET /epochs/{number}/blocks` | ✅ | Fast with composite index (see below) |
+| `GET /epochs/{number}/blocks/{pool_id}` | ✅ | Same composite index |
 
 ## Open Gaps
 
@@ -31,13 +31,36 @@
   Correct approach: use `adapot` table for past epochs; for current epoch, `SUM` transaction fees
   from the `block` table. Caching recommended for performance.
 
-- **Block query performance (#791):** `GET /epochs/{number}/blocks` runs a full scan
-  (~19 s on mainnet, 11.6 M rows) without a composite index.
+- **Block query performance (#791) — ✅ resolved by `idx_block_epoch_slot`:**
+  `GET /epochs/{number}/blocks` was slow specifically for `order=asc` on epochs far from
+  the chain tip. Without a composite index, the JDBC prepared-statement plan walks
+  `idx_block_slot` ascending and filters by epoch, traversing millions of older blocks
+  before reaching the target epoch. Adding `block (epoch, slot)` gives the planner a direct
+  access path. Measured on preprod: `order=asc` dropped from **~3.2 s → ~70 ms**; `order=desc`
+  was always fast (the descending scan finds recent epochs immediately).
+
+  > Note: a manual `EXPLAIN` with a literal `epoch = N` (or `force_generic_plan`) picks
+  > `idx_block_epoch` and runs in ~16 ms, masking the problem. The regression only appears
+  > through the application's actual prepared-statement plan — verify via the live endpoint,
+  > not just `psql`.
+
+## Performance
+
+### `active_stake` query — partition-key pruning
+
+`getActiveStakesByEpochs` (backing `active_stake` in `/epochs/{number}`, `/next`, `/previous`)
+originally filtered `epoch_stake` on `active_epoch`. Because `epoch_stake` is **partitioned by
+`epoch`**, that filter scanned every partition. Since `active_epoch = epoch + 2` is an invariant
+(set by `StakeSnapshotService`), the query now filters on the partition key `epoch` (= `active_epoch − 2`)
+and remaps the grouped result back to `active_epoch`. This enables partition pruning and reuse of the
+PK `(epoch, address)` — no schema change. Measured on preprod: `/next` **~1016 ms → ~132 ms**,
+`/previous` **~1066 ms → ~529 ms**.
 
 ## Indexes
 
 ```sql
--- Required for /epochs/{number}/blocks and /blocks/{pool_id} performance
+-- Required for /epochs/{number}/blocks and /blocks/{pool_id} performance.
+-- Verified: order=asc on far-from-tip epochs ~3.2 s -> ~70 ms (preprod).
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_epoch_slot
     ON block (epoch, slot);
 ```

--- a/extensions/blockfrost/adr/epoch_gaps.md
+++ b/extensions/blockfrost/adr/epoch_gaps.md
@@ -1,0 +1,53 @@
+# Epoch Module — Gaps & Open Items
+
+**PR:** #780 | **Status:** ✅ Merged | **Endpoints:** 10 / 10
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /epochs/latest` | ✅ | |
+| `GET /epochs/{number}` | ⚠️ | `total_fees` mismatch (see #781) |
+| `GET /epochs/{number}/parameters` | ✅ | |
+| `GET /epochs/{number}/next` | ✅ | |
+| `GET /epochs/{number}/previous` | ✅ | |
+| `GET /epochs/{number}/stakes` | ⚠️ | `active_stake` is `null` when `store.adapot.enabled=false` |
+| `GET /epochs/{number}/stakes/{pool_id}` | ⚠️ | Same adapot dependency |
+| `GET /epochs/{number}/blocks` | ⚠️ | Slow without composite index (see below) |
+| `GET /epochs/{number}/blocks/{pool_id}` | ⚠️ | Same performance issue |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **`active_stake` null:** When `store.adapot.enabled=false`, stake fields return `null`.
+  Intentional graceful degradation — document in deployment guide.
+
+### Tracked Issues
+
+- **`total_fees` mismatch (#781):** `GET /epochs/{number}` returns incorrect `total_fees`.
+  Correct approach: use `adapot` table for past epochs; for current epoch, `SUM` transaction fees
+  from the `block` table. Caching recommended for performance.
+
+- **Block query performance (#791):** `GET /epochs/{number}/blocks` runs a full scan
+  (~19 s on mainnet, 11.6 M rows) without a composite index.
+
+## Indexes
+
+```sql
+-- Required for /epochs/{number}/blocks and /blocks/{pool_id} performance
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_epoch_slot
+    ON block (epoch, slot);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.epoch.enabled=true` | All epoch endpoints |
+| `store.adapot.enabled=true` | `/stakes`, `/stakes/{pool_id}` — otherwise returns null |
+
+## Release Notes
+
+`total_fees` discrepancy (#781) is the only functional gap preventing full parity.
+All other gaps are either accepted limitations or performance-only.

--- a/extensions/blockfrost/adr/epoch_gaps.md
+++ b/extensions/blockfrost/adr/epoch_gaps.md
@@ -11,17 +11,19 @@
 | `GET /epochs/{number}/parameters` | ✅ | |
 | `GET /epochs/{number}/next` | ✅ | |
 | `GET /epochs/{number}/previous` | ✅ | |
-| `GET /epochs/{number}/stakes` | ⚠️ | `active_stake` is `null` when `store.adapot.enabled=false` |
-| `GET /epochs/{number}/stakes/{pool_id}` | ⚠️ | Same adapot dependency |
+| `GET /epochs/{number}/stakes` | ✅ | Requires `store.adapot.enabled=true`; returns `null` when disabled |
+| `GET /epochs/{number}/stakes/{pool_id}` | ✅ | Same adapot dependency |
 | `GET /epochs/{number}/blocks` | ⚠️ | Slow without composite index (see below) |
 | `GET /epochs/{number}/blocks/{pool_id}` | ⚠️ | Same performance issue |
 
 ## Open Gaps
 
-### Accepted Limitations
+### Configuration Notes
 
-- **`active_stake` null:** When `store.adapot.enabled=false`, stake fields return `null`.
-  Intentional graceful degradation — document in deployment guide.
+- **`active_stake` dependency on AdaPot job:** `active_stake` fields in `/stakes` and
+  `/stakes/{pool_id}` return `null` when `store.adapot.enabled=false`. This is not a gap —
+  it is expected behavior when the AdaPot aggregation job is not running. Enable
+  `store.adapot.enabled=true` to populate these fields.
 
 ### Tracked Issues
 

--- a/extensions/blockfrost/adr/governance_gaps.md
+++ b/extensions/blockfrost/adr/governance_gaps.md
@@ -1,0 +1,70 @@
+# Governance Module — Gaps & Open Items
+
+**PR:** #865 | **Status:** 🔄 Open PR | **Endpoints:** 17 / 17
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /governance/dreps` | ✅ | |
+| `GET /governance/dreps/{drep_id}` | ✅ | Retired DReps return `null` `active_epoch` to match BF |
+| `GET /governance/dreps/{drep_id}/delegators` | ✅ | Optimized with indexed window functions |
+| `GET /governance/dreps/{drep_id}/metadata` | ⚠️ | Returns 200 instead of 404 when off-chain fetch fails |
+| `GET /governance/dreps/{drep_id}/updates` | ✅ | |
+| `GET /governance/dreps/{drep_id}/votes` | ✅ | |
+| `GET /governance/proposals` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}` | ⚠️ | `ratified_epoch`/`expired_epoch` null without aggr |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/parameters` | ✅ | Returned as strings matching BF format |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/withdrawals` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/votes` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/metadata` | ⚠️ | Off-chain fetch returns 200 vs BF 404 |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/dreps` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/pools` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/committees` | ✅ | |
+| `GET /governance/votes/{tx_hash}/{cert_index}` | ✅ | |
+| `GET /governance/proposals/{tx_hash}/{cert_index}/linked_proposals` | ✅ | |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **Special DReps not indexed:** `drep_always_abstain` and `drep_always_no_confidence` are
+  CIP-1694 predefined options — not registered on-chain, cannot be indexed. Queries targeting
+  these virtual DReps return empty/null, matching Blockfrost behavior.
+
+- **`ratified_epoch`/`expired_epoch` null:** When `store.governance-aggr.enabled=false`, these
+  fields are not computed and return `null`. Enable governance aggregation for full parity.
+
+- **Off-chain metadata status code mismatch:** When off-chain fetch fails, yaci-store returns
+  HTTP 200 with partial response while Blockfrost returns HTTP 404. Requires a fetch + caching
+  layer to align. Currently out of scope.
+
+- **Delegator UTXO timing:** Small differences in delegator counts between syncs due to UTXO
+  observation timing. Not a code issue.
+
+## Indexes
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_drep_registration_drep_hash
+    ON drep_registration (drep_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_voting_procedure_drep_hash_type
+    ON voting_procedure (drep_hash, voter_type);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.governance=true` | All governance endpoints |
+| `store.governance.enabled=true` | Governance data |
+| `store.governance-aggr.enabled=true` | `ratified_epoch`, `expired_epoch` fields |
+| `store.cardano.n2c-host=<node-ip>` | N2C live DRep data |
+| `store.cardano.n2c-port=31001` | N2C live DRep data |
+
+## Release Notes
+
+No hard blockers. Main gaps:
+1. Off-chain metadata status code mismatch (accepted for now).
+2. `ratified_epoch`/`expired_epoch` require `governance-aggr` module (document as prerequisite).
+Module is in review with reviewers assigned.

--- a/extensions/blockfrost/adr/metadata_gaps.md
+++ b/extensions/blockfrost/adr/metadata_gaps.md
@@ -6,7 +6,7 @@
 
 | Endpoint | Match | Data | Notes |
 |----------|-------|------|-------|
-| `GET /metadata/txs/labels` | ⚠️ | Partial | `cip10` null; duplicate rows on reconnect |
+| `GET /metadata/txs/labels` | ⚠️ | Partial | `cip10` null; rare duplicate rows on reconnect |
 | `GET /metadata/txs/labels/{label}` | ✅ | Full | |
 | `GET /metadata/txs/labels/{label}/cbor` | ⚠️ | Partial | CBOR null when not stored at ingest time |
 
@@ -30,9 +30,10 @@
 
 ### Tracked Issues
 
-- **Duplicate rows on reconnect:** `GET /metadata/txs/labels` can return duplicate label rows
-  after a node reconnection triggers re-indexing. Deduplication logic does not handle
-  re-processed transactions. Should be resolved before merge.
+- **Duplicate rows on reconnect (low severity):** `GET /metadata/txs/labels` can theoretically
+  return duplicate label rows after a node reconnection triggers re-indexing, if deduplication
+  logic does not cover re-processed transactions. This is a rare edge case, hard to reproduce
+  in practice. Track as a low-priority follow-up item; not a merge blocker.
 
 ## Indexes
 
@@ -56,5 +57,6 @@ blockfrost:
 
 ## Release Notes
 
-The duplicate-rows-on-reconnect issue is the only item that should be resolved before merge.
-All other gaps are accepted limitations. Minor code style review comments also outstanding.
+No merge blockers. The duplicate-rows-on-reconnect edge case is rare and hard to reproduce —
+tracked as a low-priority follow-up. All other gaps are accepted limitations.
+Minor code style review comments also outstanding.

--- a/extensions/blockfrost/adr/metadata_gaps.md
+++ b/extensions/blockfrost/adr/metadata_gaps.md
@@ -1,0 +1,60 @@
+# Metadata Module — Gaps & Open Items
+
+**PR:** #872 | **Status:** 🔄 Open PR | **Endpoints:** 3 / 3
+
+## Endpoint Status
+
+| Endpoint | Match | Data | Notes |
+|----------|-------|------|-------|
+| `GET /metadata/txs/labels` | ⚠️ | Partial | `cip10` null; duplicate rows on reconnect |
+| `GET /metadata/txs/labels/{label}` | ✅ | Full | |
+| `GET /metadata/txs/labels/{label}/cbor` | ⚠️ | Partial | CBOR null when not stored at ingest time |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **`cip10` always null:** `BFMetadataLabelDto.cip10` is hardcoded to `null`. Populating it
+  requires integration with the CIP-10 community registry (numeric label → human-readable name
+  mapping). No integration planned at this time.
+
+- **CBOR null when not stored:** `GET /metadata/txs/labels/{label}/cbor` returns `null` for
+  `cbor_metadata` when the transaction's raw CBOR bytes were not captured at ingestion time.
+  Re-encoding from stored JSON is not attempted. Affects older indexed data.
+
+- **Raw JSON passthrough:** Uses `@JsonRawValue` for metadata content. Malformed stored metadata
+  produces structurally invalid JSON responses. Acceptable as the source data is already invalid.
+
+- **Numeric label sort workaround:** Labels cast to `BigDecimal` for sort ordering instead of
+  native `BIGINT`. Functionally equivalent but less efficient. Low priority.
+
+### Tracked Issues
+
+- **Duplicate rows on reconnect:** `GET /metadata/txs/labels` can return duplicate label rows
+  after a node reconnection triggers re-indexing. Deduplication logic does not handle
+  re-processed transactions. Should be resolved before merge.
+
+## Indexes
+
+No additional indexes required beyond those provided by existing metadata infrastructure.
+The `transaction_metadata` table is queried directly.
+
+## Configuration
+
+```yaml
+store:
+  extensions:
+    blockfrost:
+      metadata:
+        enabled: true
+  metadata:
+    enabled: true
+
+blockfrost:
+  apiPrefix: /api/v1/blockfrost
+```
+
+## Release Notes
+
+The duplicate-rows-on-reconnect issue is the only item that should be resolved before merge.
+All other gaps are accepted limitations. Minor code style review comments also outstanding.

--- a/extensions/blockfrost/adr/metadata_gaps.md
+++ b/extensions/blockfrost/adr/metadata_gaps.md
@@ -7,8 +7,8 @@
 | Endpoint | Match | Data | Notes |
 |----------|-------|------|-------|
 | `GET /metadata/txs/labels` | ⚠️ | Partial | `cip10` null; rare duplicate rows on reconnect |
-| `GET /metadata/txs/labels/{label}` | ✅ | Full | |
-| `GET /metadata/txs/labels/{label}/cbor` | ⚠️ | Partial | CBOR null when not stored at ingest time |
+| `GET /metadata/txs/labels/{label}` | ⚠️ | Partial | Ordering inside the same block may differ from Blockfrost |
+| `GET /metadata/txs/labels/{label}/cbor` | ⚠️ | Partial | CBOR null when not stored at ingest time; ordering inside the same block may differ from Blockfrost |
 
 ## Open Gaps
 
@@ -28,12 +28,23 @@
 - **Numeric label sort workaround:** Labels cast to `BigDecimal` for sort ordering instead of
   native `BIGINT`. Functionally equivalent but less efficient. Low priority.
 
+- **Ordering inside the same block:** Blockfrost orders metadata-by-label responses by chain
+  position, including transaction index inside the block. Yaci Store currently sorts these rows
+  by slot, but `transaction_metadata` does not store `tx_index`. When multiple transactions in
+  the same block share a metadata label, `GET /metadata/txs/labels/{label}` and
+  `GET /metadata/txs/labels/{label}/cbor` may return the same records in a different order than
+  Blockfrost. This is accepted for now as long as the metadata label records are present.
+
 ### Tracked Issues
 
 - **Duplicate rows on reconnect (low severity):** `GET /metadata/txs/labels` can theoretically
   return duplicate label rows after a node reconnection triggers re-indexing, if deduplication
   logic does not cover re-processed transactions. This is a rare edge case, hard to reproduce
   in practice. Track as a low-priority follow-up item; not a merge blocker.
+
+- **Add transaction index to metadata rows:** Introduce `tx_index` on `transaction_metadata`, and
+  other tables that need Blockfrost-compatible ordering inside a block, so metadata-by-label
+  endpoints can sort by `slot, tx_index` without joining the transaction table at query time.
 
 ## Indexes
 
@@ -57,6 +68,7 @@ blockfrost:
 
 ## Release Notes
 
-No merge blockers. The duplicate-rows-on-reconnect edge case is rare and hard to reproduce —
-tracked as a low-priority follow-up. All other gaps are accepted limitations.
-Minor code style review comments also outstanding.
+The remaining gaps are accepted limitations. The duplicate-rows-on-reconnect edge case is rare
+and hard to reproduce. Metadata-by-label ordering inside the same block is also accepted for now;
+future schema work should add `tx_index` to metadata rows so these endpoints can match
+Blockfrost ordering without an expensive transaction-table join.

--- a/extensions/blockfrost/adr/network_gaps.md
+++ b/extensions/blockfrost/adr/network_gaps.md
@@ -15,8 +15,11 @@
 
 ### Accepted Limitations
 
-- **Root endpoint identity:** `url` and `version` reflect the local yaci-store service.
-  Intentional — yaci-store is a self-hosted replacement, not a proxy for Blockfrost.
+- **Root endpoint `url`:** yaci-store serves its own configured base URL — correct and
+  intentional for a self-hosted deployment. The tracked issue below covers the specific
+  case where the URL was previously hardcoded to a mainnet value instead of reading from
+  configuration; once that fix lands, the `url` field will reflect the actual configured
+  network endpoint.
 
 - **`supply.locked` = 0:** Computing true locked supply requires scanning all script-locked
   UTxOs — a heavy query with no pre-aggregated table. Marked as permanent limitation unless
@@ -26,8 +29,10 @@
   Local State Query (LSQ) protocol. Not persisted to database tables. Structural gap — cannot
   be resolved without LSQ integration.
 
-- **Conway era end null:** `GET /network/eras` returns `null` for the Conway boundary because
-  no successor era row exists yet. Will auto-populate once the next hardfork fires.
+- **Conway era end null:** `GET /network/eras` returns `null` for the Conway era's `end`
+  boundary because Conway is the current era — no successor era exists yet. This is expected
+  behavior: the `end` field will auto-populate once the next hardfork event fires and the
+  new era begins. No action required.
 
 - **Circulating supply sync lag:** ~4 ADA difference vs. Blockfrost due to AdaPot
   materialization timing. Accepted.

--- a/extensions/blockfrost/adr/network_gaps.md
+++ b/extensions/blockfrost/adr/network_gaps.md
@@ -1,0 +1,57 @@
+# Network Module — Gaps & Open Items
+
+**PR:** #866 | **Status:** 🔄 Open PR | **Endpoints:** 4 / 4 (76 / 82 field matches)
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /` (root) | ⚠️ | `url`/`version` reflect local service; root hardcodes mainnet URL |
+| `GET /genesis` | ✅ | Exact match on all 10 fields; sourced from bundled config |
+| `GET /network` | ⚠️ | `supply.locked` = 0 (stub); `stake.live` = 0 (structural gap) |
+| `GET /network/eras` | ⚠️ | Conway era end is `null` until next hardfork fires |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **Root endpoint identity:** `url` and `version` reflect the local yaci-store service.
+  Intentional — yaci-store is a self-hosted replacement, not a proxy for Blockfrost.
+
+- **`supply.locked` = 0:** Computing true locked supply requires scanning all script-locked
+  UTxOs — a heavy query with no pre-aggregated table. Marked as permanent limitation unless
+  a materialized summary is introduced.
+
+- **`stake.live` = 0:** Live stake requires the Cardano node's in-memory mark snapshot via the
+  Local State Query (LSQ) protocol. Not persisted to database tables. Structural gap — cannot
+  be resolved without LSQ integration.
+
+- **Conway era end null:** `GET /network/eras` returns `null` for the Conway boundary because
+  no successor era row exists yet. Will auto-populate once the next hardfork fires.
+
+- **Circulating supply sync lag:** ~4 ADA difference vs. Blockfrost due to AdaPot
+  materialization timing. Accepted.
+
+### Tracked Issues
+
+- **Root endpoint hardcodes mainnet URL:** Raised by a reviewer in PR #866.
+  Should read network identifier from configuration. Needs a fix before merge.
+
+## Indexes
+
+No additional indexes required. Supply and stake values are computed from existing AdaPot
+tables already indexed by epoch.
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.network.enabled=true` | All network endpoints |
+| `store.adapot.enabled=true` | `supply.*` and `stake.active` fields |
+| `store.adapot.api-enabled=true` | `NetworkInfoApiService` dependency |
+
+## Release Notes
+
+Two permanent structural gaps (`supply.locked`, `stake.live`) — document clearly.
+One actionable tracked item: root endpoint hardcodes mainnet URL regardless of network.
+Remaining gaps are accepted limitations.

--- a/extensions/blockfrost/adr/pools_gaps.md
+++ b/extensions/blockfrost/adr/pools_gaps.md
@@ -1,0 +1,90 @@
+# Pools Module — Gaps & Open Items
+
+**PR:** #847 | **Status:** 🔄 Open PR | **Endpoints:** 12 / 12 (36 / 60 full field matches)
+
+## Endpoint Status
+
+| Endpoint | Match | Category | Notes |
+|----------|-------|----------|-------|
+| `GET /pools` | ✅ | — | |
+| `GET /pools/extended` | ⚠️ | Architecture | Stake semantics differ; off-chain metadata fields null |
+| `GET /pools/retired` | ⚠️ | Ordering | Same-epoch tie-breaking drift |
+| `GET /pools/retiring` | ✅ | — | |
+| `GET /pools/{pool_id}` | ⚠️ | Architecture | `calidus_key` not populated; live/active size semantics differ |
+| `GET /pools/{pool_id}/history` | ⚠️ | Formatting | Tiny floating-point serialization tail drift |
+| `GET /pools/{pool_id}/metadata` | ⚠️ | Architecture | Off-chain metadata (ticker, name, description, homepage) unsupported |
+| `GET /pools/{pool_id}/relays` | ⚠️ | Upstream | IPv6 byte-order decode bug in `yaci 0.4.0` |
+| `GET /pools/{pool_id}/delegators` | ✅ | — | |
+| `GET /pools/{pool_id}/blocks` | ✅ | — | |
+| `GET /pools/{pool_id}/updates` | ✅ | — | |
+| `GET /pools/{pool_id}/votes` | ⚠️ | Upstream | Blockfrost preprod returns `404` for all pools |
+
+## Open Gaps
+
+### Category A — Architecture / yaci-store Scope
+
+- **Off-chain metadata unavailable:** `GET /pools/{pool_id}/metadata` and the `name`, `ticker`,
+  `description`, `homepage` fields in `GET /pools/extended` and `GET /pools/{pool_id}` are always
+  `null`. Only on-chain URL and hash are indexed. Requires a separate off-chain metadata crawler.
+
+- **Stake semantics:** `live_stake` and `active_stake` use epoch-snapshot values from AdaPot
+  tables rather than Blockfrost's UTxO-derived methodology. Small value differences expected.
+
+- **`calidus_key` not populated:** Always `null` in `GET /pools/{pool_id}`.
+  Requires dedicated indexing support for the Calidus key certificate.
+
+- **Live/active size semantics:** `live_size` and `active_size` are fractions computed from
+  snapshots, not live UTxO data.
+
+### Category B — Upstream / Source-of-Truth Gaps
+
+- **`/votes` returns 404 on preprod:** Blockfrost preprod returns `404` for all pool vote queries.
+  Our implementation returns `[]`. Re-validate once Blockfrost indexes governance pool votes.
+
+- **IPv6 relay decode bug:** IPv6 addresses decoded incorrectly due to a byte-order bug in
+  `yaci 0.4.0`. Will auto-fix on library upgrade.
+
+### Category C — Formatting / Non-Functional
+
+- **Retired pool tie-breaking:** `GET /pools/retired` has ordering drift for same-epoch retirements.
+  Blockfrost uses an undocumented secondary sort key.
+
+- **History floating-point drift:** `GET /pools/{pool_id}/history` shows a tiny tail difference
+  in floating-point serialization. Values are functionally identical.
+
+## Indexes
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pool_registration_pool_id_slot
+    ON pool_registration (pool_id, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pool_retirement_pool_id_slot
+    ON pool_retirement (pool_id, slot);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pool_status_pool_id
+    ON pool_status (pool_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_epoch_stake_pool_epoch
+    ON epoch_stake (pool_id, epoch);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_slot_leader_epoch
+    ON block (slot_leader, epoch);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gov_action_pool_id
+    ON voting_procedure (pool_hash);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.pools.enabled=true` | All pool endpoints |
+| `store.adapot.enabled=true` | Stake fields |
+| `store.account.stake-address-balance-enabled=true` | `live_stake` / delegator amounts |
+| `store.governance.enabled=true` | `/votes` endpoint |
+
+## Release Notes
+
+All known mismatches are: accepted architecture limitations, an upstream yaci bug (auto-resolves
+on library upgrade), or a Blockfrost preprod data gap. No blockers prevent merging.
+Off-chain metadata is the most visible user-facing gap — document prominently in release notes.

--- a/extensions/blockfrost/adr/scripts_gaps.md
+++ b/extensions/blockfrost/adr/scripts_gaps.md
@@ -1,0 +1,49 @@
+# Scripts Module — Gaps & Open Items
+
+**PR:** #852 | **Status:** 🔄 Open PR | **Endpoints:** 7 / 7 (153 matched across 3 datasets)
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /scripts` | ⚠️ | First-page partial match — genesis-era script sync gap |
+| `GET /scripts/{script_hash}` | ✅ | |
+| `GET /scripts/{script_hash}/json` | ✅ | |
+| `GET /scripts/{script_hash}/cbor` | ✅ | |
+| `GET /scripts/{script_hash}/redeemers` | ✅ | Fee: `ceil(unitMem × priceMem + unitSteps × priceStep)` |
+| `GET /scripts/datum/{datum_hash}` | ✅ | |
+| `GET /scripts/datum/{datum_hash}/cbor` | ✅ | |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **Genesis-era script sync gap:** `GET /scripts` first-page results diverge because the local
+  node has indexed 136,214 of 137,732 scripts — the 1,518 missing scripts have `NULL` slot values
+  (genesis-era scripts). Blockfrost has indexed scripts from further back in preprod history.
+  The gap will close as the local node syncs. Not a code bug.
+
+  **Workaround applied:** `ORDER BY slot NULLS FIRST` for ascending sorts so null-slot (genesis)
+  scripts sort correctly once they are indexed.
+
+## Indexes
+
+```sql
+-- Partial index on transaction_scripts to speed up redeemer purpose lookups
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_scripts_purpose_not_null
+    ON transaction_scripts (script_hash, slot)
+    WHERE purpose IS NOT NULL;
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.scripts.enabled=true` | All script endpoints |
+| `store.script.enabled=true` | Script data |
+| `store.transaction.enabled=true` | Redeemer data |
+
+## Release Notes
+
+No functional blockers. The only gap is a sync-lag on genesis-era scripts which will
+self-resolve as the node syncs. Module is ready for merge.

--- a/extensions/blockfrost/adr/transaction_gaps.md
+++ b/extensions/blockfrost/adr/transaction_gaps.md
@@ -1,0 +1,83 @@
+# Transaction Module — Gaps & Open Items
+
+**PR:** #818 | **Status:** ✅ Merged | **Endpoints:** 13 / 13
+
+## Endpoint Status
+
+| Endpoint | Match | Notes |
+|----------|-------|-------|
+| `GET /txs/{hash}` | ⚠️ | `size` field undercount; `invalid_before` ambiguity |
+| `GET /txs/{hash}/utxos` | ✅ | |
+| `GET /txs/{hash}/stakes` | ✅ | |
+| `GET /txs/{hash}/delegations` | ✅ | |
+| `GET /txs/{hash}/withdrawals` | ✅ | |
+| `GET /txs/{hash}/mirs` | ✅ | |
+| `GET /txs/{hash}/pool_updates` | ⚠️ | Off-chain metadata fields null |
+| `GET /txs/{hash}/pool_retires` | ✅ | |
+| `GET /txs/{hash}/metadata` | ✅ | |
+| `GET /txs/{hash}/metadata/cbor` | ⚠️ | Returns empty list — raw CBOR not stored at ingest time |
+| `GET /txs/{hash}/redeemers` | ✅ | Fee: `ceil(priceMem × unitMem + priceStep × unitSteps)` |
+| `GET /txs/{hash}/cbor` | ⚠️ | Body-only CBOR (`a8xx`) — not full envelope |
+| `GET /txs/{hash}/dreps` | ✅ | |
+
+## Open Gaps
+
+### Accepted Limitations
+
+- **CBOR body-only format:** `TransactionProcessor` stores body-only CBOR. Full envelope
+  (`84xx` — body + witnesses + validity + metadata) requires an ingestion-layer change.
+  Shared root cause with [Block module](block_gaps.md).
+
+- **`size` undercount:** `TRANSACTION_CBOR.CBOR_SIZE` stores only the body byte count.
+  Blockfrost reports the full serialized transaction size. Systematic undercount sharing
+  the same root cause as the CBOR format gap.
+
+- **`invalid_before` ambiguity:** When `validity_interval_start = 0`, the system cannot
+  distinguish "field absent" from "explicitly set to slot 0". Returns `null` in both cases,
+  which is correct for virtually all transactions.
+
+- **Metadata CBOR empty list:** Raw CBOR metadata bytes are not stored at ingestion — only JSON
+  is persisted. Re-encoding from JSON is not attempted.
+
+- **Pool update off-chain metadata null:** `name`, `ticker`, `homepage`, `description` always
+  `null` in `GET /txs/{hash}/pool_updates`. Requires a separate off-chain metadata crawler.
+
+- **Transaction submission unsupported:** `POST /tx/submit` is outside the scope of this module.
+
+## Indexes
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_tx_hash_tx_index
+    ON transaction (tx_hash, tx_index);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transaction_cbor_tx_hash
+    ON transaction_cbor (tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_input_tx_hash
+    ON tx_input (tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_delegation_tx_hash
+    ON delegation (tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stake_registration_tx_hash
+    ON stake_registration (tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pool_registration_tx_hash
+    ON pool_registration (tx_hash);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_drep_registration_tx_hash
+    ON drep_registration (tx_hash);
+```
+
+## Configuration
+
+| Property | Required For |
+|----------|-------------|
+| `store.extensions.blockfrost.transaction.enabled=true` | All transaction endpoints |
+| `store.transaction.saveCbor=true` | `GET /txs/{hash}/cbor` (otherwise 404) |
+| `store.transaction.enabled=true` | Underlying transaction data |
+
+## Release Notes
+
+No functional blockers. Three gaps (CBOR format, `size`, metadata CBOR) share the same
+ingestion-layer root cause. All are accepted limitations for the current release.


### PR DESCRIPTION


Adds extensions/blockfrost/adr/{module}_gaps.md for each of the 11 Blockfrost compatibility modules. Each file captures:
- Endpoint-level match/mismatch status
- Open gaps categorised as accepted limitations or tracked issues
- Required index SQL (CONCURRENTLY IF NOT EXISTS)
- Configuration prerequisites
- Release readiness notes

Modules covered: epoch (#780), address (#784), asset (#780), block (#811), transaction (#818), account (#836), pools (#847), scripts (#852), governance (#865), network (#866), metadata (#872).