### PR TITLE
feat(admin-cli): add generic index apply command

### DIFF
--- a/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
+++ b/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
@@ -18,6 +18,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.command.annotation.Option;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,7 +31,6 @@ import static com.bloxbean.cardano.yaci.store.admin.cli.common.ConsoleWriter.*;
 public class DBCommands {
     private static final String INDEX_FILE = "index.yml";
     private static final String EXTRA_INDEX_FILE = "extra-index.yml";
-    private static final String BLOCKFROST_INDEX_FILE = "blockfrost-index.yml";
     private static final String ROLLBACK_LEDGER_STATE_FILE = "rollback-ledger-state.yml";
 
     private final IndexService indexService;
@@ -70,24 +70,30 @@ public class DBCommands {
     @Command(description = "Apply the default indexes required for read operations.")
     public void applyIndexes(@Option(longNames = "skip-extra-indexes", defaultValue = "false", description = "Skip additional optional indexes.") boolean skipExtraIndexes) {
         writeLn(info("Start to apply index ..."));
-        applyIndexes(INDEX_FILE);
+        applyIndexesFromFiles(INDEX_FILE);
 
         if (!skipExtraIndexes) {
             writeLn(info("Start to apply extra index ..."));
-            applyIndexes(EXTRA_INDEX_FILE);
+            applyIndexesFromFiles(EXTRA_INDEX_FILE);
         }
     }
 
     @Command(description = "Apply only additional optional read indexes")
     public void applyExtraIndexes() {
         writeLn(info("Start to apply extra index ..."));
-        applyIndexes(EXTRA_INDEX_FILE);
+        applyIndexesFromFiles(EXTRA_INDEX_FILE);
     }
 
-    @Command(description = "Apply Blockfrost compatibility read indexes")
-    public void applyBlockfrostIndexes() {
-        writeLn(info("Start to apply Blockfrost index ..."));
-        applyBlockfrostIndexes(BLOCKFROST_INDEX_FILE);
+    @Command(description = "Apply one or more optional index definitions")
+    public void applyOptionalIndexes(
+            @Option(longNames = "indexes", label = "indexes",
+                    description = "Comma-separated optional index names (e.g., 'blockfrost-index,asset-ext-index')")
+            String indexes,
+            @Option(longNames = "index-files", label = "index-files",
+                    description = "Comma-separated index definition file paths (e.g., 'file:///path/to/index.yml')")
+            String indexFiles) {
+        writeLn(info("Start to apply optional indexes ..."));
+        applyIndexesFromFiles(getIndexFiles(indexes, indexFiles));
     }
 
     @Command(description = "Rollback data to a previous epoch")
@@ -136,12 +142,12 @@ public class DBCommands {
         }
     }
 
-    private void applyIndexes(String indexFile) {
+    private void applyIndexesFromFiles(String... indexFiles) {
         IndexLoader indexLoader = new IndexLoader();
-        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexes(indexFile);
+        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexesFromMultipleFiles(indexFiles);
         if (indexDefinitionList == null || indexDefinitionList.isEmpty()) {
             log.warn("No optional index found to apply");
-            writeLn(warn("No optional index found to apply : {}", indexFile));
+            writeLn(warn("No optional index found to apply from files: %s", String.join(", ", indexFiles)));
             return;
         }
 
@@ -149,22 +155,6 @@ public class DBCommands {
 
         if (!result.getSecond().isEmpty()) {
             log.warn(">> Failed to apply these indexes : " + result.getSecond());
-        }
-    }
-
-    private void applyBlockfrostIndexes(String indexFile) {
-        IndexLoader indexLoader = new IndexLoader();
-        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexes(indexFile);
-        if (indexDefinitionList == null || indexDefinitionList.isEmpty()) {
-            log.warn("No Blockfrost index found to apply");
-            writeLn(warn("No Blockfrost index found to apply : {}", indexFile));
-            return;
-        }
-
-        var result = indexService.applyIndexes(indexDefinitionList);
-
-        if (!result.getSecond().isEmpty()) {
-            log.warn(">> Failed to apply these Blockfrost indexes : " + result.getSecond());
         }
     }
 
@@ -205,6 +195,45 @@ public class DBCommands {
         }
 
         return new String[]{this.rollbackFiles};
+    }
+
+    private String[] getIndexFiles(String indexes, String indexFiles) {
+        List<String> files = new ArrayList<>();
+
+        if (indexes != null && !indexes.trim().isEmpty()) {
+            List<String> internalIndexes = parseCommaSeparatedFiles(indexes);
+            internalIndexes.stream()
+                    .filter(this::isResourcePath)
+                    .findFirst()
+                    .ifPresent(resourcePath -> {
+                        throw new IllegalArgumentException("External index file paths should be provided with --index-files: " + resourcePath);
+                    });
+            files.addAll(internalIndexes);
+        }
+
+        if (indexFiles != null && !indexFiles.trim().isEmpty()) {
+            files.addAll(parseCommaSeparatedFiles(indexFiles));
+        }
+
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException("Index names or --index-files must be provided");
+        }
+
+        return files.toArray(String[]::new);
+    }
+
+    private List<String> parseCommaSeparatedFiles(String files) {
+        return Arrays.stream(files.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private boolean isResourcePath(String filePath) {
+        return filePath.startsWith("classpath:") ||
+                filePath.startsWith("file:") ||
+                filePath.startsWith("http:") ||
+                filePath.startsWith("https:");
     }
 
     private void applyRollback(String[] rollbackFiles, RollbackContext rollbackContext) {

--- a/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
+++ b/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
@@ -30,6 +30,7 @@ import static com.bloxbean.cardano.yaci.store.admin.cli.common.ConsoleWriter.*;
 public class DBCommands {
     private static final String INDEX_FILE = "index.yml";
     private static final String EXTRA_INDEX_FILE = "extra-index.yml";
+    private static final String BLOCKFROST_INDEX_FILE = "blockfrost-index.yml";
     private static final String ROLLBACK_LEDGER_STATE_FILE = "rollback-ledger-state.yml";
 
     private final IndexService indexService;
@@ -81,6 +82,12 @@ public class DBCommands {
     public void applyExtraIndexes() {
         writeLn(info("Start to apply extra index ..."));
         applyIndexes(EXTRA_INDEX_FILE);
+    }
+
+    @Command(description = "Apply Blockfrost compatibility read indexes")
+    public void applyBlockfrostIndexes() {
+        writeLn(info("Start to apply Blockfrost index ..."));
+        applyBlockfrostIndexes(BLOCKFROST_INDEX_FILE);
     }
 
     @Command(description = "Rollback data to a previous epoch")
@@ -142,6 +149,22 @@ public class DBCommands {
 
         if (!result.getSecond().isEmpty()) {
             log.warn(">> Failed to apply these indexes : " + result.getSecond());
+        }
+    }
+
+    private void applyBlockfrostIndexes(String indexFile) {
+        IndexLoader indexLoader = new IndexLoader();
+        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexes(indexFile);
+        if (indexDefinitionList == null || indexDefinitionList.isEmpty()) {
+            log.warn("No Blockfrost index found to apply");
+            writeLn(warn("No Blockfrost index found to apply : {}", indexFile));
+            return;
+        }
+
+        var result = indexService.applyIndexes(indexDefinitionList);
+
+        if (!result.getSecond().isEmpty()) {
+            log.warn(">> Failed to apply these Blockfrost indexes : " + result.getSecond());
         }
     }
 

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexDefinition.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexDefinition.java
@@ -21,5 +21,6 @@ public class IndexDefinition {
         private List<String> columns;
         private String type;
         private List<String> excludes;
+        private String where;
     }
 }

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/IndexService.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/IndexService.java
@@ -69,7 +69,10 @@ public class IndexService {
                     return null;
 
                 String using = index.getType() != null? "USING " + index.getType().trim() : "";
-                return String.format("CREATE INDEX IF NOT EXISTS %s ON %s %s (%s);", indexName, tableName, using, columns);
+                String where = index.getWhere() != null && !index.getWhere().trim().isEmpty()
+                        ? " WHERE " + index.getWhere().trim()
+                        : "";
+                return String.format("CREATE INDEX IF NOT EXISTS %s ON %s %s (%s) %s;", indexName, tableName, using, columns, where);
             case h2:
                 if (index.getExcludes() != null && index.getExcludes().contains(DatabaseUtils.DbType.h2.toString()))
                     return null;

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
@@ -30,7 +30,8 @@ public class IndexLoader {
                 List<String> columns = (List<String>) indexMap.get("columns");
                 String type = (String) indexMap.get("type");
                 List<String> excludes = (List<String>) indexMap.get("excludes");
-                IndexDefinition.Index index = new IndexDefinition.Index(name, columns, type, excludes);
+                String where = (String) indexMap.get("where");
+                IndexDefinition.Index index = new IndexDefinition.Index(name, columns, type, excludes, where);
                 indexes.add(index);
             }
 

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
@@ -1,14 +1,28 @@
 package com.bloxbean.cardano.yaci.store.dbutils.index.util;
 
 import com.bloxbean.cardano.yaci.store.dbutils.index.model.IndexDefinition;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class IndexLoader {
+
+    private ResourceLoader resourceLoader;
+
+    public IndexLoader() {
+        this.resourceLoader = new DefaultResourceLoader();
+    }
+
+    public IndexLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
 
     public List<IndexDefinition> loadIndexes(String yamlFilePath) {
         Yaml yaml = new Yaml();
@@ -18,6 +32,89 @@ public class IndexLoader {
         }
 
         List<Map<String, Object>> data = yaml.load(inputStream);
+        return parseIndexDefinitions(data);
+    }
+
+    public List<IndexDefinition> loadIndexesFromMultipleFiles(String... filePaths) {
+        List<IndexDefinition> allIndexDefinitions = new ArrayList<>();
+
+        for (String filePath : filePaths) {
+            String normalizedFilePath = normalizeFilePath(filePath);
+            List<IndexDefinition> indexDefinitions;
+
+            if (isResourcePath(normalizedFilePath)) {
+                if (resourceLoader == null) {
+                    throw new IllegalStateException("ResourceLoader not configured for resource path: " + normalizedFilePath);
+                }
+                indexDefinitions = loadIndexesFromResourcePath(normalizedFilePath);
+            } else {
+                indexDefinitions = loadIndexes(normalizedFilePath);
+            }
+
+            if (indexDefinitions != null) {
+                allIndexDefinitions.addAll(indexDefinitions);
+            }
+        }
+
+        return allIndexDefinitions;
+    }
+
+    private boolean isResourcePath(String filePath) {
+        return filePath.startsWith("classpath:") ||
+                filePath.startsWith("file:") ||
+                filePath.startsWith("http:") ||
+                filePath.startsWith("https:");
+    }
+
+    private List<IndexDefinition> loadIndexesFromResourcePath(String resourcePath) {
+        try {
+            Resource resource = resourceLoader.getResource(resourcePath);
+            if (!resource.exists()) {
+                throw new IllegalArgumentException("Resource not found: " + resourcePath);
+            }
+
+            Yaml yaml = new Yaml();
+            try (InputStream inputStream = resource.getInputStream()) {
+                List<Map<String, Object>> data = yaml.load(inputStream);
+                return parseIndexDefinitions(data);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error loading resource: " + resourcePath, e);
+        }
+    }
+
+    private String normalizeFilePath(String filePath) {
+        if (filePath == null) {
+            throw new IllegalArgumentException("Index file path cannot be null");
+        }
+
+        String normalizedFilePath = filePath.trim();
+        if (normalizedFilePath.isEmpty()) {
+            throw new IllegalArgumentException("Index file path cannot be empty");
+        }
+
+        if (isResourcePath(normalizedFilePath)) {
+            return normalizedFilePath;
+        }
+
+        String fileName = normalizedFilePath;
+        int lastSeparator = Math.max(normalizedFilePath.lastIndexOf('/'), normalizedFilePath.lastIndexOf('\\'));
+        if (lastSeparator >= 0) {
+            fileName = normalizedFilePath.substring(lastSeparator + 1);
+        }
+
+        if (!fileName.contains(".")) {
+            return normalizedFilePath + ".yml";
+        }
+
+        return normalizedFilePath;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<IndexDefinition> parseIndexDefinitions(List<Map<String, Object>> data) {
+        if (data == null) {
+            return new ArrayList<>();
+        }
 
         List<IndexDefinition> indexDefinitions = new ArrayList<>();
         for (Map<String, Object> item : data) {

--- a/components/dbutils/src/main/resources/META-INF/native-image/yaci-store-dbutils/resource-config.json
+++ b/components/dbutils/src/main/resources/META-INF/native-image/yaci-store-dbutils/resource-config.json
@@ -1,6 +1,7 @@
 {
   "resources":{
   "includes":[
+    {"pattern": "blockfrost-index.yml$"},
     {"pattern": "extra-index.yml$"},
     {"pattern":  "index.yml$"},
     {"pattern":  "rollback.yml$"},

--- a/components/dbutils/src/main/resources/blockfrost-index.yml
+++ b/components/dbutils/src/main/resources/blockfrost-index.yml
@@ -1,0 +1,59 @@
+- table: address_utxo
+  indexes:
+    - name: idx_address_utxo_owner_addr_full
+      columns:
+        - owner_addr_full
+    - name: idx_address_utxo_block
+      columns:
+        - block_hash
+
+- table: assets
+  indexes:
+    - name: idx_assets_unit_slot
+      columns:
+        - unit
+        - slot
+    - name: idx_assets_unit_policy
+      columns:
+        - unit
+        - policy
+    - name: idx_assets_unit_qty
+      columns:
+        - unit
+        - quantity
+
+- table: transaction
+  indexes:
+    - name: idx_transaction_block_tx_index_tx_hash
+      columns:
+        - block_hash
+        - tx_index
+        - tx_hash
+
+- table: tx_input
+  indexes:
+    - name: idx_tx_input_spent_at_block_spent_tx_hash
+      columns:
+        - spent_at_block
+        - spent_tx_hash
+    - name: idx_tx_input_tx_hash
+      columns:
+        - tx_hash
+
+- table: block
+  indexes:
+    - name: idx_block_epoch_slot
+      columns:
+        - epoch
+        - slot
+
+- table: transaction_scripts
+  indexes:
+    - name: idx_transaction_scripts_purpose_not_null
+      columns:
+        - script_hash
+        - slot
+      where: purpose IS NOT NULL
+      excludes:
+        - mysql
+        - h2

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
@@ -3,9 +3,11 @@ package com.bloxbean.cardano.yaci.store.dbutils.index.model;
 import com.bloxbean.cardano.yaci.store.dbutils.index.util.IndexLoader;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class IndexLoaderTest {
 
@@ -33,5 +35,44 @@ class IndexLoaderTest {
         assertThat(indexDefinitions).hasSizeGreaterThan(0);
         assertThat(indexDefinitions).hasSizeGreaterThan(5);
         assertThat(indexDefinitions.get(0)).isInstanceOf(IndexDefinition.class);
+    }
+
+    @Test
+    void loadIndexesFromMultipleFiles() {
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles("test-index-1.yml", "test-index-2.yml");
+
+        assertThat(indexDefinitions).hasSize(2);
+        assertThat(indexDefinitions)
+                .extracting(IndexDefinition::getTable)
+                .containsExactly("test_table_1", "test_table_2");
+    }
+
+    @Test
+    void loadIndexesFromFileResourcePath() throws Exception {
+        var resource = getClass().getClassLoader().getResource("test-index-1.yml");
+        assertThat(resource).isNotNull();
+
+        String filePath = Path.of(resource.toURI()).toUri().toString();
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles(filePath);
+
+        assertThat(indexDefinitions).hasSize(1);
+        assertThat(indexDefinitions.get(0).getTable()).isEqualTo("test_table_1");
+    }
+
+    @Test
+    void loadIndexesFromMultipleFilesShouldAppendYmlSuffix() {
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles("test-index-1");
+
+        assertThat(indexDefinitions).hasSize(1);
+        assertThat(indexDefinitions.get(0).getTable()).isEqualTo("test_table_1");
+    }
+
+    @Test
+    void loadIndexesFromMultipleFilesShouldThrowForMissingFile() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IndexLoader().loadIndexesFromMultipleFiles("missing-index"));
     }
 }

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
@@ -26,4 +26,12 @@ class IndexLoaderTest {
         assertThat(indexDefinitions.get(0).getIndexes().get(0).getType()).isEqualTo("gin");
         assertThat(indexDefinitions.get(0).getIndexes().get(0).getExcludes()).hasSizeGreaterThan(0);
     }
+
+    @Test
+    void loadBlockfrostIndexes() {
+        List<IndexDefinition> indexDefinitions = new IndexLoader().loadIndexes("blockfrost-index.yml");
+        assertThat(indexDefinitions).hasSizeGreaterThan(0);
+        assertThat(indexDefinitions).hasSizeGreaterThan(5);
+        assertThat(indexDefinitions.get(0)).isInstanceOf(IndexDefinition.class);
+    }
 }

--- a/components/dbutils/src/test/resources/test-index-1.yml
+++ b/components/dbutils/src/test/resources/test-index-1.yml
@@ -1,0 +1,5 @@
+- table: test_table_1
+  indexes:
+    - name: idx_test_table_1_slot
+      columns:
+        - slot

--- a/components/dbutils/src/test/resources/test-index-2.yml
+++ b/components/dbutils/src/test/resources/test-index-2.yml
@@ -1,0 +1,5 @@
+- table: test_table_2
+  indexes:
+    - name: idx_test_table_2_hash
+      columns:
+        - hash


### PR DESCRIPTION
## Summary

  This PR add  a generic optional index command that can apply one or more named index definitions and external index definition files. 

  The existing `apply-indexes` and `apply-extra-indexes` commands remain unchanged.

  ## Changes

  - Add `apply-optional-indexes` command for optional index definitions.
  - Enhance `IndexLoader` to support:
    - multiple index definition files
    - named index definitions resolved from classpath resources
    - external resources via `file:`, `classpath:`, `http:`, and `https:`
  - Keep shorthand named index usage ergonomic by resolving names without extension as `.yml`.
  - Add `IndexLoader` tests for multi-file loading, `.yml` shorthand resolution, external `file:` loading, and missing file handling.

  ## Command Usage

  ```bash
  ## Apply BF Compatibility Indexes
  apply-optional-indexes blockfrost-index

  ## Apply multiple named index definitions:

  apply-optional-indexes blockfrost-index,asset-ext-index

  ## Apply an external index definition file:

  apply-optional-indexes --index-files file:///opt/yaci-store/custom-index.yml

  ## Apply multiple external index definition files:

  apply-optional-indexes --index-files file:///opt/index-a.yml,file:///opt/index-b.yml

  ## Apply a named index definition together with an external file:

  apply-optional-indexes blockfrost-index --index-files file:///opt/yaci-store/custom-index.yml
```
  ## Notes

  - External resource paths should be passed through --index-files.
  - Existing commands still work:
      - apply-indexes
      - apply-extra-indexes

