### PR TITLE
[BF compatibility] Add Blockfrost-compatible tx submit and utilities endpoints

### DIFF
--- a/extensions/blockfrost/transaction/build.gradle
+++ b/extensions/blockfrost/transaction/build.gradle
@@ -2,6 +2,7 @@ import org.gradle.api.publish.maven.MavenPublication
 
 dependencies {
     api project(":extensions:blockfrost:blockfrost-common")
+    api project(":components:submit")
     api project(":stores:transaction")
     api project(":stores:utxo")
     api project(":stores:staking")

--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTxSubmitController.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTxSubmitController.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.transaction.controller;
+
+import com.bloxbean.cardano.yaci.store.blockfrost.transaction.service.BFTxSubmitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Blockfrost Transactions")
+@RequestMapping("${blockfrost.apiPrefix}/tx")
+@ConditionalOnExpression("${store.extensions.blockfrost.transaction.enabled:false}")
+public class BFTxSubmitController {
+
+    private final BFTxSubmitService bfTxSubmitService;
+
+    @PostConstruct
+    public void postConstruct() {
+        log.info("Blockfrost TxSubmitController initialized >>>");
+    }
+
+    @PostMapping(value = "submit", consumes = MediaType.APPLICATION_CBOR_VALUE)
+    @Operation(summary = "Submit a transaction",
+               description = "Submit an already serialized transaction to the network.")
+    public ResponseEntity<String> submitTx(@RequestBody byte[] cborTx) {
+        String txHash = bfTxSubmitService.submitTx(cborTx);
+        return ResponseEntity.ok(txHash);
+    }
+}

--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/service/BFTxSubmitService.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/service/BFTxSubmitService.java
@@ -1,0 +1,88 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.transaction.service;
+
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.yaci.core.common.TxBodyType;
+import com.bloxbean.cardano.yaci.helper.model.TxResult;
+import com.bloxbean.cardano.yaci.store.submit.service.OgmiosService;
+import com.bloxbean.cardano.yaci.store.submit.service.TxSubmissionService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Slf4j
+public class BFTxSubmitService {
+
+    private final String submitApiUrl;
+    private final ObjectProvider<OgmiosService> ogmiosServiceProvider;
+    private final ObjectProvider<TxSubmissionService> txSubmissionServiceProvider;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public BFTxSubmitService(Environment env,
+                             ObjectProvider<OgmiosService> ogmiosServiceProvider,
+                             ObjectProvider<TxSubmissionService> txSubmissionServiceProvider) {
+        this.submitApiUrl = env.getProperty("store.cardano.submit-api-url");
+        this.ogmiosServiceProvider = ogmiosServiceProvider;
+        this.txSubmissionServiceProvider = txSubmissionServiceProvider;
+    }
+
+    public String submitTx(byte[] cborTx) {
+        if (submitApiUrl != null && !submitApiUrl.isBlank()) {
+            return submitViaExternalApi(cborTx);
+        }
+
+        OgmiosService ogmiosService = ogmiosServiceProvider.getIfAvailable();
+        if (ogmiosService != null) {
+            return submitViaOgmios(ogmiosService, cborTx);
+        }
+
+        TxSubmissionService txSubmissionService = txSubmissionServiceProvider.getIfAvailable();
+        if (txSubmissionService != null) {
+            return submitViaLocalNode(txSubmissionService, cborTx);
+        }
+
+        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                "No transaction submission backend configured. Configure one of: store.cardano.submit-api-url, store.cardano.ogmios-url, or store.cardano.n2c-node-socket-path");
+    }
+
+    private String submitViaExternalApi(byte[] cborTx) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/cbor");
+        HttpEntity<byte[]> entity = new HttpEntity<>(cborTx, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(submitApiUrl, HttpMethod.POST, entity, String.class);
+            return response.getBody();
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            throw new ResponseStatusException(HttpStatus.valueOf(e.getStatusCode().value()), e.getResponseBodyAsString());
+        }
+    }
+
+    private String submitViaOgmios(OgmiosService ogmiosService, byte[] cborTx) {
+        try {
+            Result<String> result = ogmiosService.submitTx(cborTx);
+            if (result.isSuccessful()) {
+                return result.getValue();
+            }
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, result.getResponse());
+        } catch (ResponseStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    private String submitViaLocalNode(TxSubmissionService txSubmissionService, byte[] cborTx) {
+        TxResult txResult = txSubmissionService.submitTx(TxBodyType.CONWAY, cborTx);
+        if (txResult.isAccepted()) {
+            return txResult.getTxHash();
+        }
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, txResult.getErrorCbor());
+    }
+}

--- a/extensions/blockfrost/util/build.gradle
+++ b/extensions/blockfrost/util/build.gradle
@@ -3,6 +3,7 @@ import org.gradle.api.publish.maven.MavenPublication
 dependencies {
     api project(":extensions:blockfrost:blockfrost-common")
     api project(":components:submit")
+    api project(":components:common")
 
     implementation libs.vavr
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/extensions/blockfrost/util/build.gradle
+++ b/extensions/blockfrost/util/build.gradle
@@ -1,0 +1,20 @@
+import org.gradle.api.publish.maven.MavenPublication
+
+dependencies {
+    api project(":extensions:blockfrost:blockfrost-common")
+    api project(":components:submit")
+
+    implementation libs.vavr
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yaci Store Blockfrost Util'
+                description = 'Yaci Store Blockfrost Utilities API'
+            }
+        }
+    }
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/BFUtilConfiguration.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/BFUtilConfiguration.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(
+        name = "store.extensions.blockfrost.util.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+@ComponentScan(basePackages = "com.bloxbean.cardano.yaci.store.blockfrost.util")
+public class BFUtilConfiguration {
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.blockfrost.util.controller;
 
+import com.bloxbean.cardano.yaci.store.blockfrost.util.dto.BFDeriveAddressDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.util.dto.BFEvaluateUtxosRequest;
 import com.bloxbean.cardano.yaci.store.blockfrost.util.service.BFUtilService;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,5 +45,14 @@ public class BFUtilController {
                                                         @RequestParam(name = "version", defaultValue = "5") int version) {
         JsonNode result = bfUtilService.evaluateTxWithUtxos(request.getCbor(), request.getAdditionalUtxoSet(), version);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/addresses/xpub/{xpub}/{role}/{index}")
+    @Operation(summary = "Derive an address",
+               description = "Derive Shelley address from an xpub.")
+    public BFDeriveAddressDto deriveAddress(@PathVariable String xpub,
+                                            @PathVariable int role,
+                                            @PathVariable int index) {
+        return bfUtilService.deriveAddress(xpub, role, index);
     }
 }

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
@@ -1,0 +1,48 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util.controller;
+
+import com.bloxbean.cardano.yaci.store.blockfrost.util.dto.BFEvaluateUtxosRequest;
+import com.bloxbean.cardano.yaci.store.blockfrost.util.service.BFUtilService;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Blockfrost Utilities")
+@RequestMapping("${blockfrost.apiPrefix}/utils")
+@ConditionalOnExpression("${store.extensions.blockfrost.util.enabled:false}")
+public class BFUtilController {
+
+    private final BFUtilService bfUtilService;
+
+    @PostConstruct
+    public void postConstruct() {
+        log.info("Blockfrost UtilController initialized >>>");
+    }
+
+    @PostMapping(value = "/txs/evaluate", consumes = MediaType.APPLICATION_CBOR_VALUE)
+    @Operation(summary = "Submit a transaction for execution units evaluation",
+               description = "Submit a CBOR-encoded transaction to evaluate execution units.")
+    public ResponseEntity<JsonNode> evaluateTx(@RequestBody byte[] cborTx,
+                                               @RequestParam(name = "version", defaultValue = "5") int version) {
+        JsonNode result = bfUtilService.evaluateTx(cborTx, version);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping(value = "/txs/evaluate/utxos", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Submit a transaction for execution units evaluation (additional UTXO set)",
+               description = "Submit a JSON payload with transaction CBOR and additional UTXO set to evaluate execution units.")
+    public ResponseEntity<JsonNode> evaluateTxWithUtxos(@RequestBody BFEvaluateUtxosRequest request,
+                                                        @RequestParam(name = "version", defaultValue = "5") int version) {
+        JsonNode result = bfUtilService.evaluateTxWithUtxos(request.getCbor(), request.getAdditionalUtxoSet(), version);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/dto/BFDeriveAddressDto.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/dto/BFDeriveAddressDto.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BFDeriveAddressDto {
+    private String xpub;
+    private int role;
+    private int index;
+    private String address;
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/dto/BFEvaluateUtxosRequest.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/dto/BFEvaluateUtxosRequest.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BFEvaluateUtxosRequest {
+    private String cbor;
+    private JsonNode additionalUtxoSet;
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
@@ -1,0 +1,56 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util.service;
+
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vavr.control.Either;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BFUtilService {
+
+    private final TxEvaluationService txEvaluationService;
+
+    public JsonNode evaluateTx(byte[] cborTx, int version) {
+        try {
+            Either<JsonNode, JsonNode> result = txEvaluationService.evaluateTx(cborTx, null);
+            return formatResult(result, version);
+        } catch (Exception e) {
+            log.error("Transaction evaluation failed", e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    public JsonNode evaluateTxWithUtxos(String cborHex, JsonNode additionalUtxoSet, int version) {
+        try {
+            byte[] cborTx = HexUtil.decodeHexString(cborHex);
+            Either<JsonNode, JsonNode> result = txEvaluationService.evaluateTx(cborTx, additionalUtxoSet);
+            return formatResult(result, version);
+        } catch (ResponseStatusException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Transaction evaluation with utxos failed", e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    private JsonNode formatResult(Either<JsonNode, JsonNode> result, int version) {
+        if (result.isRight()) {
+            if (version == 6) {
+                return result.get();
+            }
+            return txEvaluationService.transformTxEvaluationSuccessResultToV5BFFormat(result.get());
+        } else {
+            if (version == 6) {
+                return result.getLeft();
+            }
+            return txEvaluationService.transformTxEvaluationErrorToV5BFFormat(result.getLeft());
+        }
+    }
+}

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Base64;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -28,9 +30,9 @@ public class BFUtilService {
         }
     }
 
-    public JsonNode evaluateTxWithUtxos(String cborHex, JsonNode additionalUtxoSet, int version) {
+    public JsonNode evaluateTxWithUtxos(String cbor, JsonNode additionalUtxoSet, int version) {
         try {
-            byte[] cborTx = HexUtil.decodeHexString(cborHex);
+            byte[] cborTx = decodeCbor(cbor);
             Either<JsonNode, JsonNode> result = txEvaluationService.evaluateTx(cborTx, additionalUtxoSet);
             return formatResult(result, version);
         } catch (ResponseStatusException e) {
@@ -40,6 +42,17 @@ public class BFUtilService {
                 log.error("Transaction evaluation with utxos failed", e);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    private byte[] decodeCbor(String cbor) {
+        if (cbor == null || cbor.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "cbor field is required");
+        }
+        String trimmed = cbor.trim();
+        if (trimmed.matches("[0-9a-fA-F]+")) {
+            return HexUtil.decodeHexString(trimmed);
+        }
+        return Base64.getDecoder().decode(trimmed);
     }
 
     private JsonNode formatResult(Either<JsonNode, JsonNode> result, int version) {

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
@@ -22,7 +22,8 @@ public class BFUtilService {
             Either<JsonNode, JsonNode> result = txEvaluationService.evaluateTx(cborTx, null);
             return formatResult(result, version);
         } catch (Exception e) {
-            log.error("Transaction evaluation failed", e);
+            if (log.isDebugEnabled())
+                log.error("Transaction evaluation failed", e);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }
@@ -35,7 +36,8 @@ public class BFUtilService {
         } catch (ResponseStatusException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Transaction evaluation with utxos failed", e);
+            if (log.isDebugEnabled())
+                log.error("Transaction evaluation with utxos failed", e);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
@@ -1,6 +1,14 @@
 package com.bloxbean.cardano.yaci.store.blockfrost.util.service;
 
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.common.model.Network;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.crypto.bip32.key.HdPublicKey;
+import com.bloxbean.cardano.client.crypto.cip1852.CIP1852;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.blockfrost.util.dto.BFDeriveAddressDto;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.vavr.control.Either;
@@ -18,6 +26,7 @@ import java.util.Base64;
 public class BFUtilService {
 
     private final TxEvaluationService txEvaluationService;
+    private final StoreProperties storeProperties;
 
     public JsonNode evaluateTx(byte[] cborTx, int version) {
         try {
@@ -42,6 +51,36 @@ public class BFUtilService {
                 log.error("Transaction evaluation with utxos failed", e);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    public BFDeriveAddressDto deriveAddress(String xpub, int role, int index) {
+        byte[] xpubBytes = HexUtil.decodeHexString(xpub);
+        if (xpubBytes.length != 64) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Invalid xpub length. Expected 64 bytes (public key + chain code), got " + xpubBytes.length);
+        }
+
+        CIP1852 cip1852 = new CIP1852();
+        HdPublicKey paymentKey = cip1852.getPublicKeyFromAccountPubKey(xpubBytes, role, index);
+        HdPublicKey stakeKey = cip1852.getPublicKeyFromAccountPubKey(xpubBytes, 2, 0);
+
+        Network network = getNetwork();
+        Address address = AddressProvider.getBaseAddress(paymentKey, stakeKey, network);
+
+        return BFDeriveAddressDto.builder()
+                .xpub(xpub)
+                .role(role)
+                .index(index)
+                .address(address.toBech32())
+                .build();
+    }
+
+    private Network getNetwork() {
+        long protocolMagic = storeProperties.getProtocolMagic();
+        if (protocolMagic == Networks.mainnet().getProtocolMagic()) {
+            return Networks.mainnet();
+        }
+        return Networks.testnet();
     }
 
     private byte[] decodeCbor(String cbor) {

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilService.java
@@ -35,7 +35,7 @@ public class BFUtilService {
         } catch (Exception e) {
             if (log.isDebugEnabled())
                 log.error("Transaction evaluation failed", e);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Transaction evaluation failed.");
         }
     }
 
@@ -49,7 +49,7 @@ public class BFUtilService {
         } catch (Exception e) {
             if (log.isDebugEnabled())
                 log.error("Transaction evaluation with utxos failed", e);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Transaction evaluation failed.");
         }
     }
 

--- a/extensions/blockfrost/util/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilServiceTest.java
+++ b/extensions/blockfrost/util/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/util/service/BFUtilServiceTest.java
@@ -1,0 +1,59 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.util.service;
+
+import com.bloxbean.cardano.yaci.store.blockfrost.util.dto.BFDeriveAddressDto;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.submit.service.TxEvaluationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class BFUtilServiceTest {
+    private static final long MAINNET_PROTOCOL_MAGIC = 764824073L;
+    private static final long PREPROD_PROTOCOL_MAGIC = 1097911063L;
+    private static final String XPUB = "8e8131277ac46bf6b526fff4fe00cecc71026c278340c44458878bd162f70367505e1ea016e67052b3697ac749e4b034010056e7fd8e8486682665cd9693fb21";
+
+    @Test
+    void deriveAddressReturnsTestnetBaseAddress() {
+        BFDeriveAddressDto result = service(PREPROD_PROTOCOL_MAGIC).deriveAddress(XPUB, 0, 0);
+
+        assertThat(result.getXpub()).isEqualTo(XPUB);
+        assertThat(result.getRole()).isEqualTo(0);
+        assertThat(result.getIndex()).isEqualTo(0);
+        assertThat(result.getAddress()).isEqualTo("addr_test1qzm3qwm0gsda3vavu43a4fe9ls8xlfjv45mjadxv6z5a3uq5wh8uvn3vr6vd7n80yyluxt87u336syy9678flma06sfs33797j");
+    }
+
+    @Test
+    void deriveAddressReturnsMainnetBaseAddressWhenProtocolMagicIsMainnet() {
+        BFDeriveAddressDto result = service(MAINNET_PROTOCOL_MAGIC).deriveAddress(XPUB, 0, 0);
+
+        assertThat(result.getAddress()).isEqualTo("addr1qxm3qwm0gsda3vavu43a4fe9ls8xlfjv45mjadxv6z5a3uq5wh8uvn3vr6vd7n80yyluxt87u336syy9678flma06sfsj8r9jd");
+    }
+
+    @Test
+    void deriveAddressUsesRequestedRoleAndIndex() {
+        BFDeriveAddressDto result = service(PREPROD_PROTOCOL_MAGIC).deriveAddress(XPUB, 1, 7);
+
+        assertThat(result.getRole()).isEqualTo(1);
+        assertThat(result.getIndex()).isEqualTo(7);
+        assertThat(result.getAddress()).isEqualTo("addr_test1qz7v5x33xz6dek5ssh25dm80hjp5a566q3f9gml870w2m3c5wh8uvn3vr6vd7n80yyluxt87u336syy9678flma06sfsjceddk");
+    }
+
+    @Test
+    void deriveAddressRejectsInvalidXpubLength() {
+        assertThatThrownBy(() -> service(PREPROD_PROTOCOL_MAGIC).deriveAddress("abcd", 0, 0))
+                .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(exception.getReason()).isEqualTo("Invalid xpub length. Expected 64 bytes (public key + chain code), got 2");
+                });
+    }
+
+    private BFUtilService service(long protocolMagic) {
+        StoreProperties storeProperties = new StoreProperties();
+        storeProperties.setProtocolMagic(protocolMagic);
+        return new BFUtilService(mock(TxEvaluationService.class), storeProperties);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -116,4 +116,7 @@ project(':extensions:blockfrost:blockfrost-transaction').projectDir = new File('
 include ':extensions:blockfrost:blockfrost-scripts'
 project(':extensions:blockfrost:blockfrost-scripts').projectDir = new File('extensions/blockfrost/scripts')
 
+include ':extensions:blockfrost:blockfrost-util'
+project(':extensions:blockfrost:blockfrost-util').projectDir = new File('extensions/blockfrost/util')
+
 include 'e2e-tests'

--- a/starters/blockfrost-spring-boot-starter/build.gradle
+++ b/starters/blockfrost-spring-boot-starter/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(":extensions:blockfrost:blockfrost-block")
     api project(":extensions:blockfrost:blockfrost-scripts")
     api project(":extensions:blockfrost:blockfrost-metadata")
+    api project(":extensions:blockfrost:blockfrost-util")
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFAutoConfiguration.java
+++ b/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFAutoConfiguration.java
@@ -8,6 +8,7 @@ import com.bloxbean.cardano.yaci.store.blockfrost.transaction.BFTransactionConfi
 import com.bloxbean.cardano.yaci.store.blockfrost.block.BFBlockConfiguration;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.BFMetadataConfiguration;
 import com.bloxbean.cardano.yaci.store.blockfrost.scripts.BFScriptsConfiguration;
+import com.bloxbean.cardano.yaci.store.blockfrost.util.BFUtilConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -16,7 +17,7 @@ import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
 @EnableConfigurationProperties(BFProperties.class)
-@Import({BFEpochConfiguration.class, BFAddressConfiguration.class, BFAssetConfiguration.class, BFAccountConfiguration.class, BFTransactionConfiguration.class, BFBlockConfiguration.class, BFScriptsConfiguration.class, BFMetadataConfiguration.class})
+@Import({BFEpochConfiguration.class, BFAddressConfiguration.class, BFAssetConfiguration.class, BFAccountConfiguration.class, BFTransactionConfiguration.class, BFBlockConfiguration.class, BFScriptsConfiguration.class, BFMetadataConfiguration.class, BFUtilConfiguration.class})
 @Slf4j
 public class BFAutoConfiguration {
 

--- a/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFProperties.java
+++ b/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFProperties.java
@@ -28,6 +28,7 @@ public class BFProperties {
             private Blocks blocks = new Blocks();
             private Scripts scripts = new Scripts();
             private Metadata metadata = new Metadata();
+            private Util util = new Util();
 
             @Getter
             @Setter
@@ -74,6 +75,12 @@ public class BFProperties {
             @Getter
             @Setter
             public static final class Metadata {
+                private boolean enabled = false;
+            }
+
+            @Getter
+            @Setter
+            public static final class Util {
                 private boolean enabled = false;
             }
 


### PR DESCRIPTION
## Summary
  
  Adds Blockfrost-compatible endpoints for transaction submission, transaction evaluation, and address derivation, following the Blockfrost spec.

  ## New Endpoints
  
  | Method | Path | Tag | Description |
  |--------|------|-----|-------------|
  | POST | `/tx/submit` | Cardano » Transactions | Submit a signed CBOR transaction |
  | POST | `/utils/txs/evaluate` | Cardano » Utilities | Evaluate tx execution units |
  | POST | `/utils/txs/evaluate/utxos` | Cardano » Utilities | Evaluate tx with additional UTxO set |
  | GET | `/utils/addresses/xpub/{xpub}/{role}/{index}` | Cardano » Utilities | Derive Shelley address from xpub |

  ## Implementation

  These are thin Blockfrost-formatted wrappers on top of existing core services (`TxSubmissionService`, `OgmiosService`, `TxEvaluationService`).

  **Transaction Submit** (`extensions/blockfrost/transaction/`)
  - Added `BFTxSubmitController` + `BFTxSubmitService` to the existing transaction module
  - Supports all 3 submission backends with priority: external submit-api → Ogmios → local n2c

  **Utilities** (`extensions/blockfrost/util/` — new module)
  - `BFUtilController` + `BFUtilService`
  - Supports `version` query param (5 = Ogmios v5 Blockfrost format, 6 = raw Ogmios v6 format)
  - CBOR field in evaluate/utxos accepts both base16 (hex) and base64 encoding per Blockfrost spec
  - Address derivation uses CIP-1852 HD key derivation from `cardano-client-lib`, network auto-detected from `store.cardano.protocol-magic`

  ## Configuration

  ```properties
  store.extensions.blockfrost.transaction.enabled=true
  store.extensions.blockfrost.util.enabled=true