### PR TITLE
fix: align Blockfrost V3 cost model output

### DIFF
--- a/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/dto/BFProtocolParamsDto.java
+++ b/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/dto/BFProtocolParamsDto.java
@@ -11,7 +11,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
@@ -89,8 +88,8 @@ public class BFProtocolParamsDto {
     private String committeeMinSize;
     private String committeeMaxTermLength;
     private String govActionLifetime;
-    private BigInteger govActionDeposit;
-    private BigInteger drepDeposit;
+    private String govActionDeposit;
+    private String drepDeposit;
     private String drepActivity;
     private BigDecimal minFeeRefScriptCostPerByte;
 

--- a/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/mapper/BFProtocolParamMapperDecorator.java
+++ b/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/mapper/BFProtocolParamMapperDecorator.java
@@ -39,20 +39,28 @@ public class BFProtocolParamMapperDecorator implements BFProtocolParamMapper {
             bfProtocolParamsDto.setDecentralisationParam(BigDecimal.ZERO);
         }
 
-        if(protocolParamsDto.getCostModels() != null) {
-            Map<String, List<Long>> costModelsRaw =  protocolParamsDto.getCostModels().entrySet().stream()
+        Map<String, List<Long>> costModelsRaw = protocolParamsDto.getCostModelsRaw();
+        if(costModelsRaw == null && protocolParamsDto.getCostModels() != null) {
+            costModelsRaw = protocolParamsDto.getCostModels().entrySet().stream()
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
                             entry -> entry.getValue().entrySet().stream()
                                     .map(Map.Entry::getValue)
                                     .collect(Collectors.toList())
                     ));
+        }
+
+        if (costModelsRaw != null) {
             bfProtocolParamsDto.setCostModelsRaw(costModelsRaw);
         }
 
         bfProtocolParamsDto.setEMax(protocolParamsDto.getEMax());
         bfProtocolParamsDto.setNOpt(protocolParamsDto.getNOpt());
         bfProtocolParamsDto.setPvtPPSecurityGroup(protocolParamsDto.getPvtppSecurityGroup());
+        bfProtocolParamsDto.setGovActionDeposit(protocolParamsDto.getGovActionDeposit() != null
+                ? protocolParamsDto.getGovActionDeposit().toString() : null);
+        bfProtocolParamsDto.setDrepDeposit(protocolParamsDto.getDrepDeposit() != null
+                ? protocolParamsDto.getDrepDeposit().toString() : null);
 
         return bfProtocolParamsDto;
     }

--- a/extensions/blockfrost/epoch/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/mapper/BFProtocolParamMapperTest.java
+++ b/extensions/blockfrost/epoch/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/mapper/BFProtocolParamMapperTest.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.epoch.mapper;
+
+import com.bloxbean.cardano.yaci.store.blockfrost.epoch.dto.BFProtocolParamsDto;
+import com.bloxbean.cardano.yaci.store.epoch.dto.ProtocolParamsDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BFProtocolParamMapperTest {
+    private final BFProtocolParamMapper mapper = BFProtocolParamMapper.INSTANCE;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldSerializeGovernanceDepositsAsStrings() throws Exception {
+        ProtocolParamsDto protocolParamsDto = ProtocolParamsDto.builder()
+                .govActionDeposit(BigInteger.valueOf(100000000000L))
+                .drepDeposit(BigInteger.valueOf(500000000L))
+                .build();
+
+        BFProtocolParamsDto bfProtocolParamsDto = mapper.toBFProtocolParamsDto(protocolParamsDto);
+        String json = objectMapper.writeValueAsString(bfProtocolParamsDto);
+
+        assertThat(bfProtocolParamsDto.getGovActionDeposit()).isEqualTo("100000000000");
+        assertThat(bfProtocolParamsDto.getDrepDeposit()).isEqualTo("500000000");
+        assertThat(json).contains("\"gov_action_deposit\":\"100000000000\"");
+        assertThat(json).contains("\"drep_deposit\":\"500000000\"");
+    }
+}

--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/util/PlutusOps.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/util/PlutusOps.java
@@ -691,10 +691,9 @@ public class PlutusOps {
             keys = map2.keySet();
             V2_OPS = keys.stream().sorted().toList();
 
-            Map<String, Long> map3 = objectMapper.readValue(PLUTUS_V3_COSTS, new TypeReference<SortedMap<String, Long>>() {
+            Map<String, Long> map3 = objectMapper.readValue(PLUTUS_V3_COSTS, new TypeReference<LinkedHashMap<String, Long>>() {
             });
-            keys = map3.keySet();
-            V3_OPS = keys.stream().sorted().toList();
+            V3_OPS = map3.keySet().stream().toList();
 
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Summary

This PR fixes Blockfrost epoch protocol parameter parity for Plutus V3 cost model output.

When comparing local Blockfrost-compatible epoch APIs against Blockfrost mainnet, the `/epochs/{number}/parameters` response showed mismatches in the Plutus V3 cost model values. The local response was returning V3 cost model entries in an order that did not match the ledger/Blockfrost order, causing value-to-operation mismatches in the serialized response.

## Problem

- Blockfrost expects Plutus V3 cost model values to follow ledger order.
- Local output derived V3 cost model operation names in a different order.
- This caused many Plutus V3 cost model fields to have incorrect values when compared with Blockfrost.
- Governance deposit fields also needed Blockfrost-compatible string serialization.

## Fix

- Updated Plutus V3 cost model operation ordering to preserve the ledger-defined order.
- Reused the existing V3 cost model source instead of adding a Blockfrost-specific duplicate model.
- Updated Blockfrost epoch protocol parameter mapping to:
  - preserve raw cost model data when available
  - serialize `gov_action_deposit` as a string
  - serialize `drep_deposit` as a string
## Validation
- [x] testing on mainnet
- [ ] testing on preprod
- [ ] testing on the preview