### PR TITLE
Normalize direct-start genesis protocol parameters

### DIFF
--- a/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/processor/EpochParamProcessor.java
+++ b/stores/epoch/src/main/java/com/bloxbean/cardano/yaci/store/epoch/processor/EpochParamProcessor.java
@@ -60,6 +60,11 @@ public class EpochParamProcessor {
                 .orElse(null);
 
         if (genesisProtocolParams != null) {
+            //Normalize direct-start genesis params (e.g. direct Conway/Babbage/Alonzo start) the same way
+            //resolveEpochParam() does, so the initial epoch_param row exposes effective protocol params
+            //(clears Alonzo minUtxo, applies Babbage byte-based UTxO cost translation).
+            ppEraChangeRules.apply(startEra, null, genesisProtocolParams);
+
             log.info("Network is starting with the following protocol params : \n" + genesisProtocolParams);
 
             EpochParam epochParam = EpochParam.builder()

--- a/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/EpochParamProcessorTest.java
+++ b/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/EpochParamProcessorTest.java
@@ -13,6 +13,7 @@ import com.bloxbean.cardano.yaci.store.epoch.domain.EpochParam;
 import com.bloxbean.cardano.yaci.store.epoch.storage.EpochParamStorage;
 import com.bloxbean.cardano.yaci.store.epoch.storage.ProtocolParamsProposalStorage;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
+import com.bloxbean.cardano.yaci.store.events.GenesisBlockEvent;
 import com.bloxbean.cardano.yaci.store.events.internal.PreAdaPotJobProcessingEvent;
 import com.bloxbean.cardano.yaci.store.events.internal.PreEpochTransitionEvent;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -199,5 +201,83 @@ class EpochParamProcessorTest {
         assertThat(epochParam.getParams().getDrepActivity()).isEqualTo(20);
         assertThat(epochParam.getParams().getMaxTxSize()).isEqualTo(1000);
     }
+    @Test
+    void givenGenesisBlockEvent_directConwayStart_shouldNormalizeProtocolParams() {
+        //Direct Conway start (custom/devnet): merged genesis params carry raw pre-Babbage values
+        ProtocolParams genesisParams = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))      //Shelley minUTxOValue
+                .adaPerUtxoByte(BigInteger.valueOf(34482))  //Alonzo lovelacePerUTxOWord
+                .build();
+
+        GenesisBlockEvent genesisBlockEvent = GenesisBlockEvent.builder()
+                .era(Era.Conway)
+                .epoch(0)
+                .slot(-1)
+                .block(-1)
+                .blockTime(1666342887)
+                .protocolMagic(42)
+                .build();
+
+        Mockito.when(eraGenesisProtocolParamsUtil.getGenesisProtocolParameters(Era.Conway, null, 42))
+                .thenReturn(Optional.of(genesisParams));
+
+        epochParamProcessor.handleGenesisBlockEvent(genesisBlockEvent);
+
+        Mockito.verify(epochParamStorage, Mockito.times(1)).save(argCaptor.capture());
+        EpochParam epochParam = argCaptor.getValue();
+
+        //Both Alonzo and Babbage rules applied for a direct Conway start
+        assertThat(epochParam.getParams().getMinUtxo()).isNull();
+        assertThat(epochParam.getParams().getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(4310)); //34482 / 8
+        assertThat(epochParam.getEpoch()).isEqualTo(0);
+        assertThat(epochParam.getBlockTime()).isEqualTo(1666342887);
+    }
+
+    @Test
+    void givenGenesisBlockEvent_directAlonzoStart_shouldClearMinUtxoOnly() {
+        //Direct Alonzo start (e.g. preview): only the Alonzo rule applies; the word-based
+        //adaPerUtxoByte (34482) is correct for Alonzo and must NOT be divided by 8 here.
+        ProtocolParams genesisParams = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        GenesisBlockEvent genesisBlockEvent = GenesisBlockEvent.builder()
+                .era(Era.Alonzo)
+                .epoch(0)
+                .slot(-1)
+                .block(-1)
+                .blockTime(1666342887)
+                .protocolMagic(2)
+                .build();
+
+        Mockito.when(eraGenesisProtocolParamsUtil.getGenesisProtocolParameters(Era.Alonzo, null, 2))
+                .thenReturn(Optional.of(genesisParams));
+
+        epochParamProcessor.handleGenesisBlockEvent(genesisBlockEvent);
+
+        Mockito.verify(epochParamStorage, Mockito.times(1)).save(argCaptor.capture());
+        EpochParam epochParam = argCaptor.getValue();
+
+        assertThat(epochParam.getParams().getMinUtxo()).isNull();
+        assertThat(epochParam.getParams().getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(34482)); //unchanged
+    }
+
+    @Test
+    void givenGenesisBlockEvent_whenNoGenesisProtocolParams_shouldNotSave() {
+        GenesisBlockEvent genesisBlockEvent = GenesisBlockEvent.builder()
+                .era(Era.Byron)
+                .epoch(0)
+                .protocolMagic(1)
+                .build();
+
+        Mockito.when(eraGenesisProtocolParamsUtil.getGenesisProtocolParameters(Era.Byron, null, 1))
+                .thenReturn(Optional.empty());
+
+        epochParamProcessor.handleGenesisBlockEvent(genesisBlockEvent);
+
+        Mockito.verify(epochParamStorage, Mockito.never()).save(Mockito.any());
+    }
+
     //TODO -- Add more test cases without mock
 }

--- a/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/PPEraChangeRulesTest.java
+++ b/stores/epoch/src/test/java/com/bloxbean/cardano/yaci/store/epoch/processor/PPEraChangeRulesTest.java
@@ -1,10 +1,78 @@
 package com.bloxbean.cardano.yaci.store.epoch.processor;
 
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PPEraChangeRulesTest {
 
+    private final PPEraChangeRules rules = new PPEraChangeRules();
+
     @Test
-    void apply() {
+    void apply_directConwayStart_appliesAlonzoAndBabbageRules() {
+        ProtocolParams pp = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        rules.apply(Era.Conway, null, pp);
+
+        assertThat(pp.getMinUtxo()).isNull();
+        assertThat(pp.getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(4310)); //34482 / 8
+    }
+
+    @Test
+    void apply_directBabbageStart_appliesAlonzoAndBabbageRules() {
+        ProtocolParams pp = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        rules.apply(Era.Babbage, null, pp);
+
+        assertThat(pp.getMinUtxo()).isNull();
+        assertThat(pp.getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(4310));
+    }
+
+    @Test
+    void apply_directAlonzoStart_appliesOnlyAlonzoRule() {
+        ProtocolParams pp = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        rules.apply(Era.Alonzo, null, pp);
+
+        assertThat(pp.getMinUtxo()).isNull();
+        //Word-based value is correct in Alonzo; must not be divided by 8 here
+        assertThat(pp.getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(34482));
+    }
+
+    @Test
+    void apply_babbageFromAlonzoTransition_appliesBabbageRuleOnce() {
+        ProtocolParams pp = ProtocolParams.builder()
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        rules.apply(Era.Babbage, Era.Alonzo, pp);
+
+        assertThat(pp.getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(4310));
+    }
+
+    @Test
+    void apply_sameEra_isNoOp() {
+        ProtocolParams pp = ProtocolParams.builder()
+                .minUtxo(BigInteger.valueOf(1000000))
+                .adaPerUtxoByte(BigInteger.valueOf(34482))
+                .build();
+
+        rules.apply(Era.Conway, Era.Conway, pp);
+
+        assertThat(pp.getMinUtxo()).isEqualTo(BigInteger.valueOf(1000000));
+        assertThat(pp.getAdaPerUtxoByte()).isEqualTo(BigInteger.valueOf(34482));
     }
 }


### PR DESCRIPTION
## Summary
  - Apply era transition normalization when saving genesis protocol parameters for direct-start networks.
  - Fix direct Conway/Babbage genesis rows so `minUtxo` is cleared and Alonzo word-based UTxO cost is translated to byte-based cost.
  - Add regression tests for direct Conway, direct Babbage, direct Alonzo, and missing genesis parameter handling.

