### PR TITLE
chore(scripts): add Blockfrost API compatibility comparison scripts

### DIFF
--- a/scripts/compare-blockfrost/.env.example
+++ b/scripts/compare-blockfrost/.env.example
@@ -1,0 +1,19 @@
+# Copy to .env and fill in. Loaded automatically by bf_compare.load_dotenv().
+# Existing exported env vars take precedence over this file.
+
+# Blockfrost project IDs (network-locked). Required by compare_*.py.
+BF_PROJECT_ID_MAINNET=mainnet_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+BF_PROJECT_ID_PREPROD=preprod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+BF_PROJECT_ID_PREVIEW=preview_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# --- Endpoint overrides (optional; defaults shown). Uncomment to change. ---
+# Local Yaci Store base URLs:
+# YACI_LOCAL_MAINNET=http://localhost:8101
+# YACI_LOCAL_PREPROD=http://localhost:8301
+# YACI_LOCAL_PREVIEW=http://localhost:8201
+# Official Blockfrost base URLs (e.g. to point at a proxy):
+# BF_URL_MAINNET=https://cardano-mainnet.blockfrost.io/api/v0
+# BF_URL_PREPROD=https://cardano-preprod.blockfrost.io/api/v0
+# BF_URL_PREVIEW=https://cardano-preview.blockfrost.io/api/v0
+# Local API path prefix:
+# YACI_LOCAL_PREFIX=/api/v1/blockfrost

--- a/scripts/compare-blockfrost/.env.example
+++ b/scripts/compare-blockfrost/.env.example
@@ -6,6 +6,18 @@ BF_PROJECT_ID_MAINNET=mainnet_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 BF_PROJECT_ID_PREPROD=preprod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 BF_PROJECT_ID_PREVIEW=preview_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# --- DB seeding (optional; enables fast test-data seeding straight from Postgres). ---
+# libpq DSN/URI per network. When set, seeding reads from the DB instead of the API.
+# YACI_DB_MAINNET=postgresql://user:pass@host:5432/yaci_store
+# YACI_DB_PREPROD=postgresql://user:pass@host:5432/yaci_store
+# YACI_DB_PREVIEW=postgresql://user:pass@host:5432/yaci_store
+# Schema holding the store tables. Global default (used when no per-network override):
+# YACI_DB_SCHEMA=yaci_store
+# Per-network schema override (wins over YACI_DB_SCHEMA). Set only where a DB differs:
+# YACI_DB_SCHEMA_MAINNET=yaci_store
+# YACI_DB_SCHEMA_PREPROD=yaci_store
+# YACI_DB_SCHEMA_PREVIEW=yaci_store
+
 # --- Endpoint overrides (optional; defaults shown). Uncomment to change. ---
 # Local Yaci Store base URLs:
 # YACI_LOCAL_MAINNET=http://localhost:8101

--- a/scripts/compare-blockfrost/.gitignore
+++ b/scripts/compare-blockfrost/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+report/

--- a/scripts/compare-blockfrost/.gitignore
+++ b/scripts/compare-blockfrost/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 report/
+.env

--- a/scripts/compare-blockfrost/README.md
+++ b/scripts/compare-blockfrost/README.md
@@ -21,31 +21,79 @@ Python scripts that compare **Yaci Store** API responses against live **Blockfro
 - Python 3.8+
 - No third-party packages (uses only stdlib: `urllib`, `json`, `csv`, `argparse`)
 
-## Setup
+## Configuration
 
-### 1. Running Yaci Store instances
+Nothing is hardcoded in the scripts anymore. Three things are configurable, all
+outside the code:
 
-The scripts expect local Yaci Store containers running on these ports:
+| What | Where | Notes |
+|---|---|---|
+| Blockfrost API keys (secrets) | `.env` | Auto-loaded; gitignored |
+| API endpoints (local + Blockfrost) | `.env` (optional) | Sensible defaults in code |
+| Per-module test data (addresses, assets, pools, …) | `config/<module>.json` | One file per module |
 
-| Network | Port |
-|---|---|
-| mainnet | `http://localhost:8101` |
-| preprod | `http://localhost:8301` |
-| preview  | `http://localhost:8201` |
+### 1. Secrets and endpoints — `.env`
 
-See `docker/deployments/` for deployment instructions.
-
-### 2. Blockfrost API keys
-
-Obtain project IDs from [blockfrost.io](https://blockfrost.io) and export them as environment variables:
+Copy the template and fill in your Blockfrost project IDs:
 
 ```bash
-export BF_PROJECT_ID_MAINNET=mainnet...
-export BF_PROJECT_ID_PREPROD=preprod...
-export BF_PROJECT_ID_PREVIEW=preview...
+cd scripts/compare-blockfrost
+cp .env.example .env
+# edit .env
 ```
 
-You only need to set the key for the network(s) you intend to test.
+`.env` is loaded automatically at startup (no manual `export` needed). A real
+shell `export` still takes precedence over the file.
+
+```bash
+# .env
+BF_PROJECT_ID_MAINNET=mainnet...
+BF_PROJECT_ID_PREPROD=preprod...
+BF_PROJECT_ID_PREVIEW=preview...
+```
+
+You only need the key(s) for the network(s) you intend to test.
+
+**Endpoint overrides (optional).** The local Yaci and Blockfrost base URLs have
+built-in defaults but can be overridden via `.env` — e.g. to point at a different
+host/port or a Blockfrost proxy:
+
+| Env var | Default |
+|---|---|
+| `YACI_LOCAL_MAINNET` / `_PREPROD` / `_PREVIEW` | `http://localhost:8101` / `8301` / `8201` |
+| `BF_URL_MAINNET` / `_PREPROD` / `_PREVIEW` | `https://cardano-<net>.blockfrost.io/api/v0` |
+| `YACI_LOCAL_PREFIX` | `/api/v1/blockfrost` |
+
+See `.env.example` for the full commented list.
+
+### 2. Test data — `config/<module>.json`
+
+Each module reads its test identifiers from `config/<module>.json`, keyed by
+network. This keeps test cases out of shared code — add cases by editing JSON,
+never the scripts.
+
+```jsonc
+// config/address.json
+{
+  "preprod": { "asset": "...", "policy_id": "...", "addresses": [] },
+  "mainnet": { "asset": "...", "addresses": ["addr1...", "addr1..."] }
+}
+```
+
+```jsonc
+// config/epoch.json
+{ "mainnet": { "epoch": "633", "pool_id": "pool1..." } }
+```
+
+If a file or network section is missing, the script falls back to
+**auto-discovering** identifiers from the local chain, so it still runs
+zero-config. Keys not present in config are auto-seeded (e.g. `block`, `slot`,
+`tx_hash`, and — when not provided — `address`/`asset`).
+
+### 3. Running Yaci Store instances
+
+The scripts expect local Yaci Store containers (see `docker/deployments/`) on the
+ports listed above. Override via `YACI_LOCAL_*` if your setup differs.
 
 ## Usage
 
@@ -54,30 +102,46 @@ Run from this directory:
 ```bash
 cd scripts/compare-blockfrost
 
-# Compare epoch endpoints on preprod
+# Compare epoch endpoints on preprod (key comes from .env automatically)
 python3 compare_epoch.py --network preprod
 
-# Compare on preview
-python3 compare_epoch.py --network preview
-
-# Compare on mainnet
-python3 compare_epoch.py --network mainnet
+# Strict mode — treat known-divergent fields as real diffs too
+python3 compare_epoch.py --network preprod --strict
 
 # Save results to a specific CSV file
 python3 compare_epoch.py --network preprod --csv /tmp/epoch_preprod.csv
-
-# Strict mode — exit non-zero if any diff found
-python3 compare_epoch.py --network preprod --strict
 ```
 
-The same flags apply to all `compare_*.py` scripts.
+The common flags apply to all `compare_*.py` scripts.
+
+### Testing multiple datasets (address module)
+
+`compare_address.py` tests **several addresses per run** for broader evidence.
+Address selection precedence:
+
+1. `--addresses a,b,c` — explicit comma-separated list (highest priority)
+2. `config/address.json` → the network's `addresses` array (if non-empty)
+3. auto-discovery — seed N distinct addresses from recent chain UTXOs
+
+```bash
+# Auto-discover and test 8 addresses
+python3 compare_address.py --network preprod --samples 8 --strict
+
+# Test specific addresses
+python3 compare_address.py --network mainnet --addresses "addr1...,addr1..."
+
+# Use the addresses pinned in config/address.json (e.g. mainnet whales)
+python3 compare_address.py --network mainnet --strict
+```
+
+Each address is exercised across all endpoints and list variants; results are
+tagged per address (see the `sample` column in the CSV).
 
 ### Paging and ordering (list endpoints)
 
-List endpoints (`/blocks`, `/stakes`, `/next`, `/previous`, …) accept Blockfrost's
-`order` and `page`/`count` query parameters. By default each list endpoint is
-compared across **both orders** (`asc`, `desc`) and **pages 1 and 2**, so a single
-run validates that ordering and pagination match Blockfrost in every combination.
+List endpoints (`/blocks`, `/stakes`, `/utxos`, `/transactions`, …) accept
+Blockfrost's `order` and `page`/`count` query parameters. By default each list
+endpoint is compared across **both orders** (`asc`, `desc`) and **pages 1 and 2**.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -86,18 +150,11 @@ run validates that ordering and pagination match Blockfrost in every combination
 | `--count` | `100` | Page size (rows per page) for list endpoints |
 
 ```bash
-# Test both orders across the first three pages
+# Both orders across the first three pages
 python3 compare_epoch.py --network preprod --orders asc desc --pages 1 2 3
 
 # Descending only, first page, smaller page size
 python3 compare_epoch.py --network preprod --orders desc --pages 1 --count 20
-```
-
-Each (order, page) combination is reported as its own line, e.g.:
-
-```
-DIFF  /epochs/{epoch}/stakes?order=desc&page=2  (60 field(s))  [Yaci=68ms  BF=656ms]
-OK    /epochs/{epoch}/blocks?order=desc&page=1  [Yaci=104ms  BF=416ms]
 ```
 
 Non-list endpoints (e.g. `/epochs/latest`) are compared once; `order`/`page` do
@@ -105,37 +162,37 @@ not apply to them.
 
 ## Output
 
-Each run prints a summary per endpoint:
+Each run prints a per-endpoint summary:
 
 ```
-OK    /epochs/291/blocks  [Yaci=105ms  BF=473ms]
-DIFF  /epochs/291/previous  (315 field(s))  [Yaci=529ms  BF=568ms]
-      [0].fees: BF='9206177808'  Yaci='678030'
-      ...
+OK    /addresses/{address}  [Yaci=38ms  BF=870ms]
+DIFF  /addresses/{address}/utxos?order=asc&page=1  (2 field(s))  [Yaci=60ms  BF=397ms]
+      [0].tx_index: missing in Yaci
 ```
 
 - **OK** — responses match (after stripping known-volatile fields)
 - **DIFF** — field-level differences listed with BF and Yaci values
-- **SLOW** badge — Yaci response exceeded the threshold relative to BF
+- **STATUS** — HTTP status differs between Yaci and Blockfrost
+- **SKIP** — required param missing for that endpoint
+- **:warning: SLOW** badge — Yaci exceeded the latency threshold (>500 ms or >3× BF)
 
 ### CSV results
 
-Every run also appends results to a CSV. If `--csv` is not given, it defaults to:
+Every run appends results to a CSV. If `--csv` is not given, it defaults to:
 
 ```
 scripts/compare-blockfrost/report/<module>_<network>.csv
 ```
 
-e.g. `report/epoch_preprod.csv`. The directory is created automatically. Rows are
-appended (not overwritten), so repeated runs accumulate history. Pass `--csv FILE`
-to write somewhere else.
+Columns: `date, network, module, sample, endpoint, result, yaci_status,
+bf_status, yaci_ms, bf_ms, slow, diff_count, diff_fields`. The `sample` column
+identifies which dataset (e.g. address) produced the row. Rows are appended, so
+repeated runs accumulate history; delete the file for a clean slate.
 
 ## Known expected divergences
 
-Some diffs are pre-existing data issues, not bugs. They are documented in `bf_compare.py` under `IGNORE_FIELDS` / comments. Current out-of-scope items:
-
-| Field | Reason |
-|---|---|
-| `nonce` | Epoch nonce not yet computed (BUG-4, out of scope) |
-| `fees` | Fee aggregation incomplete for in-progress epochs (BUG-2) |
-| `stakes` data | Stake snapshot divergence vs Blockfrost reference data |
+Some diffs are accepted limitations rather than bugs. Strict mode (`--strict`)
+surfaces them anyway; without it, fields listed in `IGNORE_DIVERGENT` (and the
+always-volatile `IGNORE_VOLATILE`, e.g. `confirmations`, `next_block`) in
+`bf_compare.py` are ignored. Findings per module are tracked under
+`extensions/blockfrost/adr/` and in `report/` (e.g. `address_compare.html`).

--- a/scripts/compare-blockfrost/README.md
+++ b/scripts/compare-blockfrost/README.md
@@ -66,6 +66,20 @@ host/port or a Blockfrost proxy:
 
 See `.env.example` for the full commented list.
 
+**DB seeding (optional).** When a Postgres DSN is configured for a network, the
+scripts seed test data (recent block/slot/tx/address/asset) straight from the DB
+instead of walking the API — much faster. All keys are optional; without a DSN the
+scripts fall back to the API path.
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `YACI_DB_MAINNET` / `_PREPROD` / `_PREVIEW` | libpq DSN/URI, e.g. `postgresql://user:pass@host:5432/yaci_store` | _(unset → API seeding)_ |
+| `YACI_DB_SCHEMA` | Schema holding the store tables (global default) | `yaci_store` |
+| `YACI_DB_SCHEMA_MAINNET` / `_PREPROD` / `_PREVIEW` | Per-network schema override; wins over `YACI_DB_SCHEMA`. Set only where a network's DB uses a different schema name. | _(falls back to `YACI_DB_SCHEMA`)_ |
+
+The `psql` client must be on `PATH` for DB seeding. Queries are read-only and
+bounded by a server-side `statement_timeout`.
+
 ### 2. Test data — `config/<module>.json`
 
 Each module reads its test identifiers from `config/<module>.json`, keyed by

--- a/scripts/compare-blockfrost/README.md
+++ b/scripts/compare-blockfrost/README.md
@@ -1,0 +1,141 @@
+# Blockfrost Compatibility Comparison Scripts
+
+Python scripts that compare **Yaci Store** API responses against live **Blockfrost** responses, endpoint by endpoint. Used to validate parity between a local Yaci Store instance and the Blockfrost reference API.
+
+## Contents
+
+| Script | Endpoints compared |
+|---|---|
+| `compare_epoch.py` | `/epochs/*`, `/epochs/{epoch}/parameters`, `/epochs/{epoch}/next`, `/epochs/{epoch}/previous`, `/epochs/{epoch}/stakes`, `/epochs/{epoch}/blocks` |
+| `compare_block.py` | `/blocks/*` |
+| `compare_address.py` | `/addresses/*` |
+| `compare_account.py` | `/accounts/*` |
+| `compare_asset.py` | `/assets/*` |
+| `compare_transaction.py` | `/txs/*` |
+| `compare_metadata.py` | `/metadata/*` |
+| `compare_scripts.py` | `/scripts/*` |
+| `bf_compare.py` | Shared core — not run directly |
+
+## Requirements
+
+- Python 3.8+
+- No third-party packages (uses only stdlib: `urllib`, `json`, `csv`, `argparse`)
+
+## Setup
+
+### 1. Running Yaci Store instances
+
+The scripts expect local Yaci Store containers running on these ports:
+
+| Network | Port |
+|---|---|
+| mainnet | `http://localhost:8101` |
+| preprod | `http://localhost:8301` |
+| preview  | `http://localhost:8201` |
+
+See `docker/deployments/` for deployment instructions.
+
+### 2. Blockfrost API keys
+
+Obtain project IDs from [blockfrost.io](https://blockfrost.io) and export them as environment variables:
+
+```bash
+export BF_PROJECT_ID_MAINNET=mainnet...
+export BF_PROJECT_ID_PREPROD=preprod...
+export BF_PROJECT_ID_PREVIEW=preview...
+```
+
+You only need to set the key for the network(s) you intend to test.
+
+## Usage
+
+Run from this directory:
+
+```bash
+cd scripts/compare-blockfrost
+
+# Compare epoch endpoints on preprod
+python3 compare_epoch.py --network preprod
+
+# Compare on preview
+python3 compare_epoch.py --network preview
+
+# Compare on mainnet
+python3 compare_epoch.py --network mainnet
+
+# Save results to a specific CSV file
+python3 compare_epoch.py --network preprod --csv /tmp/epoch_preprod.csv
+
+# Strict mode — exit non-zero if any diff found
+python3 compare_epoch.py --network preprod --strict
+```
+
+The same flags apply to all `compare_*.py` scripts.
+
+### Paging and ordering (list endpoints)
+
+List endpoints (`/blocks`, `/stakes`, `/next`, `/previous`, …) accept Blockfrost's
+`order` and `page`/`count` query parameters. By default each list endpoint is
+compared across **both orders** (`asc`, `desc`) and **pages 1 and 2**, so a single
+run validates that ordering and pagination match Blockfrost in every combination.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--orders` | `asc desc` | Order values to exercise on list endpoints |
+| `--pages` | `1 2` | Page numbers to exercise on list endpoints |
+| `--count` | `100` | Page size (rows per page) for list endpoints |
+
+```bash
+# Test both orders across the first three pages
+python3 compare_epoch.py --network preprod --orders asc desc --pages 1 2 3
+
+# Descending only, first page, smaller page size
+python3 compare_epoch.py --network preprod --orders desc --pages 1 --count 20
+```
+
+Each (order, page) combination is reported as its own line, e.g.:
+
+```
+DIFF  /epochs/{epoch}/stakes?order=desc&page=2  (60 field(s))  [Yaci=68ms  BF=656ms]
+OK    /epochs/{epoch}/blocks?order=desc&page=1  [Yaci=104ms  BF=416ms]
+```
+
+Non-list endpoints (e.g. `/epochs/latest`) are compared once; `order`/`page` do
+not apply to them.
+
+## Output
+
+Each run prints a summary per endpoint:
+
+```
+OK    /epochs/291/blocks  [Yaci=105ms  BF=473ms]
+DIFF  /epochs/291/previous  (315 field(s))  [Yaci=529ms  BF=568ms]
+      [0].fees: BF='9206177808'  Yaci='678030'
+      ...
+```
+
+- **OK** — responses match (after stripping known-volatile fields)
+- **DIFF** — field-level differences listed with BF and Yaci values
+- **SLOW** badge — Yaci response exceeded the threshold relative to BF
+
+### CSV results
+
+Every run also appends results to a CSV. If `--csv` is not given, it defaults to:
+
+```
+scripts/compare-blockfrost/report/<module>_<network>.csv
+```
+
+e.g. `report/epoch_preprod.csv`. The directory is created automatically. Rows are
+appended (not overwritten), so repeated runs accumulate history. Pass `--csv FILE`
+to write somewhere else.
+
+## Known expected divergences
+
+Some diffs are pre-existing data issues, not bugs. They are documented in `bf_compare.py` under `IGNORE_FIELDS` / comments. Current out-of-scope items:
+
+| Field | Reason |
+|---|---|
+| `nonce` | Epoch nonce not yet computed (BUG-4, out of scope) |
+| `fees` | Fee aggregation incomplete for in-progress epochs (BUG-2) |
+| `stakes` data | Stake snapshot divergence vs Blockfrost reference data |

--- a/scripts/compare-blockfrost/bf_compare.py
+++ b/scripts/compare-blockfrost/bf_compare.py
@@ -10,18 +10,78 @@ Environment variables required (network-locked Blockfrost keys):
 """
 import csv, datetime, json, os, sys, time, urllib.request, urllib.error
 
+# ---------------------------------------------------------------------------
+# Config loading — runs before NETWORKS so endpoints can come from .env
+# ---------------------------------------------------------------------------
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
+
+
+def load_dotenv(path=None):
+    """Load KEY=value lines from a .env file into os.environ.
+
+    Existing environment variables take precedence (setdefault), so an explicit
+    `export` still overrides the file. Lines that are blank, comments (#), or
+    have no '=' are ignored. Surrounding quotes on the value are stripped.
+    """
+    path = path or os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    if not os.path.exists(path):
+        return
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+def load_config(module, net):
+    """Return per-network test data for a module from config/<module>.json.
+
+    Structure: {"<network>": { ...identifiers... }, ...}. Returns the network's
+    dict, or {} when the file or section is missing. Test data lives here (not in
+    code) so adding cases never requires editing the shared scripts.
+    """
+    if not module:
+        return {}
+    path = os.path.join(CONFIG_DIR, f"{module}.json")
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except Exception as e:
+        print(f"  ! cannot parse {path}: {e}", file=sys.stderr)
+        return {}
+    return dict(data.get(net, {})) if isinstance(data, dict) else {}
+
+
+# Load .env before building NETWORKS so endpoint overrides are available.
+load_dotenv()
+
+
+# ---------------------------------------------------------------------------
+# Network endpoints — defaults here, each overridable via .env
+#   YACI_LOCAL_<NET>   e.g. http://localhost:8301
+#   BF_URL_<NET>       e.g. https://cardano-preprod.blockfrost.io/api/v0
+#   YACI_LOCAL_PREFIX  e.g. /api/v1/blockfrost
+# ---------------------------------------------------------------------------
+
+def _network(key, local_default, bf_default):
+    return dict(
+        local=os.environ.get(f"YACI_LOCAL_{key}", local_default),
+        bf=os.environ.get(f"BF_URL_{key}", bf_default),
+        pid_env=f"BF_PROJECT_ID_{key}",
+    )
+
+
 NETWORKS = {
-    "mainnet": dict(local="http://localhost:8101",
-                    bf="https://cardano-mainnet.blockfrost.io/api/v0",
-                    pid_env="BF_PROJECT_ID_MAINNET"),
-    "preprod": dict(local="http://localhost:8301",
-                    bf="https://cardano-preprod.blockfrost.io/api/v0",
-                    pid_env="BF_PROJECT_ID_PREPROD"),
-    "preview": dict(local="http://localhost:8201",
-                    bf="https://cardano-preview.blockfrost.io/api/v0",
-                    pid_env="BF_PROJECT_ID_PREVIEW"),
+    "mainnet": _network("MAINNET", "http://localhost:8101", "https://cardano-mainnet.blockfrost.io/api/v0"),
+    "preprod": _network("PREPROD", "http://localhost:8301", "https://cardano-preprod.blockfrost.io/api/v0"),
+    "preview": _network("PREVIEW", "http://localhost:8201", "https://cardano-preview.blockfrost.io/api/v0"),
 }
-LOCAL_PREFIX = "/api/v1/blockfrost"
+LOCAL_PREFIX = os.environ.get("YACI_LOCAL_PREFIX", "/api/v1/blockfrost")
 LIST_QUERY   = "count=100&page=1&order=asc"
 
 # Volatile: always stripped before diffing (change between the two calls)
@@ -32,21 +92,9 @@ IGNORE_DIVERGENT: dict = {
     # "field": "reason",
 }
 
-# Known-active sample identifiers per network.
-# block/slot/epoch/tx_hash/address/asset/policy_id are auto-seeded from local chain.
-PARAMS: dict = {
-    "preprod": dict(
-        stake_address="stake_test1uqgvl08c9kfzduvfd7r9n2eqh4n9j6nkxcxhkzuq5gv37psg34zyp",
-        pool_id="pool1lenzcfx02maescnpv8mk6gc6c59t0dramqucdgcvr4revw89xpz",
-        script_hash="", datum_hash="", label="674",
-    ),
-    "preview": dict(stake_address="", pool_id="pool1ynfnjspgckgxjf2zeye8s33jz3e3ndk9pcwp0qzaupzvvd8ukwt", script_hash="", datum_hash="", label="674"),
-    "mainnet": dict(
-        epoch="633",
-        pool_id="pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2qnikdy",
-        stake_address="", script_hash="", datum_hash="", label="674",
-    ),
-}
+# Deprecated: per-module test data now lives in config/<module>.json (loaded via
+# load_config). Kept empty only as a last-resort fallback for un-migrated modules.
+PARAMS: dict = {}
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +123,10 @@ def http_get(url, project_id=None, timeout=30):
 # Seeding: discover block/slot/epoch/tx/address/asset from local chain
 # ---------------------------------------------------------------------------
 
-def seed_params(net, cfg, depth=20):
-    p = dict(PARAMS.get(net, {}))
+def seed_params(net, cfg, depth=20, module=None):
+    # Base identifiers come from config/<module>.json; PARAMS is a legacy
+    # fallback kept only for modules not yet migrated to config files.
+    p = dict(load_config(module, net)) or dict(PARAMS.get(net, {}))
     st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
     if st != 200 or not isinstance(latest, dict):
         print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
@@ -114,6 +164,102 @@ def seed_params(net, cfg, depth=20):
                 if p.get("asset"):
                     break
     return p
+
+
+def seed_addresses(net, cfg, want=5, depth=20, scan_limit=600):
+    """Discover up to `want` distinct addresses from recent local-chain UTXOs.
+
+    Walks back blocks from (tip - depth), reading tx outputs to collect a
+    varied set of real addresses. For each address, also captures one native
+    asset it holds (when present) so /addresses/{address}/utxos/{asset} can be
+    exercised. Returns a list of param dicts: {"address", ["asset","policy_id"]}.
+    """
+    out, seen = [], set()
+    st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
+    if st != 200 or not isinstance(latest, dict):
+        print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
+        return out
+    top = max(1, int(latest["height"]) - depth)
+    scanned = 0
+    for h in range(top, max(1, top - scan_limit), -1):
+        if len(out) >= want:
+            break
+        scanned += 1
+        st, txs = http_get(cfg["local"] + LOCAL_PREFIX + f"/blocks/{h}/txs?{LIST_QUERY}")
+        if st != 200 or not isinstance(txs, list) or not txs:
+            continue
+        for txh in txs[:3]:
+            if len(out) >= want:
+                break
+            st, u = http_get(cfg["local"] + LOCAL_PREFIX + f"/txs/{txh}/utxos")
+            if st != 200 or not isinstance(u, dict):
+                continue
+            for io in (u.get("outputs") or []):
+                addr = io.get("address")
+                if not addr or addr in seen:
+                    continue
+                seen.add(addr)
+                entry = {"address": addr}
+                for amt in io.get("amount", []):
+                    if amt.get("unit") and amt["unit"] != "lovelace":
+                        entry["asset"] = amt["unit"]
+                        entry["policy_id"] = amt["unit"][:56]
+                        break
+                out.append(entry)
+                if len(out) >= want:
+                    break
+    print(f"  seeded {len(out)} address sample(s) "
+          f"({sum('asset' in e for e in out)} with a native asset) "
+          f"from {scanned} block(s)")
+    return out
+
+
+def seed_assets(net, cfg, want=5, depth=20, scan_limit=600):
+    """Discover up to `want` distinct native assets from recent local-chain UTXOs.
+
+    Mirrors seed_addresses but collects asset units (with policy_id = unit[:56])
+    so the asset endpoints can be exercised against several datasets in one run.
+    The curated PARAMS[net] asset (a known-stable anchor) is included first when
+    present. Returns a list of param dicts: {"asset", "policy_id"}.
+    """
+    out, seen = [], set()
+    base = PARAMS.get(net, {})
+    if base.get("asset"):
+        out.append({"asset": base["asset"],
+                    "policy_id": base.get("policy_id") or base["asset"][:56]})
+        seen.add(base["asset"])
+
+    st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
+    if st != 200 or not isinstance(latest, dict):
+        print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
+        return out
+    top = max(1, int(latest["height"]) - depth)
+    scanned = 0
+    for h in range(top, max(1, top - scan_limit), -1):
+        if len(out) >= want:
+            break
+        scanned += 1
+        st, txs = http_get(cfg["local"] + LOCAL_PREFIX + f"/blocks/{h}/txs?{LIST_QUERY}")
+        if st != 200 or not isinstance(txs, list) or not txs:
+            continue
+        for txh in txs[:5]:
+            if len(out) >= want:
+                break
+            st, u = http_get(cfg["local"] + LOCAL_PREFIX + f"/txs/{txh}/utxos")
+            if st != 200 or not isinstance(u, dict):
+                continue
+            for io in (u.get("outputs") or []):
+                for amt in io.get("amount", []):
+                    unit = amt.get("unit")
+                    if unit and unit != "lovelace" and unit not in seen:
+                        seen.add(unit)
+                        out.append({"asset": unit, "policy_id": unit[:56]})
+                        if len(out) >= want:
+                            break
+                if len(out) >= want:
+                    break
+    print(f"  seeded {len(out)} asset sample(s) from {scanned} block(s)")
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -154,13 +300,19 @@ def diff(a, b, path=""):
 # ---------------------------------------------------------------------------
 
 def run_module(net, module, endpoints, strict=False, depth=20, throttle=0.2,
-               csv_out=None, orders=("asc", "desc"), pages=(1, 2), count=100):
+               csv_out=None, orders=("asc", "desc"), pages=(1, 2), count=100,
+               param_sets=None):
     """
     endpoints: list of (path_template, is_list, [required_param_keys])
     csv_out:   optional file path; if given, appends one row per comparison to a CSV.
     orders:    order values to exercise on list endpoints (e.g. ("asc","desc")).
     pages:     page numbers to exercise on list endpoints (e.g. (1, 2)).
     count:     page size for list endpoints.
+    param_sets: optional list of param dicts (e.g. [{"address": ...}, ...]).
+               When given, every endpoint is exercised once per param set, with
+               each set merged over the auto-seeded base params. This lets a
+               module test many datasets (e.g. multiple addresses) in one run.
+               When None, behaves as a single run over the seeded params.
     Non-list endpoints are compared once (order/page do not apply).
     List endpoints are compared once per (order, page) combination.
     Returns totals dict {ok, diff, skip, err}.
@@ -171,7 +323,7 @@ def run_module(net, module, endpoints, strict=False, depth=20, throttle=0.2,
         sys.exit(f"Set ${cfg['pid_env']} to your Blockfrost {net} project_id")
 
     ignore = IGNORE_VOLATILE | (set() if strict else set(IGNORE_DIVERGENT))
-    params = seed_params(net, cfg, depth)
+    params = seed_params(net, cfg, depth, module=module)
 
     print(f"\n{'='*60}")
     print(f"  {module.upper()}  |  {net}")
@@ -186,7 +338,7 @@ def run_module(net, module, endpoints, strict=False, depth=20, throttle=0.2,
     run_dt = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     csv_rows = []
 
-    CSV_FIELDS = ["date", "network", "module", "endpoint",
+    CSV_FIELDS = ["date", "network", "module", "sample", "endpoint",
                   "result", "yaci_status", "bf_status",
                   "yaci_ms", "bf_ms", "slow", "diff_count", "diff_fields"]
 
@@ -254,32 +406,51 @@ def run_module(net, module, endpoints, strict=False, depth=20, throttle=0.2,
                                  yaci_ms=yaci_ms, bf_ms=bf_ms, slow=slow,
                                  diff_count=0, diff_fields=""))
 
-    for entry in endpoints:
-        path_tpl, is_list = entry[0], entry[1]
-        req_keys = entry[2] if len(entry) > 2 else []
-        missing = [k for k in req_keys if not params.get(k)]
-        if missing:
-            print(f"  SKIP  {path_tpl}  (no param: {missing})")
-            totals["skip"] += 1
-            csv_rows.append(dict(date=run_dt, network=net, module=module,
-                                 endpoint=path_tpl, result="SKIP",
-                                 yaci_status="", bf_status="",
-                                 yaci_ms="", bf_ms="", slow="",
-                                 diff_count="", diff_fields=f"missing params: {missing}"))
-            continue
+    # Each param set is merged over the auto-seeded base params and run in full.
+    # With no param_sets this is a single run over the seeded params (unchanged).
+    runs = [{**params, **ps} for ps in param_sets] if param_sets else [params]
 
-        path = path_tpl.format(**params)
+    for run_params in runs:
+        sample = str(run_params.get("address")
+                     or run_params.get("asset")
+                     or run_params.get("tx_hash")
+                     or "default")
+        if len(runs) > 1:
+            ast = str(run_params.get("asset") or "")
+            print(f"\n  --- sample: {sample}"
+                  + (f"  asset={ast[:20]}…" if ast else "") + " ---")
+        row_start = len(csv_rows)
 
-        if not is_list:
-            compare_call(path_tpl, path, "")
-            continue
+        for entry in endpoints:
+            path_tpl, is_list = entry[0], entry[1]
+            req_keys = entry[2] if len(entry) > 2 else []
+            missing = [k for k in req_keys if not run_params.get(k)]
+            if missing:
+                print(f"  SKIP  {path_tpl}  (no param: {missing})")
+                totals["skip"] += 1
+                csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                     endpoint=path_tpl, result="SKIP",
+                                     yaci_status="", bf_status="",
+                                     yaci_ms="", bf_ms="", slow="",
+                                     diff_count="", diff_fields=f"missing params: {missing}"))
+                continue
 
-        # List endpoint: exercise every (order, page) combination.
-        for order in orders:
-            for page in pages:
-                q     = f"?count={count}&page={page}&order={order}"
-                label = f"{path_tpl}?order={order}&page={page}"
-                compare_call(label, path, q)
+            path = path_tpl.format(**run_params)
+
+            if not is_list:
+                compare_call(path_tpl, path, "")
+                continue
+
+            # List endpoint: exercise every (order, page) combination.
+            for order in orders:
+                for page in pages:
+                    q     = f"?count={count}&page={page}&order={order}"
+                    label = f"{path_tpl}?order={order}&page={page}"
+                    compare_call(label, path, q)
+
+        # Tag every row produced by this param set with its sample identifier.
+        for r in csv_rows[row_start:]:
+            r["sample"] = sample
 
     print(f"\n  [{module}/{net}] ok={totals['ok']}  diff={totals['diff']}  "
           f"skip={totals['skip']}  err={totals['err']}")

--- a/scripts/compare-blockfrost/bf_compare.py
+++ b/scripts/compare-blockfrost/bf_compare.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Shared core for Blockfrost compatibility comparison.
+
+Not run directly — imported by compare_<module>.py scripts.
+
+Environment variables required (network-locked Blockfrost keys):
+  BF_PROJECT_ID_MAINNET
+  BF_PROJECT_ID_PREPROD
+  BF_PROJECT_ID_PREVIEW
+"""
+import csv, datetime, json, os, sys, time, urllib.request, urllib.error
+
+NETWORKS = {
+    "mainnet": dict(local="http://localhost:8101",
+                    bf="https://cardano-mainnet.blockfrost.io/api/v0",
+                    pid_env="BF_PROJECT_ID_MAINNET"),
+    "preprod": dict(local="http://localhost:8301",
+                    bf="https://cardano-preprod.blockfrost.io/api/v0",
+                    pid_env="BF_PROJECT_ID_PREPROD"),
+    "preview": dict(local="http://localhost:8201",
+                    bf="https://cardano-preview.blockfrost.io/api/v0",
+                    pid_env="BF_PROJECT_ID_PREVIEW"),
+}
+LOCAL_PREFIX = "/api/v1/blockfrost"
+LIST_QUERY   = "count=100&page=1&order=asc"
+
+# Volatile: always stripped before diffing (change between the two calls)
+IGNORE_VOLATILE = {"confirmations", "next_block"}
+
+# Confirmed expected divergences — add here with a comment after verifying
+IGNORE_DIVERGENT: dict = {
+    # "field": "reason",
+}
+
+# Known-active sample identifiers per network.
+# block/slot/epoch/tx_hash/address/asset/policy_id are auto-seeded from local chain.
+PARAMS: dict = {
+    "preprod": dict(
+        stake_address="stake_test1uqgvl08c9kfzduvfd7r9n2eqh4n9j6nkxcxhkzuq5gv37psg34zyp",
+        pool_id="pool1lenzcfx02maescnpv8mk6gc6c59t0dramqucdgcvr4revw89xpz",
+        script_hash="", datum_hash="", label="674",
+    ),
+    "preview": dict(stake_address="", pool_id="pool1ynfnjspgckgxjf2zeye8s33jz3e3ndk9pcwp0qzaupzvvd8ukwt", script_hash="", datum_hash="", label="674"),
+    "mainnet": dict(
+        epoch="633",
+        pool_id="pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2qnikdy",
+        stake_address="", script_hash="", datum_hash="", label="674",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def http_get(url, project_id=None, timeout=30):
+    req = urllib.request.Request(url)
+    if project_id:
+        req.add_header("project_id", project_id)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read().decode() or "null")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        try:
+            body = json.loads(body)
+        except Exception:
+            pass
+        return e.code, body
+    except Exception as e:
+        return None, str(e)
+
+
+# ---------------------------------------------------------------------------
+# Seeding: discover block/slot/epoch/tx/address/asset from local chain
+# ---------------------------------------------------------------------------
+
+def seed_params(net, cfg, depth=20):
+    p = dict(PARAMS.get(net, {}))
+    st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
+    if st != 200 or not isinstance(latest, dict):
+        print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
+        return p
+    target = max(1, int(latest["height"]) - depth)
+    st, blk = http_get(cfg["local"] + LOCAL_PREFIX + f"/blocks/{target}")
+    if st == 200 and isinstance(blk, dict):
+        p["block"] = str(blk["height"])
+        p["slot"]  = str(blk["slot"])
+        p.setdefault("epoch", str(int(blk["epoch"]) - 1))   # completed epoch
+
+    # walk back to find a block with txs
+    for h in range(int(p.get("block", target)), max(1, target - 500), -1):
+        st, txs = http_get(cfg["local"] + LOCAL_PREFIX + f"/blocks/{h}/txs?{LIST_QUERY}")
+        if st == 200 and isinstance(txs, list) and txs:
+            p["tx_hash"] = txs[0]
+            p["block"]   = str(h)
+            st, blk = http_get(cfg["local"] + LOCAL_PREFIX + f"/blocks/{h}")
+            if st == 200:
+                p["slot"]  = str(blk["slot"])
+                p.setdefault("epoch", str(int(blk["epoch"]) - 1))
+            break
+
+    # derive address + asset from tx utxos
+    if p.get("tx_hash"):
+        st, u = http_get(cfg["local"] + LOCAL_PREFIX + f"/txs/{p['tx_hash']}/utxos")
+        if st == 200 and isinstance(u, dict):
+            for io in (u.get("outputs") or []):
+                p.setdefault("address", io.get("address"))
+                for amt in io.get("amount", []):
+                    if amt.get("unit") and amt["unit"] != "lovelace":
+                        p.setdefault("asset", amt["unit"])
+                        p.setdefault("policy_id", amt["unit"][:56])
+                        break
+                if p.get("asset"):
+                    break
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Diff helpers
+# ---------------------------------------------------------------------------
+
+def strip(obj, keys):
+    if isinstance(obj, dict):
+        return {k: strip(v, keys) for k, v in obj.items() if k not in keys}
+    if isinstance(obj, list):
+        return [strip(v, keys) for v in obj]
+    return obj
+
+
+def diff(a, b, path=""):
+    out = []
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k in sorted(set(a) | set(b)):
+            if k not in a:
+                out.append(f"{path}.{k}: missing in Yaci")
+            elif k not in b:
+                out.append(f"{path}.{k}: missing in Blockfrost")
+            else:
+                out += diff(a[k], b[k], f"{path}.{k}")
+    elif isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            out.append(f"{path}: length BF={len(b)} Yaci={len(a)}")
+        for i in range(min(len(a), len(b))):
+            out += diff(a[i], b[i], f"{path}[{i}]")
+    else:
+        if a != b:
+            out.append(f"{path}: BF={b!r}  Yaci={a!r}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Core runner — called by each per-module script
+# ---------------------------------------------------------------------------
+
+def run_module(net, module, endpoints, strict=False, depth=20, throttle=0.2,
+               csv_out=None, orders=("asc", "desc"), pages=(1, 2), count=100):
+    """
+    endpoints: list of (path_template, is_list, [required_param_keys])
+    csv_out:   optional file path; if given, appends one row per comparison to a CSV.
+    orders:    order values to exercise on list endpoints (e.g. ("asc","desc")).
+    pages:     page numbers to exercise on list endpoints (e.g. (1, 2)).
+    count:     page size for list endpoints.
+    Non-list endpoints are compared once (order/page do not apply).
+    List endpoints are compared once per (order, page) combination.
+    Returns totals dict {ok, diff, skip, err}.
+    """
+    cfg = NETWORKS[net]
+    pid = os.environ.get(cfg["pid_env"])
+    if not pid:
+        sys.exit(f"Set ${cfg['pid_env']} to your Blockfrost {net} project_id")
+
+    ignore = IGNORE_VOLATILE | (set() if strict else set(IGNORE_DIVERGENT))
+    params = seed_params(net, cfg, depth)
+
+    print(f"\n{'='*60}")
+    print(f"  {module.upper()}  |  {net}")
+    print(f"  block={params.get('block')}  slot={params.get('slot')}  epoch={params.get('epoch')}")
+    tx  = str(params.get('tx_hash', ''))
+    adr = str(params.get('address', ''))
+    print(f"  tx={tx[:24]}…  addr={adr[:24]}…")
+    print(f"  list variants: orders={list(orders)}  pages={list(pages)}  count={count}")
+    print(f"{'='*60}")
+
+    totals = {"ok": 0, "diff": 0, "skip": 0, "err": 0}
+    run_dt = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    csv_rows = []
+
+    CSV_FIELDS = ["date", "network", "module", "endpoint",
+                  "result", "yaci_status", "bf_status",
+                  "yaci_ms", "bf_ms", "slow", "diff_count", "diff_fields"]
+
+    def compare_call(label, path, q):
+        """Run one Yaci-vs-BF comparison for a fully-resolved path + query string."""
+        t0 = time.monotonic()
+        ls, lb = http_get(cfg["local"] + LOCAL_PREFIX + path + q)
+        yaci_ms = int((time.monotonic() - t0) * 1000)
+        time.sleep(throttle)
+        t0 = time.monotonic()
+        bs, bb = http_get(cfg["bf"] + path + q, project_id=pid)
+        bf_ms = int((time.monotonic() - t0) * 1000)
+        time.sleep(throttle)
+
+        slow = bool(yaci_ms > 500 or yaci_ms > bf_ms * 3)
+
+        if ls != bs:
+            print(f"  STATUS  {label}  BF={bs}  Yaci={ls}")
+            if ls != 200:
+                print(f"    Yaci body: {json.dumps(lb, indent=2)[:500]}")
+            if bs != 200:
+                print(f"    BF   body: {json.dumps(bb, indent=2)[:500]}")
+            totals["err"] += 1
+            csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                 endpoint=label, result="STATUS_MISMATCH",
+                                 yaci_status=ls, bf_status=bs,
+                                 yaci_ms=yaci_ms, bf_ms=bf_ms, slow=slow,
+                                 diff_count="", diff_fields=""))
+            return
+
+        if ls != 200:
+            print(f"  ({ls})  {label}  — both non-200, skipping diff")
+            totals["skip"] += 1
+            csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                 endpoint=label, result="SKIP_NON200",
+                                 yaci_status=ls, bf_status=bs,
+                                 yaci_ms=yaci_ms, bf_ms=bf_ms, slow=slow,
+                                 diff_count="", diff_fields=""))
+            return
+
+        d = diff(strip(lb, ignore), strip(bb, ignore))
+        slow_flag = " :warning: SLOW" if slow else ""
+        timing = f"  [Yaci={yaci_ms}ms  BF={bf_ms}ms{slow_flag}]"
+        if d:
+            print(f"  DIFF  {label}  ({len(d)} field(s)){timing}")
+            for line in d[:15]:
+                print(f"        {line}")
+            if len(d) > 15:
+                print(f"        … +{len(d)-15} more")
+            print(f"    --- BF   sample: {json.dumps(bb if not isinstance(bb, list) else bb[:2], indent=2)[:800]}")
+            print(f"    --- Yaci sample: {json.dumps(lb if not isinstance(lb, list) else lb[:2], indent=2)[:800]}")
+            totals["diff"] += 1
+            csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                 endpoint=label, result="DIFF",
+                                 yaci_status=ls, bf_status=bs,
+                                 yaci_ms=yaci_ms, bf_ms=bf_ms, slow=slow,
+                                 diff_count=len(d),
+                                 diff_fields=" | ".join(d[:5])))
+        else:
+            print(f"  OK    {label}{timing}")
+            totals["ok"] += 1
+            csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                 endpoint=label, result="OK",
+                                 yaci_status=ls, bf_status=bs,
+                                 yaci_ms=yaci_ms, bf_ms=bf_ms, slow=slow,
+                                 diff_count=0, diff_fields=""))
+
+    for entry in endpoints:
+        path_tpl, is_list = entry[0], entry[1]
+        req_keys = entry[2] if len(entry) > 2 else []
+        missing = [k for k in req_keys if not params.get(k)]
+        if missing:
+            print(f"  SKIP  {path_tpl}  (no param: {missing})")
+            totals["skip"] += 1
+            csv_rows.append(dict(date=run_dt, network=net, module=module,
+                                 endpoint=path_tpl, result="SKIP",
+                                 yaci_status="", bf_status="",
+                                 yaci_ms="", bf_ms="", slow="",
+                                 diff_count="", diff_fields=f"missing params: {missing}"))
+            continue
+
+        path = path_tpl.format(**params)
+
+        if not is_list:
+            compare_call(path_tpl, path, "")
+            continue
+
+        # List endpoint: exercise every (order, page) combination.
+        for order in orders:
+            for page in pages:
+                q     = f"?count={count}&page={page}&order={order}"
+                label = f"{path_tpl}?order={order}&page={page}"
+                compare_call(label, path, q)
+
+    print(f"\n  [{module}/{net}] ok={totals['ok']}  diff={totals['diff']}  "
+          f"skip={totals['skip']}  err={totals['err']}")
+
+    # When no --csv path is given, write to the default report directory
+    # alongside this module: scripts/compare-blockfrost/report/<module>_<net>.csv
+    if csv_out is None:
+        csv_out = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "report", f"{module}_{net}.csv")
+    os.makedirs(os.path.dirname(csv_out), exist_ok=True)
+    write_header = not os.path.exists(csv_out)
+    with open(csv_out, "a", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=CSV_FIELDS)
+        if write_header:
+            w.writeheader()
+        w.writerows(csv_rows)
+    print(f"  CSV appended → {csv_out}  ({len(csv_rows)} rows)")
+
+    return totals

--- a/scripts/compare-blockfrost/bf_compare.py
+++ b/scripts/compare-blockfrost/bf_compare.py
@@ -8,7 +8,7 @@ Environment variables required (network-locked Blockfrost keys):
   BF_PROJECT_ID_PREPROD
   BF_PROJECT_ID_PREVIEW
 """
-import csv, datetime, json, os, sys, time, urllib.request, urllib.error
+import csv, datetime, json, os, subprocess, sys, time, urllib.request, urllib.error
 
 # ---------------------------------------------------------------------------
 # Config loading — runs before NETWORKS so endpoints can come from .env
@@ -120,6 +120,191 @@ def http_get(url, project_id=None, timeout=30):
 
 
 # ---------------------------------------------------------------------------
+# DB helpers — seeding reads test data straight from Postgres (no API calls).
+#   YACI_DB_<NET>   libpq URI, e.g. postgresql://user:pass@host:5432/yaci_store
+#   YACI_DB_SCHEMA  schema holding the store tables (default: yaci_store)
+# Requires the `psql` client binary on PATH. Seeding falls back to the API path
+# when no DSN is configured for the network.
+# ---------------------------------------------------------------------------
+
+DB_SCHEMA = os.environ.get("YACI_DB_SCHEMA", "yaci_store")
+
+
+def db_schema(net):
+    """Schema holding the store tables for a network.
+
+    Per-network override ``YACI_DB_SCHEMA_<NET>`` (e.g. YACI_DB_SCHEMA_MAINNET) wins;
+    otherwise the global ``YACI_DB_SCHEMA`` is used, defaulting to ``yaci_store``.
+    Lets networks whose DB uses a different schema name be compared without code changes.
+    """
+    return os.environ.get(f"YACI_DB_SCHEMA_{net.upper()}", DB_SCHEMA)
+
+
+def db_dsn(net):
+    """libpq DSN/URI for a network, or None when DB seeding isn't configured."""
+    return os.environ.get(f"YACI_DB_{net.upper()}")
+
+
+def db_query(net, sql, timeout=30):
+    """Run a read-only query via psql; return rows as lists of column strings.
+
+    Returns None when no DSN is set for the network or psql fails, so callers
+    can fall back to the API seeding path. A server-side statement_timeout
+    bounds each query so a heavy seed can never pin a connection.
+    """
+    dsn = db_dsn(net)
+    if not dsn:
+        return None
+    wrapped = f"SET statement_timeout = {int(timeout) * 1000}; {sql}"
+    try:
+        proc = subprocess.run(
+            ["psql", dsn, "-q", "-t", "-A", "-F", "\t", "-v", "ON_ERROR_STOP=1", "-c", wrapped],
+            capture_output=True, text=True, timeout=timeout + 5,
+        )
+    except Exception as e:
+        print(f"  ! db_query error: {e}", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        err = proc.stderr.strip().splitlines()
+        print(f"  ! db_query failed: {err[-1] if err else proc.returncode}", file=sys.stderr)
+        return None
+    return [line.split("\t") for line in proc.stdout.splitlines() if line]
+
+
+def db_tip(net):
+    """Latest block height from the DB, or None."""
+    rows = db_query(net, f"SELECT max(number) FROM {db_schema(net)}.block")
+    if rows and rows[0] and rows[0][0]:
+        try:
+            return int(rows[0][0])
+        except ValueError:
+            return None
+    return None
+
+
+def _db_recent_block(net, depth, require_txs=True):
+    """Most recent block at/below (tip - depth) as (number, slot, epoch) strings.
+
+    Uses idx_block_number. Returns None when the DB is unreachable, () when no
+    matching block exists. `slot` then drives the tx/utxo lookups because slot
+    is indexed on transaction and address_utxo while `block` is not (avoids the
+    F5 seq scan).
+    """
+    tip = db_tip(net)
+    if tip is None:
+        return None
+    target = max(1, tip - depth)
+    cond = "AND no_of_txs > 0" if require_txs else ""
+    rows = db_query(net, f"""SELECT number, slot, epoch FROM {db_schema(net)}.block
+        WHERE number <= {target} {cond} ORDER BY number DESC LIMIT 1""")
+    if rows is None:
+        return None
+    return tuple(rows[0]) if rows and len(rows[0]) >= 3 else ()
+
+
+def _db_native_unit(net, column, value):
+    """First non-lovelace asset unit on UTXOs where address_utxo.<column> = value.
+
+    `column` MUST be an indexed column (slot or owner_addr) to stay cheap; both
+    use a btree index, so the jsonb expansion only runs over the matched rows.
+    """
+    rows = db_query(net, f"""SELECT a->>'unit' FROM {db_schema(net)}.address_utxo au,
+            jsonb_array_elements(au.amounts) a
+        WHERE au.{column} = '{value}' AND a->>'unit' <> 'lovelace' LIMIT 1""")
+    return rows[0][0] if rows and rows[0] and rows[0][0] else None
+
+
+def _db_seed_params(net, depth):
+    """Seed block/slot/epoch/tx_hash/address/asset directly from the DB.
+
+    Returns a param dict, {} when no suitable block is found, or None when the
+    DB is unreachable (caller then falls back to the API path).
+    """
+    blk = _db_recent_block(net, depth, require_txs=True)
+    if blk is None:
+        return None
+    if not blk:
+        return {}
+    number, slot, epoch = blk
+    p = {"block": number, "slot": slot}
+    try:
+        p.setdefault("epoch", str(int(epoch) - 1))   # completed epoch
+    except (ValueError, TypeError):
+        pass
+    # slot is indexed on both transaction and address_utxo (block is not).
+    txs = db_query(net, f"""SELECT tx_hash FROM {db_schema(net)}.transaction
+        WHERE slot = '{slot}' ORDER BY tx_index LIMIT 1""")
+    if txs and txs[0][0]:
+        p["tx_hash"] = txs[0][0]
+    addr = db_query(net, f"""SELECT owner_addr FROM {db_schema(net)}.address_utxo
+        WHERE slot = '{slot}' AND owner_addr IS NOT NULL
+        ORDER BY output_index LIMIT 1""")
+    if addr and addr[0][0]:
+        p["address"] = addr[0][0]
+    unit = _db_native_unit(net, "slot", slot)
+    if unit:
+        p["asset"] = unit
+        p["policy_id"] = unit[:56]
+    return p
+
+
+def _db_seed_addresses(net, want, depth, slot_window=40000):
+    """Discover up to `want` recent distinct addresses (+ one asset each) from DB.
+
+    Scans a bounded slot window via idx_address_utxo_slot, then looks up one
+    native asset per address via idx_address_utxo_owner_addr.
+    """
+    blk = _db_recent_block(net, depth, require_txs=False)
+    if blk is None:
+        return None
+    if not blk:
+        return []
+    hi = int(blk[1])
+    lo = max(0, hi - slot_window)
+    rows = db_query(net, f"""SELECT DISTINCT owner_addr FROM {db_schema(net)}.address_utxo
+        WHERE slot BETWEEN {lo} AND {hi} AND owner_addr IS NOT NULL LIMIT {want}""")
+    if rows is None:
+        return None
+    out = []
+    for r in rows:
+        addr = r[0]
+        if not addr:
+            continue
+        entry = {"address": addr}
+        unit = _db_native_unit(net, "owner_addr", addr)
+        if unit:
+            entry["asset"] = unit
+            entry["policy_id"] = unit[:56]
+        out.append(entry)
+    print(f"  seeded {len(out)} address sample(s) "
+          f"({sum('asset' in e for e in out)} with a native asset) from DB")
+    return out
+
+
+def _db_seed_assets(net, want, depth, slot_window=40000):
+    """Discover up to `want` recent distinct native asset units from DB.
+
+    Scans a bounded slot window via idx_address_utxo_slot, expanding amounts
+    only over the matched rows.
+    """
+    blk = _db_recent_block(net, depth, require_txs=False)
+    if blk is None:
+        return None
+    if not blk:
+        return []
+    hi = int(blk[1])
+    lo = max(0, hi - slot_window)
+    rows = db_query(net, f"""SELECT DISTINCT a->>'unit' FROM {db_schema(net)}.address_utxo au,
+            jsonb_array_elements(au.amounts) a
+        WHERE au.slot BETWEEN {lo} AND {hi} AND a->>'unit' <> 'lovelace' LIMIT {want}""")
+    if rows is None:
+        return None
+    out = [{"asset": r[0], "policy_id": r[0][:56]} for r in rows if r and r[0]]
+    print(f"  seeded {len(out)} asset sample(s) from DB")
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Seeding: discover block/slot/epoch/tx/address/asset from local chain
 # ---------------------------------------------------------------------------
 
@@ -127,6 +312,15 @@ def seed_params(net, cfg, depth=20, module=None):
     # Base identifiers come from config/<module>.json; PARAMS is a legacy
     # fallback kept only for modules not yet migrated to config files.
     p = dict(load_config(module, net)) or dict(PARAMS.get(net, {}))
+
+    # Prefer seeding from the DB directly; fall back to the API path below.
+    if db_dsn(net):
+        seeded = _db_seed_params(net, depth)
+        if seeded is not None:
+            for k, v in seeded.items():
+                p.setdefault(k, v)
+            return p
+
     st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
     if st != 200 or not isinstance(latest, dict):
         print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
@@ -175,6 +369,13 @@ def seed_addresses(net, cfg, want=5, depth=20, scan_limit=600):
     exercised. Returns a list of param dicts: {"address", ["asset","policy_id"]}.
     """
     out, seen = [], set()
+
+    # Prefer seeding from the DB directly; fall back to the API walk below.
+    if db_dsn(net):
+        seeded = _db_seed_addresses(net, want, depth)
+        if seeded is not None:
+            return seeded
+
     st, latest = http_get(cfg["local"] + LOCAL_PREFIX + "/blocks/latest")
     if st != 200 or not isinstance(latest, dict):
         print(f"  ! cannot read local /blocks/latest: {latest}", file=sys.stderr)
@@ -223,6 +424,13 @@ def seed_assets(net, cfg, want=5, depth=20, scan_limit=600):
     present. Returns a list of param dicts: {"asset", "policy_id"}.
     """
     out, seen = [], set()
+
+    # Prefer seeding from the DB directly; fall back to the API walk below.
+    if db_dsn(net):
+        seeded = _db_seed_assets(net, want, depth)
+        if seeded is not None:
+            return seeded
+
     base = PARAMS.get(net, {})
     if base.get("asset"):
         out.append({"asset": base["asset"],

--- a/scripts/compare-blockfrost/compare_account.py
+++ b/scripts/compare-blockfrost/compare_account.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Compare /accounts endpoints: Yaci vs Blockfrost.
+
+NOTE: requires store.account + store.adapot synced from genesis.
+      Fill stake_address/pool_id in bf_compare.PARAMS for each network.
+"""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/accounts/{stake_address}",                       False, ["stake_address"]),
+    ("/accounts/{stake_address}/rewards",               True,  ["stake_address"]),
+    ("/accounts/{stake_address}/history",               True,  ["stake_address"]),
+    ("/accounts/{stake_address}/delegations",           True,  ["stake_address"]),
+    ("/accounts/{stake_address}/registrations",         True,  ["stake_address"]),
+    ("/accounts/{stake_address}/withdrawals",           True,  ["stake_address"]),
+    ("/accounts/{stake_address}/mirs",                  True,  ["stake_address"]),
+    ("/accounts/{stake_address}/addresses",             True,  ["stake_address"]),
+    ("/accounts/{stake_address}/addresses/assets",      True,  ["stake_address"]),
+    ("/accounts/{stake_address}/addresses/total",       False, ["stake_address"]),
+    ("/accounts/{stake_address}/utxos",                 True,  ["stake_address"]),
+    ("/accounts/{stake_address}/transactions",          True,  ["stake_address"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "account", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_address.py
+++ b/scripts/compare-blockfrost/compare_address.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Compare /addresses endpoints: Yaci vs Blockfrost."""
+"""Compare /addresses endpoints: Yaci vs Blockfrost.
+
+By default this seeds several distinct addresses from the local chain so the
+comparison has multiple datasets (more cases / more evidence). Use --samples to
+change how many, or --addresses to test an explicit comma-separated list.
+"""
 import argparse, sys
 sys.path.insert(0, __file__.rsplit("/", 1)[0])
-from bf_compare import run_module, NETWORKS
+from bf_compare import run_module, seed_addresses, load_config, NETWORKS
 
 ENDPOINTS = [
     ("/addresses/{address}",              False, ["address"]),
@@ -19,5 +24,40 @@ if __name__ == "__main__":
     ap.add_argument("--strict",  action="store_true")
     ap.add_argument("--depth",   type=int,   default=20)
     ap.add_argument("--throttle",type=float, default=0.2)
+    ap.add_argument("--samples", type=int,   default=5,
+                    help="number of addresses to auto-discover and test (default 5)")
+    ap.add_argument("--addresses", type=str, default="",
+                    help="comma-separated explicit addresses to test "
+                         "(overrides --samples auto-discovery)")
     a = ap.parse_args()
-    run_module(a.network, "address", ENDPOINTS, a.strict, a.depth, a.throttle)
+
+    if a.addresses.strip():
+        # 1. Explicit CLI list wins.
+        param_sets = [{"address": x.strip()} for x in a.addresses.split(",") if x.strip()]
+    else:
+        cfg = load_config("address", a.network)
+        cfg_addrs = cfg.get("addresses") or []
+        if cfg_addrs:
+            # 2. Addresses from config/address.json. Entries may be plain
+            #    strings or objects; strings inherit the network's default asset.
+            param_sets = []
+            for item in cfg_addrs:
+                if isinstance(item, dict):
+                    param_sets.append(item)
+                else:
+                    ps = {"address": item}
+                    if cfg.get("asset"):
+                        ps["asset"] = cfg["asset"]
+                    if cfg.get("policy_id"):
+                        ps["policy_id"] = cfg["policy_id"]
+                    param_sets.append(ps)
+            print(f"  using {len(param_sets)} address(es) from config/address.json [{a.network}]")
+        else:
+            # 3. Zero-config fallback: auto-discover from the local chain.
+            param_sets = seed_addresses(a.network, NETWORKS[a.network],
+                                        want=a.samples, depth=a.depth)
+            if not param_sets:
+                sys.exit("Could not seed any addresses from the local chain.")
+
+    run_module(a.network, "address", ENDPOINTS, a.strict, a.depth, a.throttle,
+               param_sets=param_sets)

--- a/scripts/compare-blockfrost/compare_address.py
+++ b/scripts/compare-blockfrost/compare_address.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Compare /addresses endpoints: Yaci vs Blockfrost."""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/addresses/{address}",              False, ["address"]),
+    ("/addresses/{address}/extended",     False, ["address"]),
+    ("/addresses/{address}/total",        False, ["address"]),
+    ("/addresses/{address}/utxos",        True,  ["address"]),
+    ("/addresses/{address}/utxos/{asset}", True, ["address", "asset"]),
+    ("/addresses/{address}/transactions", True,  ["address"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "address", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_asset.py
+++ b/scripts/compare-blockfrost/compare_asset.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Compare /assets endpoints: Yaci vs Blockfrost."""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/assets",                      True,  []),
+    ("/assets/{asset}",              False, ["asset"]),
+    ("/assets/{asset}/history",      True,  ["asset"]),
+    ("/assets/{asset}/txs",          True,  ["asset"]),
+    ("/assets/{asset}/transactions", True,  ["asset"]),
+    ("/assets/{asset}/addresses",    True,  ["asset"]),
+    ("/assets/policy/{policy_id}",   True,  ["policy_id"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "asset", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_asset.py
+++ b/scripts/compare-blockfrost/compare_asset.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
-"""Compare /assets endpoints: Yaci vs Blockfrost."""
+"""Compare /assets endpoints: Yaci vs Blockfrost.
+
+By default this seeds several distinct assets from the local chain so the
+comparison has multiple datasets (more cases / more evidence). Use --samples to
+change how many, or --assets to test an explicit comma-separated list of units.
+
+The network-global ``/assets`` list endpoint is asset-independent, so it is
+exercised once (not per sample). All other endpoints are asset/policy-scoped and
+run once per seeded asset.
+"""
 import argparse, sys
 sys.path.insert(0, __file__.rsplit("/", 1)[0])
-from bf_compare import run_module, NETWORKS
+from bf_compare import run_module, seed_assets, NETWORKS
 
+# Asset/policy-scoped endpoints — run once per seeded asset.
 ENDPOINTS = [
-    ("/assets",                      True,  []),
     ("/assets/{asset}",              False, ["asset"]),
     ("/assets/{asset}/history",      True,  ["asset"]),
     ("/assets/{asset}/txs",          True,  ["asset"]),
@@ -14,11 +23,39 @@ ENDPOINTS = [
     ("/assets/policy/{policy_id}",   True,  ["policy_id"]),
 ]
 
+# Network-global list endpoint — asset-independent, tested once.
+GLOBAL_ENDPOINTS = [
+    ("/assets",                      True,  []),
+]
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--network", required=True, choices=list(NETWORKS))
     ap.add_argument("--strict",  action="store_true")
     ap.add_argument("--depth",   type=int,   default=20)
     ap.add_argument("--throttle",type=float, default=0.2)
+    ap.add_argument("--samples", type=int,   default=5,
+                    help="number of assets to auto-discover and test (default 5)")
+    ap.add_argument("--assets", type=str, default="",
+                    help="comma-separated explicit asset units to test "
+                         "(overrides --samples auto-discovery)")
+    ap.add_argument("--no-list", action="store_true",
+                    help="skip the network-global /assets list endpoint")
     a = ap.parse_args()
-    run_module(a.network, "asset", ENDPOINTS, a.strict, a.depth, a.throttle)
+
+    if a.assets.strip():
+        param_sets = [{"asset": x.strip(), "policy_id": x.strip()[:56]}
+                      for x in a.assets.split(",") if x.strip()]
+    else:
+        param_sets = seed_assets(a.network, NETWORKS[a.network],
+                                 want=a.samples, depth=a.depth)
+        if not param_sets:
+            sys.exit("Could not seed any assets from the local chain.")
+
+    # Per-asset endpoints across all seeded datasets.
+    run_module(a.network, "asset", ENDPOINTS, a.strict, a.depth, a.throttle,
+               param_sets=param_sets)
+
+    # Global /assets list once (unless suppressed).
+    if not a.no_list:
+        run_module(a.network, "asset", GLOBAL_ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_block.py
+++ b/scripts/compare-blockfrost/compare_block.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Compare /blocks endpoints: Yaci vs Blockfrost."""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/blocks/{block}",                         False, ["block"]),
+    ("/blocks/{block}/next",                    True,  ["block"]),
+    ("/blocks/{block}/previous",                True,  ["block"]),
+    ("/blocks/{block}/txs",                     True,  ["block"]),
+    ("/blocks/{block}/addresses",               True,  ["block"]),
+    ("/blocks/slot/{slot}",                     False, ["slot"]),
+    ("/blocks/epoch/{epoch}/slot/{slot}",       False, ["epoch", "slot"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "block", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_epoch.py
+++ b/scripts/compare-blockfrost/compare_epoch.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Compare /epochs endpoints: Yaci vs Blockfrost.
+
+Usage:
+  export BF_PROJECT_ID_PREPROD=preprod...
+  python3 compare_epoch.py --network preprod
+  python3 compare_epoch.py --network mainnet --strict
+  python3 compare_epoch.py --network preprod --csv reports/epoch_preprod.csv
+  python3 compare_epoch.py --network preprod --orders asc desc --pages 1 2 3
+  python3 compare_epoch.py --network preprod --orders desc --pages 1 --count 20
+"""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/epochs/latest",                      False, []),
+    ("/epochs/latest/parameters",           False, []),
+    ("/epochs/{epoch}",                     False, ["epoch"]),
+    ("/epochs/{epoch}/parameters",          False, ["epoch"]),
+    ("/epochs/{epoch}/next",                True,  ["epoch"]),
+    ("/epochs/{epoch}/previous",            True,  ["epoch"]),
+    ("/epochs/{epoch}/stakes",              True,  ["epoch"]),
+    ("/epochs/{epoch}/stakes/{pool_id}",    True,  ["epoch", "pool_id"]),
+    ("/epochs/{epoch}/blocks",              True,  ["epoch"]),
+    ("/epochs/{epoch}/blocks/{pool_id}",    True,  ["epoch", "pool_id"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network",  required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",   action="store_true")
+    ap.add_argument("--depth",    type=int,   default=20)
+    ap.add_argument("--throttle", type=float, default=0.2)
+    ap.add_argument("--csv",      metavar="FILE", default=None,
+                    help="Append results to a CSV file (created if absent)")
+    ap.add_argument("--orders",   nargs="+", default=["asc", "desc"],
+                    choices=["asc", "desc"],
+                    help="Order values to test on list endpoints (default: asc desc)")
+    ap.add_argument("--pages",    nargs="+", type=int, default=[1, 2],
+                    help="Page numbers to test on list endpoints (default: 1 2)")
+    ap.add_argument("--count",    type=int, default=100,
+                    help="Page size for list endpoints (default: 100)")
+    a = ap.parse_args()
+    run_module(a.network, "epoch", ENDPOINTS, a.strict, a.depth, a.throttle,
+               csv_out=a.csv, orders=a.orders, pages=a.pages, count=a.count)

--- a/scripts/compare-blockfrost/compare_metadata.py
+++ b/scripts/compare-blockfrost/compare_metadata.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Compare /metadata/txs endpoints: Yaci vs Blockfrost."""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/metadata/txs/labels",               True, []),
+    ("/metadata/txs/labels/{label}",       True, ["label"]),
+    ("/metadata/txs/labels/{label}/cbor",  True, ["label"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "metadata", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_scripts.py
+++ b/scripts/compare-blockfrost/compare_scripts.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Compare /scripts endpoints: Yaci vs Blockfrost.
+
+NOTE: fill script_hash and datum_hash in bf_compare.PARAMS for each network.
+"""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/scripts/{script_hash}",            False, ["script_hash"]),
+    ("/scripts/{script_hash}/json",       False, ["script_hash"]),
+    ("/scripts/{script_hash}/cbor",       False, ["script_hash"]),
+    ("/scripts/{script_hash}/redeemers",  True,  ["script_hash"]),
+    ("/scripts/datum/{datum_hash}",       False, ["datum_hash"]),
+    ("/scripts/datum/{datum_hash}/cbor",  False, ["datum_hash"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "scripts", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/compare_transaction.py
+++ b/scripts/compare-blockfrost/compare_transaction.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Compare /txs endpoints: Yaci vs Blockfrost."""
+import argparse, sys
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from bf_compare import run_module, NETWORKS
+
+ENDPOINTS = [
+    ("/txs/{tx_hash}",                   False, ["tx_hash"]),
+    ("/txs/{tx_hash}/utxos",             False, ["tx_hash"]),
+    ("/txs/{tx_hash}/metadata",          True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/redeemers",         True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/stakes",            True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/delegations",       True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/withdrawals",       True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/mirs",              True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/pool_updates",      True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/pool_retires",      True,  ["tx_hash"]),
+    ("/txs/{tx_hash}/required_signers",  True,  ["tx_hash"]),
+]
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--network", required=True, choices=list(NETWORKS))
+    ap.add_argument("--strict",  action="store_true")
+    ap.add_argument("--depth",   type=int,   default=20)
+    ap.add_argument("--throttle",type=float, default=0.2)
+    a = ap.parse_args()
+    run_module(a.network, "transaction", ENDPOINTS, a.strict, a.depth, a.throttle)

--- a/scripts/compare-blockfrost/config/account.json
+++ b/scripts/compare-blockfrost/config/account.json
@@ -1,0 +1,5 @@
+{
+  "preprod": { "stake_address": "stake_test1uqgvl08c9kfzduvfd7r9n2eqh4n9j6nkxcxhkzuq5gv37psg34zyp" },
+  "preview": { "stake_address": "" },
+  "mainnet": { "stake_address": "" }
+}

--- a/scripts/compare-blockfrost/config/address.json
+++ b/scripts/compare-blockfrost/config/address.json
@@ -1,0 +1,22 @@
+{
+  "preprod": {
+    "asset": "bb7f4364a3777f9cf178c545418725894dedc17f67f18de9bc8d8032466c756964202d2033303020",
+    "policy_id": "bb7f4364a3777f9cf178c545418725894dedc17f67f18de9bc8d8032",
+    "addresses": []
+  },
+  "preview": {
+    "asset": "16acc0b7b02e6795f5fe7350a36c6ca33bb6d54d1a1415cebd2fb5ca6e3465528c3b4e6a8f10ac4709d15a3b025242d4119e5120e045931c8e36bc81",
+    "policy_id": "16acc0b7b02e6795f5fe7350a36c6ca33bb6d54d1a1415cebd2fb5ca",
+    "addresses": []
+  },
+  "mainnet": {
+    "_comment": "addresses below are the most frequent owner_addr values (whales) from planner stats; empty arrays fall back to auto-discovery",
+    "asset": "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e4669727374636f696e",
+    "policy_id": "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e",
+    "addresses": [
+      "addr1zxgx3far7qygq0k6epa0zcvcvrevmn0ypsnfsue94nsn3tvpw288a4x0xf8pxgcntelxmyclq83s0ykeehchz2wtspks905plm",
+      "addr1zxn9efv2f6w82hagxqtn62ju4m293tqvw0uhmdl64ch8uw6j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq6s3z70",
+      "addr1vy740r73x2w3du2xxt76cs4hdml4zw2c5h7tddcyf3jauys9tyns4"
+    ]
+  }
+}

--- a/scripts/compare-blockfrost/config/asset.json
+++ b/scripts/compare-blockfrost/config/asset.json
@@ -1,0 +1,16 @@
+{
+  "preprod": {
+    "asset": "bb7f4364a3777f9cf178c545418725894dedc17f67f18de9bc8d8032466c756964202d2033303020",
+    "policy_id": "bb7f4364a3777f9cf178c545418725894dedc17f67f18de9bc8d8032"
+  },
+  "preview": {
+    "_comment": "low-cardinality NFT (~11 UTXOs); fungible 0652..4141444174 is in 149k UTXOs and times out",
+    "asset": "16acc0b7b02e6795f5fe7350a36c6ca33bb6d54d1a1415cebd2fb5ca6e3465528c3b4e6a8f10ac4709d15a3b025242d4119e5120e045931c8e36bc81",
+    "policy_id": "16acc0b7b02e6795f5fe7350a36c6ca33bb6d54d1a1415cebd2fb5ca"
+  },
+  "mainnet": {
+    "_comment": "firstcoin (sampled from BF /assets page 2)",
+    "asset": "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e4669727374636f696e",
+    "policy_id": "3a9241cd79895e3a8d65261b40077d4437ce71e9d7c8c6c00e3f658e"
+  }
+}

--- a/scripts/compare-blockfrost/config/epoch.json
+++ b/scripts/compare-blockfrost/config/epoch.json
@@ -1,0 +1,5 @@
+{
+  "preprod": { "pool_id": "pool1lenzcfx02maescnpv8mk6gc6c59t0dramqucdgcvr4revw89xpz" },
+  "preview": { "pool_id": "pool1ynfnjspgckgxjf2zeye8s33jz3e3ndk9pcwp0qzaupzvvd8ukwt" },
+  "mainnet": { "epoch": "633", "pool_id": "pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2qnikdy" }
+}

--- a/scripts/compare-blockfrost/config/metadata.json
+++ b/scripts/compare-blockfrost/config/metadata.json
@@ -1,0 +1,5 @@
+{
+  "preprod": { "label": "674" },
+  "preview": { "label": "674" },
+  "mainnet": { "label": "674" }
+}

--- a/scripts/compare-blockfrost/config/scripts.json
+++ b/scripts/compare-blockfrost/config/scripts.json
@@ -1,0 +1,5 @@
+{
+  "preprod": { "script_hash": "", "datum_hash": "" },
+  "preview": { "script_hash": "", "datum_hash": "" },
+  "mainnet": { "script_hash": "", "datum_hash": "" }
+}


### PR DESCRIPTION
Python scripts (stdlib-only) that compare Yaci Store API responses against live Blockfrost, endpoint by endpoint, across both orders and pages for list endpoints. Includes shared core (bf_compare.py), per-module comparators, and a README with setup/usage.