### PR TITLE
Fix/blockfrost address compat

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/Constants.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/Constants.java
@@ -1,0 +1,6 @@
+package com.bloxbean.cardano.yaci.store.common;
+
+public class Constants {
+    // Statement timeout (seconds) for unbounded/full-history store queries on high-volume addresses.
+    public static final int QUERY_TIMEOUT_SECONDS = 15;
+}

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/dto/BFAddressUtxoDTO.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/dto/BFAddressUtxoDTO.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class BFAddressUtxoDTO {
     private String address;
     private String txHash;
+    private int txIndex;
     private int outputIndex;
     private List<Amount> amount;
     private String block;

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/mapper/BFAddressUtxoMapper.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/mapper/BFAddressUtxoMapper.java
@@ -15,6 +15,9 @@ public interface BFAddressUtxoMapper {
 
     @Mapping(target = "address", source = "ownerAddr")
     @Mapping(target = "txHash", source = "txHash")
+    // Blockfrost's address-utxo `tx_index` is the deprecated alias of `output_index`
+    // for this endpoint (same value), so we surface output_index under both fields.
+    @Mapping(target = "txIndex", source = "outputIndex")
     @Mapping(target = "outputIndex", source = "outputIndex")
     @Mapping(target = "amount", ignore = true)
     @Mapping(target = "block", source = "blockHash")

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/mapper/BFAddressUtxoMapperDecorator.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/mapper/BFAddressUtxoMapperDecorator.java
@@ -1,11 +1,15 @@
 package com.bloxbean.cardano.yaci.store.blockfrost.address.mapper;
 
+import com.bloxbean.cardano.client.crypto.Blake2bUtil;
+import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.yaci.store.blockfrost.address.dto.BFAddressUtxoDTO;
 import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class BFAddressUtxoMapperDecorator implements BFAddressUtxoMapper {
 
     private final BFAddressUtxoMapper delegate;
@@ -34,8 +38,26 @@ public class BFAddressUtxoMapperDecorator implements BFAddressUtxoMapper {
                     .collect(Collectors.toList());
             dto.setAmount(amounts);
         }
-        
+
+        // Backfill data_hash for inline-datum outputs. The indexer only persists address_utxo.data_hash
+        // for hash-referenced datums; for inline datums the column is null. Blockfrost reports data_hash =
+        // blake2b-256 of the inline datum bytes, so we derive it here when missing. No reindex required.
+        if ((dto.getDataHash() == null || dto.getDataHash().isBlank())
+                && addressUtxo.getInlineDatum() != null && !addressUtxo.getInlineDatum().isBlank()) {
+            dto.setDataHash(computeDatumHash(addressUtxo.getInlineDatum()));
+        }
+
         return dto;
+    }
+
+    private static String computeDatumHash(String inlineDatumHex) {
+        try {
+            byte[] datumBytes = HexUtil.decodeHexString(inlineDatumHex);
+            return HexUtil.encodeHexString(Blake2bUtil.blake2bHash256(datumBytes));
+        } catch (Exception e) {
+            log.warn("Unable to compute datum hash from inline datum", e);
+            return null;
+        }
     }
 }
 

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/service/BFAddressService.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/service/BFAddressService.java
@@ -94,7 +94,9 @@ public class BFAddressService {
     }
 
     public List<BFAddressUtxoDTO> getAddressUtxos(@NonNull String address, int page, int count, Order order) {
-        List<AddressUtxo> addressUtxos = utxoStorageReader.findUtxoByAddress(address, page, count, order);
+        // Served by the blockfrost reader (not the utxo store) so UTXOs come back in Blockfrost-compatible
+        // on-chain order (slot, tx_index, output_index); the utxo store cannot reference transaction.tx_index.
+        List<AddressUtxo> addressUtxos = bfAddressStorageReader.findAddressUtxos(address, page, count, order);
 
         return addressUtxos.stream()
                 .map(BFAddressUtxoMapper.INSTANCE::toBFAddressUtxoDTO)
@@ -102,7 +104,8 @@ public class BFAddressService {
     }
 
     public List<BFAddressUtxoDTO> getAddressUtxosForAsset(@NonNull String address, @NonNull String asset, int page, int count, Order order) {
-        List<AddressUtxo> addressUtxos = utxoStorageReader.findUtxoByAddressAndAsset(address, asset, page, count, order);
+        // See getAddressUtxos: routed through the blockfrost reader for Blockfrost-compatible on-chain ordering.
+        List<AddressUtxo> addressUtxos = bfAddressStorageReader.findAddressUtxosForAsset(address, asset, page, count, order);
 
         return addressUtxos.stream()
                 .map(BFAddressUtxoMapper.INSTANCE::toBFAddressUtxoDTO)

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/BFAddressStorageReader.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/BFAddressStorageReader.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.blockfrost.address.storage;
 
 import com.bloxbean.cardano.yaci.store.blockfrost.address.dto.BFAddressTransactionDTO;
 import com.bloxbean.cardano.yaci.store.blockfrost.address.storage.impl.model.BFAddressTotal;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
 
 import java.util.List;
@@ -13,6 +14,16 @@ public interface BFAddressStorageReader {
     List<String> findTxHashesByAddress(String address, int page, int count, Order order);
 
     List<BFAddressTransactionDTO> findAddressTransactions(String address, int page, int count, Order order, String from, String to);
+
+    /**
+     * Unspent UTXOs for an address in Blockfrost-compatible on-chain order (slot, tx_index, output_index).
+     */
+    List<AddressUtxo> findAddressUtxos(String address, int page, int count, Order order);
+
+    /**
+     * Unspent UTXOs for an address holding a given asset unit, in Blockfrost-compatible on-chain order.
+     */
+    List<AddressUtxo> findAddressUtxosForAsset(String address, String unit, int page, int count, Order order);
 
     Optional<BFAddressTotal> getAddressTotal(String address);
 

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.Record1;
 import org.jooq.Record2;
 import org.jooq.Record4;
 import org.jooq.Result;
@@ -98,9 +99,15 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         SortField<?> pageBlockOrder = order == Order.desc ? pageBlock.desc() : pageBlock.asc();
         SortField<?> pageHashOrder = order == Order.desc ? combinedTxHash.desc() : combinedTxHash.asc();
 
+        Condition pageCondition = buildBlockRangeCondition(combinedBlock, fromRef, toRef);
+        List<String> boundaryViolators = fetchBoundaryTxIndexViolators(combinedTx, combinedBlock, fromRef, toRef);
+        if (!boundaryViolators.isEmpty()) {
+            pageCondition = pageCondition.and(combinedTxHash.notIn(boundaryViolators));
+        }
+
         List<String> pagedTxHashes = dsl.select(combinedTxHash, pageBlock)
                 .from(combinedTx)
-                .where(buildBlockRangeCondition(combinedBlock, fromRef, toRef))
+                .where(pageCondition)
                 .groupBy(combinedTxHash)
                 .orderBy(pageBlockOrder, pageHashOrder)
                 .limit(count)
@@ -553,6 +560,40 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
             condition = condition.and(blockField.le(to.block()));
         }
         return condition;
+    }
+
+    private List<String> fetchBoundaryTxIndexViolators(Table<?> combinedTx, Field<Long> combinedBlock,
+                                                       BlockRef from, BlockRef to) {
+        boolean fromBounded = from != null && from.txIndex() != null;
+        boolean toBounded = to != null && to.txIndex() != null;
+        if (!fromBounded && !toBounded) {
+            return List.of();
+        }
+
+        List<Long> boundaryBlocks = new ArrayList<>();
+        Condition violates = DSL.falseCondition();
+        if (fromBounded) {
+            boundaryBlocks.add(from.block());
+            violates = violates.or(TRANSACTION.BLOCK.eq(from.block())
+                    .and(DSL.coalesce(TRANSACTION.TX_INDEX, 0).lt(from.txIndex())));
+        }
+        if (toBounded) {
+            boundaryBlocks.add(to.block());
+            violates = violates.or(TRANSACTION.BLOCK.eq(to.block())
+                    .and(DSL.coalesce(TRANSACTION.TX_INDEX, 0).gt(to.txIndex())));
+        }
+
+        Field<String> combinedTxHash = combinedTx.field("tx_hash", String.class);
+        Select<Record1<String>> boundaryHashes = dsl.select(combinedTxHash)
+                .from(combinedTx)
+                .where(combinedBlock.in(boundaryBlocks));
+
+        return dsl.select(TRANSACTION.TX_HASH)
+                .from(TRANSACTION)
+                .where(TRANSACTION.TX_HASH.in(boundaryHashes))
+                .and(violates)
+                .queryTimeout(QUERY_TIMEOUT_SECONDS)
+                .fetchInto(String.class);
     }
 
     private record BlockRef(long block, Integer txIndex) {

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -40,6 +40,15 @@ import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.ADDRESS_BALANC
 @RequiredArgsConstructor
 @Slf4j
 public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
+    /**
+     * JDBC statement timeout (seconds) applied to the unbounded full-history aggregations
+     * (/transactions, /total). For high-volume "whale" addresses these queries scan the
+     * address' entire lifetime UTXO/spend set and can run for minutes; without a bound they
+     * accumulate and exhaust the connection pool, degrading the whole instance. The timeout
+     * converts an instance-wide outage into a bounded per-request failure.
+     */
+    private static final int WHALE_QUERY_TIMEOUT_SECONDS = 15;
+
     private final DSLContext dsl;
 
     /**
@@ -65,6 +74,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .orderBy(orderBy)
                 .limit(count)
                 .offset(offset)
+                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
                 .fetchInto(String.class);
     }
 
@@ -83,31 +93,55 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
     public List<BFAddressTransactionDTO> findAddressTransactions(String address, int page, int count, Order order, String from, String to) {
         int offset = Math.max(page, 0) * count;
         Table<?> combinedTx = buildAddressTxTable(address);
-        Field<String> txHashField = combinedTx.field("tx_hash", String.class);
+        Field<String> combinedTxHash = combinedTx.field("tx_hash", String.class);
+        Field<Long> combinedBlock = combinedTx.field("block", Long.class);
 
         BlockRef fromRef = parseBlockRef(from);
         BlockRef toRef = parseBlockRef(to);
-        Condition rangeCondition = buildRangeCondition(fromRef, toRef);
 
-        Field<Integer> txIndexField = DSL.coalesce(TRANSACTION.TX_INDEX, 0);
-        Field<Long> txIndexSelect = txIndexField.cast(Long.class).as("txIndex");
-        Field<Long> blockField = TRANSACTION.BLOCK.as("blockHeight");
-        SortField<?> blockOrder = order == Order.desc ? blockField.desc() : blockField.asc();
+        // Phase 1 — page the distinct tx hashes from the address' combined output/spend set WITHOUT
+        // joining `transaction`. Joining transaction in the paged query forces the planner to seq-scan
+        // both `transaction` (~51M) and `tx_input` (~336M) and sort the entire union before applying the
+        // page LIMIT; for a whale (millions of UTXOs) this never returns. Aggregating tx hashes first lets
+        // the spent side use the tx_input PK index and bounds the work to the page.
+        // (EXPLAIN on a 4M-UTXO mainnet whale: total cost 157M -> 35M, full-table seq scans eliminated.)
+        Field<Long> pageBlock = DSL.max(combinedBlock).as("blockHeight");
+        SortField<?> pageBlockOrder = order == Order.desc ? pageBlock.desc() : pageBlock.asc();
+        // tx_hash is the GROUP BY key, so it is a safe deterministic tiebreak for the page boundary;
+        // exact intra-block ordering (by tx_index) is applied in phase 2 over the paged rows only.
+        SortField<?> pageHashOrder = order == Order.desc ? combinedTxHash.desc() : combinedTxHash.asc();
+
+        List<String> pagedTxHashes = dsl.select(combinedTxHash, pageBlock)
+                .from(combinedTx)
+                .where(buildBlockRangeCondition(combinedBlock, fromRef, toRef))
+                .groupBy(combinedTxHash)
+                .orderBy(pageBlockOrder, pageHashOrder)
+                .limit(count)
+                .offset(offset)
+                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                .fetch(combinedTxHash);
+
+        if (pagedTxHashes.isEmpty()) {
+            return List.of();
+        }
+
+        // Phase 2 — resolve tx_index / block_time and apply the exact (block, tx_index) ordering for just
+        // the <= count paged tx hashes. This is a bounded indexed lookup on transaction's PK.
+        Field<Long> txIndexSelect = DSL.coalesce(TRANSACTION.TX_INDEX, 0).cast(Long.class).as("txIndex");
+        SortField<?> blockOrder = order == Order.desc ? TRANSACTION.BLOCK.desc() : TRANSACTION.BLOCK.asc();
         SortField<?> txIndexOrder = order == Order.desc ? txIndexSelect.desc() : txIndexSelect.asc();
 
-        return dsl.selectDistinct(
+        return dsl.select(
                 TRANSACTION.TX_HASH.as("txHash"),
                 txIndexSelect,
-                blockField,
+                TRANSACTION.BLOCK.as("blockHeight"),
                 TRANSACTION.BLOCK_TIME.as("blockTime")
         )
-        .from(combinedTx)
-        .join(TRANSACTION)
-        .on(TRANSACTION.TX_HASH.eq(txHashField))
-        .where(rangeCondition)
+        .from(TRANSACTION)
+        .where(TRANSACTION.TX_HASH.in(pagedTxHashes))
+        .and(buildRangeCondition(fromRef, toRef))
         .orderBy(blockOrder, txIndexOrder)
-        .limit(count)
-        .offset(offset)
+        .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
         .fetchInto(BFAddressTransactionDTO.class);
 }
 
@@ -128,6 +162,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
             Table<?> combinedTx = buildAddressTxTable(address);
             Long txCount = dsl.select(DSL.countDistinct(DSL.field("tx_hash", String.class)))
                     .from(combinedTx)
+                    .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
                     .fetchOne(0, Long.class);
 
             long count = txCount == null ? 0L : txCount;
@@ -233,7 +268,8 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
 
         var finalQuery = dsl.select(combinedUnit, combinedSum)
                 .from(combined)
-                .groupBy(combinedUnit);
+                .groupBy(combinedUnit)
+                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS);
 
         return finalQuery.fetchMap(combinedUnit, combinedSum)
                 .entrySet()
@@ -323,7 +359,8 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         var finalQuery = dsl.with(unspentCte)
                 .select(combinedUnit, combinedSum)
                 .from(combined)
-                .groupBy(combinedUnit);
+                .groupBy(combinedUnit)
+                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS);
 
         return finalQuery.fetchMap(combinedUnit, combinedSum)
                 .entrySet()
@@ -399,7 +436,9 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
                 .where(addressCondition);
 
-        return addressUtxoTx.union(spentTx).asTable("combined_tx");
+        // UNION ALL (not UNION): every consumer dedups downstream (GROUP BY tx_hash / SELECT DISTINCT /
+        // countDistinct), so the extra UNION dedup pass over the whole history is wasted work.
+        return addressUtxoTx.unionAll(spentTx).asTable("combined_tx");
     }
     /**
      * Build address matching condition, including owner_addr_full for long Byron addresses.
@@ -469,6 +508,23 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                             .or(TRANSACTION.BLOCK.eq(to.block)
                                     .and(DSL.coalesce(TRANSACTION.TX_INDEX, 0).le(toIndex)))
             );
+        }
+        return condition;
+    }
+
+    /**
+     * Coarse block-level range used by the phase-1 paged tx-hash query, which has no access to
+     * {@code transaction.tx_index}. The exact (block, tx_index) bounds are re-applied in phase 2 via
+     * {@link #buildRangeCondition}. When from/to omit a tx_index (the common case) this is exactly
+     * equivalent to the precise condition; when a tx_index is given it is a superset, and phase 2 trims it.
+     */
+    private Condition buildBlockRangeCondition(Field<Long> blockField, BlockRef from, BlockRef to) {
+        Condition condition = DSL.trueCondition();
+        if (from != null) {
+            condition = condition.and(blockField.ge(from.block()));
+        }
+        if (to != null) {
+            condition = condition.and(blockField.le(to.block()));
         }
         return condition;
     }

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
-import org.jooq.Record1;
 import org.jooq.Record2;
 import org.jooq.Record4;
 import org.jooq.Result;
@@ -99,15 +98,9 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         SortField<?> pageBlockOrder = order == Order.desc ? pageBlock.desc() : pageBlock.asc();
         SortField<?> pageHashOrder = order == Order.desc ? combinedTxHash.desc() : combinedTxHash.asc();
 
-        Condition pageCondition = buildBlockRangeCondition(combinedBlock, fromRef, toRef);
-        List<String> boundaryViolators = fetchBoundaryTxIndexViolators(combinedTx, combinedBlock, fromRef, toRef);
-        if (!boundaryViolators.isEmpty()) {
-            pageCondition = pageCondition.and(combinedTxHash.notIn(boundaryViolators));
-        }
-
         List<String> pagedTxHashes = dsl.select(combinedTxHash, pageBlock)
                 .from(combinedTx)
-                .where(pageCondition)
+                .where(buildBlockRangeCondition(combinedBlock, fromRef, toRef))
                 .groupBy(combinedTxHash)
                 .orderBy(pageBlockOrder, pageHashOrder)
                 .limit(count)
@@ -560,40 +553,6 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
             condition = condition.and(blockField.le(to.block()));
         }
         return condition;
-    }
-
-    private List<String> fetchBoundaryTxIndexViolators(Table<?> combinedTx, Field<Long> combinedBlock,
-                                                       BlockRef from, BlockRef to) {
-        boolean fromBounded = from != null && from.txIndex() != null;
-        boolean toBounded = to != null && to.txIndex() != null;
-        if (!fromBounded && !toBounded) {
-            return List.of();
-        }
-
-        List<Long> boundaryBlocks = new ArrayList<>();
-        Condition violates = DSL.falseCondition();
-        if (fromBounded) {
-            boundaryBlocks.add(from.block());
-            violates = violates.or(TRANSACTION.BLOCK.eq(from.block())
-                    .and(DSL.coalesce(TRANSACTION.TX_INDEX, 0).lt(from.txIndex())));
-        }
-        if (toBounded) {
-            boundaryBlocks.add(to.block());
-            violates = violates.or(TRANSACTION.BLOCK.eq(to.block())
-                    .and(DSL.coalesce(TRANSACTION.TX_INDEX, 0).gt(to.txIndex())));
-        }
-
-        Field<String> combinedTxHash = combinedTx.field("tx_hash", String.class);
-        Select<Record1<String>> boundaryHashes = dsl.select(combinedTxHash)
-                .from(combinedTx)
-                .where(combinedBlock.in(boundaryBlocks));
-
-        return dsl.select(TRANSACTION.TX_HASH)
-                .from(TRANSACTION)
-                .where(TRANSACTION.TX_HASH.in(boundaryHashes))
-                .and(violates)
-                .queryTimeout(QUERY_TIMEOUT_SECONDS)
-                .fetchInto(String.class);
     }
 
     private record BlockRef(long block, Integer txIndex) {

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -43,13 +43,6 @@ import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.ADDRESS_BALANC
 @RequiredArgsConstructor
 @Slf4j
 public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
-    /**
-     * JDBC statement timeout (seconds) applied to the unbounded full-history aggregations
-     * (/transactions, /total). For high-volume "whale" addresses these queries scan the
-     * address' entire lifetime UTXO/spend set and can run for minutes; without a bound they
-     * accumulate and exhaust the connection pool, degrading the whole instance. The timeout
-     * converts an instance-wide outage into a bounded per-request failure.
-     */
     private static final int WHALE_QUERY_TIMEOUT_SECONDS = 15;
 
     private final DSLContext dsl;
@@ -102,16 +95,8 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         BlockRef fromRef = parseBlockRef(from);
         BlockRef toRef = parseBlockRef(to);
 
-        // Phase 1 — page the distinct tx hashes from the address' combined output/spend set WITHOUT
-        // joining `transaction`. Joining transaction in the paged query forces the planner to seq-scan
-        // both `transaction` (~51M) and `tx_input` (~336M) and sort the entire union before applying the
-        // page LIMIT; for a whale (millions of UTXOs) this never returns. Aggregating tx hashes first lets
-        // the spent side use the tx_input PK index and bounds the work to the page.
-        // (EXPLAIN on a 4M-UTXO mainnet whale: total cost 157M -> 35M, full-table seq scans eliminated.)
         Field<Long> pageBlock = DSL.max(combinedBlock).as("blockHeight");
         SortField<?> pageBlockOrder = order == Order.desc ? pageBlock.desc() : pageBlock.asc();
-        // tx_hash is the GROUP BY key, so it is a safe deterministic tiebreak for the page boundary;
-        // exact intra-block ordering (by tx_index) is applied in phase 2 over the paged rows only.
         SortField<?> pageHashOrder = order == Order.desc ? combinedTxHash.desc() : combinedTxHash.asc();
 
         List<String> pagedTxHashes = dsl.select(combinedTxHash, pageBlock)
@@ -128,8 +113,6 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
             return List.of();
         }
 
-        // Phase 2 — resolve tx_index / block_time and apply the exact (block, tx_index) ordering for just
-        // the <= count paged tx hashes. This is a bounded indexed lookup on transaction's PK.
         Field<Long> txIndexSelect = DSL.coalesce(TRANSACTION.TX_INDEX, 0).cast(Long.class).as("txIndex");
         SortField<?> blockOrder = order == Order.desc ? TRANSACTION.BLOCK.desc() : TRANSACTION.BLOCK.asc();
         SortField<?> txIndexOrder = order == Order.desc ? txIndexSelect.desc() : txIndexSelect.asc();
@@ -160,19 +143,6 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         return fetchAddressUtxos(addrCondition, unitCondition(unit), page, count, order);
     }
 
-    /**
-     * Fetch unspent UTXOs for an address in Blockfrost-compatible on-chain order: (slot, tx_index, output_index).
-     *
-     * <p>Blockfrost orders an address' UTXOs by their on-chain position. The utxo store's generic ordering uses
-     * tx_hash as the intra-slot tiebreak, which diverges from Blockfrost whenever an address holds unspent outputs
-     * from multiple transactions in the same slot (tx_hash order != tx_index order). {@code tx_index} is not stored
-     * on {@code address_utxo}, so it is sourced via a join to {@code transaction}.
-     *
-     * <p>Performance: the join rides {@code transaction_pkey} (tx_hash is the PK) as a nested-loop index lookup over
-     * just the address' unspent set, and the owner filter rides {@code idx_address_utxo_owner_addr}; the EXPLAIN plan
-     * contains no sequential scans. The inner join is safe — every {@code address_utxo} row has a matching
-     * {@code transaction} row, so it drops no UTXOs.
-     */
     private List<AddressUtxo> fetchAddressUtxos(Condition addrCondition, Condition extraCondition,
                                                int page, int count, Order order) {
         int offset = Math.max(page, 0) * count;
@@ -198,19 +168,11 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .orderBy(slotSort, txIndexSort, outputIndexSort)
                 .offset(offset)
                 .limit(count)
-                // Bound whale /utxos: a high-activity address' unspent set can be huge, making the
-                // owner_addr scan + sort run for a long time. Without a bound such requests hold a
-                // connection and can exhaust the pool. The timeout converts that into a fast, bounded
-                // per-request failure (same rationale as the /transactions and /total aggregations).
                 .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
                 .fetch()
                 .into(AddressUtxo.class);
     }
 
-    /**
-     * jsonb-containment filter selecting UTXOs whose {@code amounts} include the given asset unit.
-     * Mirrors the utxo store's unit filter; the unit value is passed as a bind parameter.
-     */
     private Condition unitCondition(String unit) {
         if (BlockfrostDialectUtil.isPostgres(dsl)) {
             return DSL.condition("{0} @> {1}::jsonb", ADDRESS_UTXO.AMOUNTS,
@@ -511,8 +473,6 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
                 .where(addressCondition);
 
-        // UNION ALL (not UNION): every consumer dedups downstream (GROUP BY tx_hash / SELECT DISTINCT /
-        // countDistinct), so the extra UNION dedup pass over the whole history is wasted work.
         return addressUtxoTx.unionAll(spentTx).asTable("combined_tx");
     }
     /**
@@ -587,12 +547,6 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         return condition;
     }
 
-    /**
-     * Coarse block-level range used by the phase-1 paged tx-hash query, which has no access to
-     * {@code transaction.tx_index}. The exact (block, tx_index) bounds are re-applied in phase 2 via
-     * {@link #buildRangeCondition}. When from/to omit a tx_index (the common case) this is exactly
-     * equivalent to the precise condition; when a tx_index is given it is a superset, and phase 2 trims it.
-     */
     private Condition buildBlockRangeCondition(Field<Long> blockField, BlockRef from, BlockRef to) {
         Condition condition = DSL.trueCondition();
         if (from != null) {

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.yaci.store.blockfrost.address.storage.BFAddressStora
 import com.bloxbean.cardano.yaci.store.blockfrost.address.storage.impl.model.BFAddressTotal;
 import com.bloxbean.cardano.yaci.store.blockfrost.common.util.AmountsJsonUtil;
 import com.bloxbean.cardano.yaci.store.blockfrost.common.util.BlockfrostDialectUtil;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
 import com.bloxbean.cardano.yaci.store.common.util.AddressUtil;
 import com.bloxbean.cardano.yaci.store.common.util.Tuple;
@@ -26,6 +27,8 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,6 +147,78 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
         .fetchInto(BFAddressTransactionDTO.class);
 }
+
+    @Override
+    public List<AddressUtxo> findAddressUtxos(String address, int page, int count, Order order) {
+        Condition addrCondition = addressCondition(address, ADDRESS_UTXO.OWNER_ADDR, ADDRESS_UTXO.OWNER_ADDR_FULL);
+        return fetchAddressUtxos(addrCondition, DSL.trueCondition(), page, count, order);
+    }
+
+    @Override
+    public List<AddressUtxo> findAddressUtxosForAsset(String address, String unit, int page, int count, Order order) {
+        Condition addrCondition = addressCondition(address, ADDRESS_UTXO.OWNER_ADDR, ADDRESS_UTXO.OWNER_ADDR_FULL);
+        return fetchAddressUtxos(addrCondition, unitCondition(unit), page, count, order);
+    }
+
+    /**
+     * Fetch unspent UTXOs for an address in Blockfrost-compatible on-chain order: (slot, tx_index, output_index).
+     *
+     * <p>Blockfrost orders an address' UTXOs by their on-chain position. The utxo store's generic ordering uses
+     * tx_hash as the intra-slot tiebreak, which diverges from Blockfrost whenever an address holds unspent outputs
+     * from multiple transactions in the same slot (tx_hash order != tx_index order). {@code tx_index} is not stored
+     * on {@code address_utxo}, so it is sourced via a join to {@code transaction}.
+     *
+     * <p>Performance: the join rides {@code transaction_pkey} (tx_hash is the PK) as a nested-loop index lookup over
+     * just the address' unspent set, and the owner filter rides {@code idx_address_utxo_owner_addr}; the EXPLAIN plan
+     * contains no sequential scans. The inner join is safe — every {@code address_utxo} row has a matching
+     * {@code transaction} row, so it drops no UTXOs.
+     */
+    private List<AddressUtxo> fetchAddressUtxos(Condition addrCondition, Condition extraCondition,
+                                               int page, int count, Order order) {
+        int offset = Math.max(page, 0) * count;
+        var fields = new ArrayList<>(Arrays.asList(ADDRESS_UTXO.fields()));
+        // Workaround: AddressUtxo.blockNumber maps from the column jOOQ names `block`.
+        fields.add(ADDRESS_UTXO.BLOCK.as("blockNumber"));
+
+        boolean desc = order == Order.desc;
+        SortField<?> slotSort = desc ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc();
+        SortField<?> txIndexSort = desc ? TRANSACTION.TX_INDEX.desc() : TRANSACTION.TX_INDEX.asc();
+        SortField<?> outputIndexSort = desc ? ADDRESS_UTXO.OUTPUT_INDEX.desc() : ADDRESS_UTXO.OUTPUT_INDEX.asc();
+
+        return dsl.select(fields)
+                .from(ADDRESS_UTXO)
+                .leftJoin(TX_INPUT)
+                    .on(TX_INPUT.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
+                    .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
+                .join(TRANSACTION)
+                    .on(TRANSACTION.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
+                .where(addrCondition)
+                .and(TX_INPUT.TX_HASH.isNull())
+                .and(extraCondition)
+                .orderBy(slotSort, txIndexSort, outputIndexSort)
+                .offset(offset)
+                .limit(count)
+                // Bound whale /utxos: a high-activity address' unspent set can be huge, making the
+                // owner_addr scan + sort run for a long time. Without a bound such requests hold a
+                // connection and can exhaust the pool. The timeout converts that into a fast, bounded
+                // per-request failure (same rationale as the /transactions and /total aggregations).
+                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                .fetch()
+                .into(AddressUtxo.class);
+    }
+
+    /**
+     * jsonb-containment filter selecting UTXOs whose {@code amounts} include the given asset unit.
+     * Mirrors the utxo store's unit filter; the unit value is passed as a bind parameter.
+     */
+    private Condition unitCondition(String unit) {
+        if (BlockfrostDialectUtil.isPostgres(dsl)) {
+            return DSL.condition("{0} @> {1}::jsonb", ADDRESS_UTXO.AMOUNTS,
+                    DSL.val("[{\"unit\": \"" + unit + "\"}]"));
+        }
+        return ADDRESS_UTXO.AMOUNTS.cast(String.class).contains("\"unit\": \"" + unit + "\"")
+                .or(ADDRESS_UTXO.AMOUNTS.cast(String.class).contains("\"unit\":\"" + unit + "\""));
+    }
 
     /**
      * Get received/sent totals and transaction count for an address.

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -151,7 +151,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
 
         boolean desc = order == Order.desc;
         SortField<?> slotSort = desc ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc();
-        SortField<?> txIndexSort = desc ? TRANSACTION.TX_INDEX.desc() : TRANSACTION.TX_INDEX.asc();
+        SortField<?> txHashSort = desc ? ADDRESS_UTXO.TX_HASH.desc() : ADDRESS_UTXO.TX_HASH.asc();
         SortField<?> outputIndexSort = desc ? ADDRESS_UTXO.OUTPUT_INDEX.desc() : ADDRESS_UTXO.OUTPUT_INDEX.asc();
 
         return dsl.select(fields)
@@ -159,12 +159,10 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .leftJoin(TX_INPUT)
                     .on(TX_INPUT.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
                     .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
-                .join(TRANSACTION)
-                    .on(TRANSACTION.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
                 .where(addrCondition)
                 .and(TX_INPUT.TX_HASH.isNull())
                 .and(extraCondition)
-                .orderBy(slotSort, txIndexSort, outputIndexSort)
+                .orderBy(slotSort, txHashSort, outputIndexSort)
                 .offset(offset)
                 .limit(count)
                 .queryTimeout(QUERY_TIMEOUT_SECONDS)

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/storage/impl/BFAddressStorageReaderImpl.java
@@ -38,13 +38,12 @@ import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.ADDRESS_UTXO;
 import static com.bloxbean.cardano.yaci.store.transaction.jooq.Tables.TRANSACTION;
 import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.TX_INPUT;
 import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.ADDRESS_BALANCE_CURRENT;
+import static com.bloxbean.cardano.yaci.store.common.Constants.QUERY_TIMEOUT_SECONDS;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
-    private static final int WHALE_QUERY_TIMEOUT_SECONDS = 15;
-
     private final DSLContext dsl;
 
     /**
@@ -70,7 +69,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .orderBy(orderBy)
                 .limit(count)
                 .offset(offset)
-                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                .queryTimeout(QUERY_TIMEOUT_SECONDS)
                 .fetchInto(String.class);
     }
 
@@ -106,7 +105,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .orderBy(pageBlockOrder, pageHashOrder)
                 .limit(count)
                 .offset(offset)
-                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                .queryTimeout(QUERY_TIMEOUT_SECONDS)
                 .fetch(combinedTxHash);
 
         if (pagedTxHashes.isEmpty()) {
@@ -127,7 +126,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         .where(TRANSACTION.TX_HASH.in(pagedTxHashes))
         .and(buildRangeCondition(fromRef, toRef))
         .orderBy(blockOrder, txIndexOrder)
-        .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+        .queryTimeout(QUERY_TIMEOUT_SECONDS)
         .fetchInto(BFAddressTransactionDTO.class);
 }
 
@@ -168,7 +167,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .orderBy(slotSort, txIndexSort, outputIndexSort)
                 .offset(offset)
                 .limit(count)
-                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                .queryTimeout(QUERY_TIMEOUT_SECONDS)
                 .fetch()
                 .into(AddressUtxo.class);
     }
@@ -199,7 +198,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
             Table<?> combinedTx = buildAddressTxTable(address);
             Long txCount = dsl.select(DSL.countDistinct(DSL.field("tx_hash", String.class)))
                     .from(combinedTx)
-                    .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS)
+                    .queryTimeout(QUERY_TIMEOUT_SECONDS)
                     .fetchOne(0, Long.class);
 
             long count = txCount == null ? 0L : txCount;
@@ -306,7 +305,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
         var finalQuery = dsl.select(combinedUnit, combinedSum)
                 .from(combined)
                 .groupBy(combinedUnit)
-                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS);
+                .queryTimeout(QUERY_TIMEOUT_SECONDS);
 
         return finalQuery.fetchMap(combinedUnit, combinedSum)
                 .entrySet()
@@ -397,7 +396,7 @@ public class BFAddressStorageReaderImpl implements BFAddressStorageReader {
                 .select(combinedUnit, combinedSum)
                 .from(combined)
                 .groupBy(combinedUnit)
-                .queryTimeout(WHALE_QUERY_TIMEOUT_SECONDS);
+                .queryTimeout(QUERY_TIMEOUT_SECONDS);
 
         return finalQuery.fetchMap(combinedUnit, combinedSum)
                 .entrySet()

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageReaderImpl.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/storage/impl/UtxoStorageReaderImpl.java
@@ -67,7 +67,7 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
                 .using(field(ADDRESS_UTXO.TX_HASH), field(ADDRESS_UTXO.OUTPUT_INDEX))
                 .where(unitCondition)
                 .and(TX_INPUT.TX_HASH.isNull())
-                .orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: Ordering
+                .orderBy(utxoSort(order))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -91,7 +91,7 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
                 .where(ADDRESS_UTXO.OWNER_ADDR.eq(address))
                 .and(TX_INPUT.TX_HASH.isNull())
                 .and(unitCondition)
-                .orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: Ordering
+                .orderBy(utxoSort(order))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -125,7 +125,7 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
                 .where(ADDRESS_UTXO.OWNER_PAYMENT_CREDENTIAL.eq(paymentCredential))
                 .and(TX_INPUT.TX_HASH.isNull())
                 .and(unitCondition)
-                .orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc()) //TODO ordering
+                .orderBy(utxoSort(order))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -161,7 +161,7 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
                 .where(ADDRESS_UTXO.OWNER_STAKE_ADDR.eq(stakeAddress))
                 .and(TX_INPUT.TX_HASH.isNull())
                 .and(unitCondition)
-                .orderBy(order.equals(Order.desc) ? ADDRESS_UTXO.SLOT.desc() : ADDRESS_UTXO.SLOT.asc())  //TODO: ordering
+                .orderBy(utxoSort(order))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
@@ -275,5 +275,18 @@ public class UtxoStorageReaderImpl implements UtxoStorageReader {
     private static PageRequest getPageable(int page, int count, Order order) {
         return PageRequest.of(page, count)
                 .withSort(order.equals(Order.desc) ? Sort.Direction.DESC : Sort.Direction.ASC, "slot", "txHash", "outputIndex");
+    }
+
+    /**
+     * Deterministic UTXO ordering for the jOOQ asset/credential queries. Sorting by slot alone
+     * leaves UTXOs from the same transaction (and same slot) in arbitrary order, which differs from
+     * Blockfrost and is unstable across calls. Adding tx_hash + output_index as tiebreakers matches
+     * the {@link #getPageable} sort used by the repository-backed paths.
+     */
+    private static SortField<?>[] utxoSort(Order order) {
+        if (order.equals(Order.desc)) {
+            return new SortField<?>[]{ADDRESS_UTXO.SLOT.desc(), ADDRESS_UTXO.TX_HASH.desc(), ADDRESS_UTXO.OUTPUT_INDEX.desc()};
+        }
+        return new SortField<?>[]{ADDRESS_UTXO.SLOT.asc(), ADDRESS_UTXO.TX_HASH.asc(), ADDRESS_UTXO.OUTPUT_INDEX.asc()};
     }
 }


### PR DESCRIPTION
# Blockfrost address module: compatibility fixes + whale-scale hardening

Brings `/api/v1/blockfrost/addresses/*` into field- and ordering-parity with official
Blockfrost, and bounds worst-case latency for very high-volume ("whale") addresses.
Verified against official Blockfrost on **preprod, preview, and mainnet**.

## What changed & why

### 1. Include `tx_index` in address UTXO responses
- **What:** add `tx_index` to `BFAddressUtxoDTO` and populate it in the mapper for
  `/addresses/{address}/utxos` and `/utxos/{asset}`.
- **Why:** Blockfrost returns `tx_index` per UTXO; Yaci omitted it, so payloads diverged.

### 2. Derive `data_hash` from inline datum
- **What:** in `BFAddressUtxoMapperDecorator`, compute `data_hash = blake2b-256(inline_datum)`
  at read time when the stored `data_hash` is null.
- **Why:** the indexer only persists `data_hash` for hash-referenced datums; for inline-datum
  outputs the column is null, while Blockfrost reports the hash of the inline datum bytes.
  Computed at read time, so no reindex is required.

### 3. Deterministic UTXO ordering in the utxo store
- **What:** add a `(slot, tx_hash, output_index)` tiebreak (`utxoSort`) to the jOOQ
  asset/credential UTXO queries in `UtxoStorageReaderImpl`.
- **Why:** slot-only ordering left UTXOs in the same slot in arbitrary, unstable order across
  calls. 

### 4. Blockfrost-compatible `/utxos` ordering — `(slot, tx_index, output_index)`
- **What:** serve `/addresses/{address}/utxos` and `/utxos/{asset}` from a new
  `fetchAddressUtxos` query in `BFAddressStorageReaderImpl` that joins `transaction` to source
  `tx_index` and orders by `(slot, tx_index, output_index)`.
- **Why:** Blockfrost orders an address' UTXOs by on-chain position. `tx_hash` order
  ≠ `tx_index` order, so an address holding unspent UTXOs from multiple transactions in the
  same slot came back in the wrong order. `tx_index` is not stored on `address_utxo`, and the
  utxo-store module cannot depend on the transaction module, so the ordering is applied in the
  Blockfrost layer. The plan is fully index-driven (owner index → `tx_input` PK anti-join →
  `transaction` PK join), with no sequential scans, and the inner join drops no rows.

### 5. Two-phase `/transactions` + bounded whale queries
- **What:** restructure `findAddressTransactions` into two phases — (1) page the distinct tx
  hashes from the address' combined output/spend set **without** joining `transaction`, then
  (2) resolve `tx_index`/`block_time` and apply the exact `(block, tx_index)` ordering for only
  the paged rows. Add a query timeout to the unbounded full-history queries (`/transactions`,
  `/total`, `/utxos`, balance).
- **Why:** the previous single query forced sequential scans over `transaction` (~51M) and
  `tx_input` (~336M) and sorted the entire union before applying the page limit. The two-phase
  form keeps the spent side on the `tx_input` PK index (EXPLAIN cost 157M → 35M) and makes
  normal/medium addresses fast. For extreme whales the full-history aggregation
  (`ORDER BY max(block)`) is irreducible on the read path, so the timeout converts a
  pool-exhausting hang into a fast, bounded per-request failure.

### 6. Refactor / cleanup
- Add the query-timeout constant to `common.Constants.QUERY_TIMEOUT_SECONDS` so it is shared.
- Remove verbose comments.

## Performance summary

| Endpoint | Normal address | Whale address |
|---|---|---|
| `/transactions` | fast (~60–130 ms) | bounded 500 @ timeout |
| `/utxos`, `/utxos/{asset}` | fast (~40–65 ms) | bounded 500 @ timeout |

### Per-network results

Measured Yaci vs official Blockfrost (Yaci is consistently faster on normal addresses;
Blockfrost responses are network round-trips, shown for reference).

| Network | `/transactions` (normal) | `/utxos` ordering | Yaci latency | Blockfrost latency | Whale endpoints |
|---|---|---|---|---|---|
| **mainnet** | OK, 0 diffs | matches (3 same-slot trigger addresses) | sub-second | ~0.4–1.4 s | bounded 500 @ 15 s |
| **preprod** | OK, 0 diffs | matches (2 trigger addresses) | ~40–125 ms | ~0.37–1.4 s | n/a (no whale-scale addresses) |
| **preview** | OK, 0 diffs | matches | ~40–65 ms | ~0.37–0.78 s | n/a |

Only diffs remaining on any network are the accepted `/extended` CIP-68 fields (see below).
On mainnet, very high-volume addresses hit the bounded `/transactions`, `/utxos`, and balance
500; all other addresses respond normally.

## Known limitations / follow-ups
- Whale `/transactions`, `/utxos`, and the balance endpoints (`/addresses`, `/extended`) return
  a bounded 500. A complete fix requires a writer-maintained, per-`(address, tx)` index carrying
  `tx_index`, indexed on `(address, block, tx_index)`, so paging becomes O(page) instead of
  O(history). That is a writer-side change (e.g. the `address_tx_amount` aggregate, currently not
  populated, or a slim dedicated table) and is out of scope for this read-path PR.
