### PR TITLE
[backport] Enable both submit-api and ogimios service for yaci-store all profile, so that controllers are available in YS all native image

### DIFF
--- a/applications/all/src/main/resources/application-all.properties
+++ b/applications/all/src/main/resources/application-all.properties
@@ -1,5 +1,8 @@
 ##### Configurations for graal native image with all profile #####
 
+store.cardano.submit-api-url=http://localhost:8090/api/submit/tx
+store.cardano.ogmios-url=http://localhost:1337
+
 store.account.enabled=true
 store.account.api-enabled=true
 store.account.balance-aggregation-enabled=true


### PR DESCRIPTION
check #965 