### PR TITLE
 chore: Set JVM DNS cache TTL defaults for Yaci 0.4.4

### DIFF
--- a/bin/start.bat
+++ b/bin/start.bat
@@ -9,6 +9,9 @@ REM ------------------------------------------------------------
 REM Save the current working directory
 SET CURRENT_DIR=%CD%
 
+REM Lower JVM DNS cache TTLs to avoid stale DNS cache.
+SET "JAVA_OPTS=-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10 %JAVA_OPTS%"
+
 REM Uncomment the following line to enable polyglot (Python, JS) plugins support.
 :: set "JAVA_OPTS=%JAVA_OPTS% -Dloader.path=plugins,plugins/lib,plugins/ext-jars"
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Lower JVM DNS cache TTLs to avoid stale DNS cache.
+JAVA_OPTS="-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10 $JAVA_OPTS"
+
 # Uncomment the following line to enable polyglot (Python, JS) plugins support.
 #JAVA_OPTS="$JAVA_OPTS -Dloader.path=plugins,plugins/lib,plugins/ext-jars"
 

--- a/docker/config/env
+++ b/docker/config/env
@@ -1,11 +1,14 @@
 # Common env file
 
-# Java Options
+# Lower JVM DNS cache TTLs to avoid stale DNS cache.
+JAVA_TOOL_OPTIONS=-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10
+
+# JVM options (heap, GC, etc.).
 # JDK_JAVA_OPTIONS=-Xms4G -Xmx12G
 
 ## Enable Ledger State profile
 #SPRING_PROFILES_ACTIVE=ledger-state
 
 ## Enable polyglot plugins (Python, JS) support.
-# JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+# LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
 

--- a/docs/pages/plugins/plugin-getting-started.mdx
+++ b/docs/pages/plugins/plugin-getting-started.mdx
@@ -22,7 +22,7 @@ First, unzip your yaci-store docker distribution and navigate to the directory.
 Edit the `config/env` file to enable plugin support by uncommenting the following line:
 
 ```bash
-JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
 ```
 
 ### 2. Understanding the Plugin Directory Structure

--- a/docs/pages/tutorials/tracking-address-utxos.mdx
+++ b/docs/pages/tutorials/tracking-address-utxos.mdx
@@ -203,7 +203,7 @@ Yaci Store uses a plugin system to extend its functionality. Let's enable it.
    Find and uncomment (remove the `#` at the beginning) this line:
 
    ```bash
-   JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+   LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
    ```
 
    This tells Yaci Store to load plugins from the `plugins` directory.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-yaci = "com.bloxbean.cardano:yaci:0.4.3"
+yaci = "com.bloxbean.cardano:yaci:0.4.4"
 cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.2"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.2"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.2"


### PR DESCRIPTION
 ## Summary
  
  Pair the upstream Yaci 0.4.4 stale-DNS-cache fix ([bloxbean/yaci#163](https://github.com/bloxbean/yaci/pull/163)) with the JVM-level TTL flags it requires. Without these flags the JVM keeps returning a stale cached IP and the upstream re-resolve-on-retry logic never sees a fresh address — the fix appears to ship but does nothing in practice.

  ## Changes

  - **`bin/start.sh`, `bin/start.bat`** — prepend `-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10` to `JAVA_OPTS`. Any user-exported `JAVA_OPTS` is preserved (appended after our defaults so the user wins on conflicting `-D` keys).
  - **`docker/config/env`** — ship the same flags via `JAVA_TOOL_OPTIONS` as an always-on baseline. `JDK_JAVA_OPTIONS` stays reserved for operator-tunable heap/GC flags (the JVM combines both — they do not overwrite each other unless they target the same `-D` key).
  - **`docker/config/env` (polyglot example)** — migrate from the broken `JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=…` self-append pattern (Compose `env_file` does not interpolate,
  and duplicate keys overwrite) to `LOADER_PATH=…`, which Spring Boot's `PropertiesLauncher` reads natively as an env var.
  - **Docs** — update `docs/pages/plugins/plugin-getting-started.mdx` and `docs/pages/tutorials/tracking-address-utxos.mdx` to reference the new `LOADER_PATH=` form for the Docker setup.