### PR TITLE
 Align devnet genesis AdaPot bookkeeping with Haskell ledger

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessor.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessor.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.yaci.core.model.CredentialType;
 import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.store.adapot.domain.EpochStake;
 import com.bloxbean.cardano.yaci.store.adapot.service.AdaPotService;
@@ -18,6 +19,8 @@ import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
 import com.bloxbean.cardano.yaci.store.staking.domain.Pool;
 import com.bloxbean.cardano.yaci.store.staking.domain.PoolRegistration;
 import com.bloxbean.cardano.yaci.store.staking.domain.PoolStatusType;
+import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
 import com.bloxbean.cardano.yaci.store.staking.storage.PoolCertificateStorage;
 import com.bloxbean.cardano.yaci.store.staking.storage.PoolStorage;
 import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorage;
@@ -31,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.bloxbean.cardano.yaci.store.adapot.AdaPotConfiguration.STORE_ADAPOT_ENABLED;
@@ -47,6 +51,10 @@ import static com.bloxbean.cardano.yaci.store.common.util.UnitIntervalUtil.safeR
 @EnableIf(value = STORE_ADAPOT_ENABLED, defaultValue = false)
 @Slf4j
 public class GenesisPoolProcessor {
+    // Synthetic rows created from shelley-genesis use this tx hash. Deposit snapshots
+    // exclude it because genesis deposits are seeded into the epoch-0 AdaPot directly.
+    private static final String GENESIS_TX_HASH = "Genesis";
+
     private final StoreProperties storeProperties;
     private final PoolStorage poolStorage;
     private final PoolCertificateStorage poolCertificateStorage;
@@ -54,6 +62,7 @@ public class GenesisPoolProcessor {
     private final GenesisConfig genesisConfig;
     private final AdaPotService adaPotService;
     private final DSLContext dslContext;
+    private final DepositParamService depositParamService;
 
     @EventListener
     @Transactional
@@ -70,94 +79,130 @@ public class GenesisPoolProcessor {
         if (poolParamsList == null)
             return;
 
-        String genesisTxHash = "Genesis";
+        String genesisTxHash = GENESIS_TX_HASH;
 
         //Handle Pool registration
-        var poolRegistrations = poolParamsList.stream()
-                .map(poolParams -> {
-                    Address rewardAddress = new Address(HexUtil.decodeHexString(poolParams.getRewardAccount()));
-                    String rewardAddressBech32 = rewardAddress.toBech32();
+        List<PoolRegistration> poolRegistrations = new ArrayList<>();
+        for (int i = 0; i < poolParamsList.size(); i++) {
+            var poolParams = poolParamsList.get(i);
+            Address rewardAddress = new Address(HexUtil.decodeHexString(poolParams.getRewardAccount()));
+            String rewardAddressBech32 = rewardAddress.toBech32();
 
-                    BigDecimal marginDecimal = safeRatio(poolParams.getMargin());
+            BigDecimal marginDecimal = safeRatio(poolParams.getMargin());
 
-                    PoolRegistration poolRegistration = PoolRegistration.builder()
-                            .txHash(genesisTxHash)
-                            .certIndex(0)
-                            .txIndex(0)
-                            .poolId(poolParams.getOperator())
-                            .vrfKeyHash(poolParams.getVrfKeyHash())
-                            .pledge(poolParams.getPledge())
-                            .cost(poolParams.getCost())
-                            .margin(marginDecimal != null? marginDecimal.doubleValue(): 0.0)
-                            .marginNumerator(poolParams.getMargin().getNumerator())
-                            .marginDenominator(poolParams.getMargin().getDenominator())
-                            .rewardAccount(rewardAddressBech32)
-                            .poolOwners(poolParams.getPoolOwners())
-                            .relays(poolParams.getRelays())
-                            .metadataUrl(poolParams.getPoolMetadataUrl())
-                            .metadataHash(poolParams.getPoolMetadataHash())
-                            .epoch(genesisBlockEvent.getEpoch())
-                            .slot(genesisBlockEvent.getSlot())
-                            .blockNumber(genesisBlockEvent.getBlock())
-                            .blockHash(genesisBlockEvent.getBlockHash())
-                            .blockTime(genesisBlockEvent.getBlockTime())
-                            .build();
-                    return poolRegistration;
-                }).toList();
+            PoolRegistration poolRegistration = PoolRegistration.builder()
+                    .txHash(genesisTxHash)
+                    .certIndex(i)
+                    .txIndex(0)
+                    .poolId(poolParams.getOperator())
+                    .vrfKeyHash(poolParams.getVrfKeyHash())
+                    .pledge(poolParams.getPledge())
+                    .cost(poolParams.getCost())
+                    .margin(marginDecimal != null? marginDecimal.doubleValue(): 0.0)
+                    .marginNumerator(poolParams.getMargin().getNumerator())
+                    .marginDenominator(poolParams.getMargin().getDenominator())
+                    .rewardAccount(rewardAddressBech32)
+                    .poolOwners(poolParams.getPoolOwners())
+                    .relays(poolParams.getRelays())
+                    .metadataUrl(poolParams.getPoolMetadataUrl())
+                    .metadataHash(poolParams.getPoolMetadataHash())
+                    .epoch(genesisBlockEvent.getEpoch())
+                    .slot(genesisBlockEvent.getSlot())
+                    .blockNumber(genesisBlockEvent.getBlock())
+                    .blockHash(genesisBlockEvent.getBlockHash())
+                    .blockTime(genesisBlockEvent.getBlockTime())
+                    .build();
+            poolRegistrations.add(poolRegistration);
+        }
 
         if (poolRegistrations != null && !poolRegistrations.isEmpty())
             poolCertificateStorage.savePoolRegistrations(poolRegistrations);
 
-        //Pools table
-        List<Pool> pools = poolParamsList.stream()
-                .map(poolParams -> {
-                    Pool pool = Pool.builder()
-                            .poolId(poolParams.getOperator())
-                            .txHash(genesisTxHash)
-                            .certIndex(0)
-                            .txIndex(0)
-                            .status(PoolStatusType.REGISTRATION)
-                            .amount(BigInteger.ZERO)
-                            .epoch(genesisBlockEvent.getEpoch())
-                            .activeEpoch(0)
-                            .registrationSlot(genesisBlockEvent.getSlot()) //This is the registration slot
-                            .slot(genesisBlockEvent.getSlot())
-                            .blockNumber(genesisBlockEvent.getBlock())
-                            .blockHash(genesisBlockEvent.getBlockHash())
-                            .blockTime(genesisBlockEvent.getBlockTime())
-                            .build();
-                    return pool;
-                }).toList();
+        // Pools table
+        // Devnet genesis pools are not created by on-chain pool registration certificates,
+        // but the ledger still tracks their pool deposits. Store the deposit here so later
+        // pool retirement and reward paths see the same deposit amount as the Haskell ledger.
+        BigInteger poolDeposit = poolParamsList.isEmpty()
+                ? BigInteger.ZERO
+                : depositParamService.getPoolDeposit(genesisBlockEvent.getEpoch());
+        List<Pool> pools = new ArrayList<>();
+        for (int i = 0; i < poolParamsList.size(); i++) {
+            var poolParams = poolParamsList.get(i);
+            Pool pool = Pool.builder()
+                    .poolId(poolParams.getOperator())
+                    .txHash(genesisTxHash)
+                    .certIndex(i)
+                    .txIndex(0)
+                    .status(PoolStatusType.REGISTRATION)
+                    .amount(poolDeposit)
+                    .epoch(genesisBlockEvent.getEpoch())
+                    .activeEpoch(0)
+                    .registrationSlot(genesisBlockEvent.getSlot()) //This is the registration slot
+                    .slot(genesisBlockEvent.getSlot())
+                    .blockNumber(genesisBlockEvent.getBlock())
+                    .blockHash(genesisBlockEvent.getBlockHash())
+                    .blockTime(genesisBlockEvent.getBlockTime())
+                    .build();
+            pools.add(pool);
+        }
 
         if (pools != null && !pools.isEmpty())
             poolStorage.save(pools);
 
-        //Update delegations
+        // Update delegations
         List<GenesisStaking.Stake> stakes = genesisStaking.getStakes();
-        List<Delegation> delegations = stakes.stream()
-                .map(stake -> {
-                    Address address = AddressProvider.getRewardAddress(Credential.fromKey(stake.getStakeKeyHash()),
-                            storeProperties.isMainnet() ? Networks.mainnet() : Networks.testnet());
-                    Delegation delegation = Delegation.builder()
-                            .credential(stake.getStakeKeyHash())
-                            .credentialType(CredentialType.ADDR_KEYHASH)
-                            .address(address.toBech32())
-                            .slot(genesisBlockEvent.getSlot())
-                            .txHash(genesisTxHash)
-                            .certIndex(0)
-                            .txIndex(0)
-                            .poolId(stake.getPoolHash())
-                            .epoch(genesisBlockEvent.getEpoch())
-                            .slot(genesisBlockEvent.getSlot())
-                            .blockNumber(genesisBlockEvent.getBlock())
-                            .blockHash(genesisBlockEvent.getBlockHash())
-                            .blockTime(genesisBlockEvent.getBlockTime())
-                            .build();
-                    return delegation;
-                }).toList();
+        if (stakes == null)
+            stakes = List.of();
+
+        // Genesis delegates need synthetic stake registration rows as well as delegation rows.
+        // Reward filtering checks the registration table, so without these rows devnet genesis
+        // stake would look delegated but unregistered.
+        List<Delegation> delegations = new ArrayList<>();
+        List<StakeRegistrationDetail> stakeRegistrations = new ArrayList<>();
+        for (int i = 0; i < stakes.size(); i++) {
+            var stake = stakes.get(i);
+            Address address = AddressProvider.getRewardAddress(Credential.fromKey(stake.getStakeKeyHash()),
+                    storeProperties.isMainnet() ? Networks.mainnet() : Networks.testnet());
+            Delegation delegation = Delegation.builder()
+                    .credential(stake.getStakeKeyHash())
+                    .credentialType(CredentialType.ADDR_KEYHASH)
+                    .address(address.toBech32())
+                    .slot(genesisBlockEvent.getSlot())
+                    .txHash(genesisTxHash)
+                    .certIndex(i)
+                    .txIndex(0)
+                    .poolId(stake.getPoolHash())
+                    .epoch(genesisBlockEvent.getEpoch())
+                    .slot(genesisBlockEvent.getSlot())
+                    .blockNumber(genesisBlockEvent.getBlock())
+                    .blockHash(genesisBlockEvent.getBlockHash())
+                    .blockTime(genesisBlockEvent.getBlockTime())
+                    .build();
+            delegations.add(delegation);
+
+            StakeRegistrationDetail stakeRegistrationDetail = StakeRegistrationDetail.builder()
+                    .credential(stake.getStakeKeyHash())
+                    .credentialType(CredentialType.ADDR_KEYHASH)
+                    .address(address.toBech32())
+                    .slot(genesisBlockEvent.getSlot())
+                    .txHash(genesisTxHash)
+                    .certIndex(i)
+                    .txIndex(0)
+                    .type(CertificateType.STAKE_REGISTRATION)
+                    .epoch(genesisBlockEvent.getEpoch())
+                    .blockNumber(genesisBlockEvent.getBlock())
+                    .blockHash(genesisBlockEvent.getBlockHash())
+                    .blockTime(genesisBlockEvent.getBlockTime())
+                    .build();
+            stakeRegistrations.add(stakeRegistrationDetail);
+        }
 
         if (delegations != null && !delegations.isEmpty()) {
             stakingCertificateStorage.saveDelegations(delegations);
+        }
+
+        if (!stakeRegistrations.isEmpty()) {
+            stakingCertificateStorage.saveRegistrations(stakeRegistrations);
         }
     }
 
@@ -177,6 +222,9 @@ public class GenesisPoolProcessor {
             return;
 
         List<GenesisStaking.Stake> stakes = genesisStaking.getStakes();
+        if (stakes == null)
+            stakes = List.of();
+
         List<EpochStake> epochStakes = stakes.stream()
                 .map(stake -> {
                     String poolHash = stake.getPoolHash();
@@ -237,7 +285,20 @@ public class GenesisPoolProcessor {
                     .map(genesisBalance -> genesisBalance.getBalance())
                     .reduce(BigInteger::add).orElse(BigInteger.ZERO);
 
-            var reserves = genesisConfig.getMaxLovelaceSupply().subtract(totalInitialBalance);
+            var poolCount = BigInteger.valueOf(poolParamsList.size());
+            var stakeCount = BigInteger.valueOf(stakes.size());
+            var genesisDeposits = BigInteger.ZERO;
+            if (poolCount.signum() > 0 || stakeCount.signum() > 0) {
+                var poolDeposit = depositParamService.getPoolDeposit(0);
+                var keyDeposit = depositParamService.getKeyDeposit(0);
+                genesisDeposits = poolDeposit.multiply(poolCount).add(keyDeposit.multiply(stakeCount));
+            }
+
+            // Match the ledger initialization used by Haskell: epoch-0 reserves are based on
+            // max supply minus initial UTxO balances. Genesis staking deposits are tracked in
+            // the AdaPot deposit field separately, not subtracted from reserves here.
+            var reserves = genesisConfig.getMaxLovelaceSupply()
+                    .subtract(totalInitialBalance);
 
             EpochCalculationResult result = EpochCalculationResult.builder()
                     .treasury(BigInteger.ZERO)
@@ -246,6 +307,7 @@ public class GenesisPoolProcessor {
                     .totalPoolRewardsPot(BigInteger.ZERO)
                     .totalUndistributedRewards(BigInteger.ZERO)
                     .build();
+            adaPotService.updateAdaPotDeposit(0, genesisDeposits);
             adaPotService.updateAdaPot(0, result);
         }
     }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/BlockInfoService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/BlockInfoService.java
@@ -38,4 +38,16 @@ public class BlockInfoService {
                 .epoch(epoch)
                 .build(), epoch);
     }
+
+    // Used by direct-start devnets to avoid adding a synthetic slot-0 pool block
+    // when the block table already contains a real pool-led slot-0 block.
+    public boolean hasPoolBlockAtSlot(long slot) {
+        String query = """
+            select count(number) from block b
+            where b.slot = ? and b.slot_leader in (select pool_id from pool_registration)
+        """;
+
+        Integer count = jdbcTemplate.queryForObject(query, Integer.class, slot);
+        return count != null && count > 0;
+    }
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationService.java
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -179,11 +180,16 @@ public class EpochRewardCalculationService {
         }
 
         //Blocks made by pools in epoch
-        List<PoolBlock> blocksMadeByPoolsInEpoch = blockInfoService.getPoolBlockCount(activeEpoch) //active epoch //TODO --  check epoch value
+        List<PoolBlock> blocksMadeByPoolsInEpoch = new ArrayList<>(blockInfoService.getPoolBlockCount(activeEpoch) //active epoch //TODO --  check epoch value
                 .stream().map(poolBlock -> PoolBlock.builder()
                         .poolId(poolBlock.getPoolId())
                         .blockCount(poolBlock.getBlocks())
-                        .build()).toList();
+                        .build()).toList());
+
+        // Direct Shelley-start devnets have no Byron bootstrap epoch. The Haskell ledger
+        // includes the slot-0 genesis block in epoch-0 pool block accounting; infer that
+        // block once when Yaci did not persist it as a pool-led block.
+        blocksMadeByPoolsInEpoch = includeDirectStartGenesisSlot0Block(activeEpoch, nonByronEpoch, blocksMadeByPoolsInEpoch);
 
         int poolBlockCount = blocksMadeByPoolsInEpoch.stream()
                 .mapToInt(poolBlock -> poolBlock.getBlockCount() != null ? poolBlock.getBlockCount() : 0)
@@ -281,6 +287,43 @@ public class EpochRewardCalculationService {
                 .build();
 
         return rewardsCalcInput;
+    }
+
+    List<PoolBlock> includeDirectStartGenesisSlot0Block(int activeEpoch, int nonByronEpoch, List<PoolBlock> blocksMadeByPoolsInEpoch) {
+        if (activeEpoch != 0 || nonByronEpoch != 0 || blocksMadeByPoolsInEpoch == null || blocksMadeByPoolsInEpoch.isEmpty())
+            return blocksMadeByPoolsInEpoch;
+
+        var genesisStaking = genesisConfig.getGenesisStaking();
+        if (genesisStaking == null || genesisStaking.getPools() == null || genesisStaking.getPools().isEmpty())
+            return blocksMadeByPoolsInEpoch;
+
+        // If a real pool-led slot-0 block exists in storage, reward calculation already has it.
+        // The synthetic increment is only for direct-start devnets where slot 0 is represented
+        // by genesis state instead of a normal stored pool block.
+        if (blockInfoService.hasPoolBlockAtSlot(0))
+            return blocksMadeByPoolsInEpoch;
+
+        String genesisSlot0Pool = genesisStaking.getPools().get(0).getOperator();
+        List<PoolBlock> adjustedPoolBlocks = new ArrayList<>(blocksMadeByPoolsInEpoch.size());
+        boolean adjusted = false;
+        for (PoolBlock poolBlock : blocksMadeByPoolsInEpoch) {
+            if (!adjusted && Objects.equals(genesisSlot0Pool, poolBlock.getPoolId())) {
+                int blockCount = poolBlock.getBlockCount() != null ? poolBlock.getBlockCount() : 0;
+                adjustedPoolBlocks.add(PoolBlock.builder()
+                        .poolId(poolBlock.getPoolId())
+                        .blockCount(blockCount + 1)
+                        .build());
+                adjusted = true;
+            } else {
+                adjustedPoolBlocks.add(poolBlock);
+            }
+        }
+
+        if (adjusted) {
+            log.info("Counting direct-start genesis slot 0 block for pool {} in epoch 0 reward calculation", genesisSlot0Pool);
+        }
+
+        return adjustedPoolBlocks;
     }
 
     public EpochCalculationResult calculateEpochRewards(int epoch) {

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/PoolStateService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/service/PoolStateService.java
@@ -19,6 +19,7 @@ import org.cardanofoundation.rewards.calculation.domain.PoolBlock;
 import org.cardanofoundation.rewards.calculation.domain.PoolState;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -117,7 +118,9 @@ public class PoolStateService {
                 poolState.setRewardAddress(rewardAccount);
 
                 poolState.setFixedCost(latestUpdate.getCost());
-                poolState.setMargin(latestUpdate.getMargin() != null? latestUpdate.getMargin().doubleValue() : 0);
+                // Keep the exact BigDecimal ratio for the rewards library instead of
+                // converting through double, which can drift from Haskell ledger math.
+                poolState.setMargin(latestUpdate.getMargin() != null ? latestUpdate.getMargin() : BigDecimal.ZERO);
                 poolState.setPledge(latestUpdate.getPledge());
                 poolState.setEpoch(epoch);
                 poolState.setPoolId(PoolUtil.getBech32PoolId(poolId)); //bech32

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotService.java
@@ -18,6 +18,9 @@ public class DepositSnapshotService {
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public BigInteger getNetStakeDepositInEpoch(int epoch) {
+        // GenesisPoolProcessor writes synthetic "Genesis" rows for devnet initial
+        // stake/pool certificates. Those deposits are already seeded into epoch 0,
+        // so regular epoch snapshots must exclude them to avoid double-counting.
         String stakeRegDeRegAndPoolDepositQuery = """
                             SELECT
                 -- Net deposit from stake registrations and deregistrations in the specified epoch
@@ -32,6 +35,7 @@ public class DepositSnapshotService {
                                  stake_registration
                              WHERE
                                  epoch = :epoch
+                               AND tx_hash <> :genesis_tx_hash
                          ), 0) AS stake_deposits,
                 
                 -- Net deposit from pool registrations in the specified epoch
@@ -43,6 +47,7 @@ public class DepositSnapshotService {
                              WHERE
                                  epoch = :epoch
                                AND status = 'REGISTRATION'
+                               AND tx_hash <> :genesis_tx_hash
                          ), 0) AS pool_deposits,
                 
                 -- Net deposit from pool retirements in the next epoch
@@ -57,9 +62,10 @@ public class DepositSnapshotService {
                          ), 0) AS pool_retires;
                 """;
 
-        Map param = new HashMap<>();
+        Map<String, Object> param = new HashMap<>();
         param.put("epoch", epoch);
         param.put("stake_reg_deposit", BigInteger.valueOf(2000000));
+        param.put("genesis_tx_hash", "Genesis");
 
         var stakeDeposit = jdbcTemplate.queryForObject(stakeRegDeRegAndPoolDepositQuery, param, new RowMapper<StakeDeposit>() {
             @Override

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessorTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessorTest.java
@@ -1,0 +1,194 @@
+package com.bloxbean.cardano.yaci.store.adapot.processor;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.PoolParams;
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.types.UnitInterval;
+import com.bloxbean.cardano.yaci.store.adapot.service.AdaPotService;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.events.GenesisBalance;
+import com.bloxbean.cardano.yaci.store.events.GenesisBlockEvent;
+import com.bloxbean.cardano.yaci.store.events.GenesisStaking;
+import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
+import com.bloxbean.cardano.yaci.store.staking.domain.Pool;
+import com.bloxbean.cardano.yaci.store.staking.domain.PoolRegistration;
+import com.bloxbean.cardano.yaci.store.staking.domain.PoolStatusType;
+import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
+import com.bloxbean.cardano.yaci.store.staking.storage.PoolCertificateStorage;
+import com.bloxbean.cardano.yaci.store.staking.storage.PoolStorage;
+import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorage;
+import org.cardanofoundation.rewards.calculation.domain.EpochCalculationResult;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GenesisPoolProcessorTest {
+    private static final BigInteger POOL_DEPOSIT = BigInteger.valueOf(500_000_000L);
+    private static final BigInteger KEY_DEPOSIT = BigInteger.valueOf(2_000_000L);
+    private static final String POOL_ID = "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57";
+    private static final String POOL_ID_2 = "8301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc58";
+    private static final String STAKE_HASH = "295b987135610616f3c74e11c94d77b6ced5ccc93a7d719cfb135062";
+    private static final String STAKE_HASH_2 = "395b987135610616f3c74e11c94d77b6ced5ccc93a7d719cfb135063";
+
+    @Mock
+    private StoreProperties storeProperties;
+    @Mock
+    private PoolStorage poolStorage;
+    @Mock
+    private PoolCertificateStorage poolCertificateStorage;
+    @Mock
+    private StakingCertificateStorage stakingCertificateStorage;
+    @Mock
+    private GenesisConfig genesisConfig;
+    @Mock
+    private AdaPotService adaPotService;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DSLContext dslContext;
+    @Mock
+    private DepositParamService depositParamService;
+
+    @InjectMocks
+    private GenesisPoolProcessor genesisPoolProcessor;
+
+    @Captor
+    private ArgumentCaptor<List<PoolRegistration>> poolRegistrationsCaptor;
+    @Captor
+    private ArgumentCaptor<List<Pool>> poolsCaptor;
+    @Captor
+    private ArgumentCaptor<List<Delegation>> delegationsCaptor;
+    @Captor
+    private ArgumentCaptor<List<StakeRegistrationDetail>> stakeRegistrationsCaptor;
+    @Captor
+    private ArgumentCaptor<EpochCalculationResult> epochCalculationResultCaptor;
+
+    @Test
+    void handleGenesisPoolRegistration_booksPoolDepositsAndStakeRegistrations() {
+        when(storeProperties.isMainnet()).thenReturn(false);
+        when(depositParamService.getPoolDeposit(0)).thenReturn(POOL_DEPOSIT);
+
+        genesisPoolProcessor.handleGenesisPoolRegistration(genesisBlockEvent(genesisStaking()));
+
+        verify(poolCertificateStorage).savePoolRegistrations(poolRegistrationsCaptor.capture());
+        assertThat(poolRegistrationsCaptor.getValue())
+                .extracting(PoolRegistration::getCertIndex)
+                .containsExactly(0, 1);
+
+        verify(poolStorage).save(poolsCaptor.capture());
+        assertThat(poolsCaptor.getValue())
+                .extracting(Pool::getAmount)
+                .containsExactly(POOL_DEPOSIT, POOL_DEPOSIT);
+        assertThat(poolsCaptor.getValue())
+                .extracting(Pool::getStatus)
+                .containsOnly(PoolStatusType.REGISTRATION);
+
+        verify(stakingCertificateStorage).saveDelegations(delegationsCaptor.capture());
+        assertThat(delegationsCaptor.getValue())
+                .extracting(Delegation::getCertIndex)
+                .containsExactly(0, 1);
+
+        verify(stakingCertificateStorage).saveRegistrations(stakeRegistrationsCaptor.capture());
+        assertThat(stakeRegistrationsCaptor.getValue())
+                .extracting(StakeRegistrationDetail::getCertIndex)
+                .containsExactly(0, 1);
+        assertThat(stakeRegistrationsCaptor.getValue())
+                .extracting(StakeRegistrationDetail::getType)
+                .containsOnly(CertificateType.STAKE_REGISTRATION);
+        assertThat(stakeRegistrationsCaptor.getValue())
+                .extracting(StakeRegistrationDetail::getTxHash)
+                .containsOnly("Genesis");
+    }
+
+    @Test
+    void handleGenesisEpochStake_booksGenesisDepositsIntoEpochZeroWithoutReducingReserves() {
+        when(storeProperties.isMainnet()).thenReturn(false);
+        when(depositParamService.getPoolDeposit(0)).thenReturn(POOL_DEPOSIT);
+        when(depositParamService.getKeyDeposit(0)).thenReturn(KEY_DEPOSIT);
+        when(genesisConfig.getMaxLovelaceSupply()).thenReturn(BigInteger.valueOf(20_000_000_000L));
+        when(dslContext.batch(any(Collection.class)).execute()).thenReturn(new int[]{1, 1});
+
+        genesisPoolProcessor.handleGenesisEpochStake(genesisBlockEvent(genesisStaking()));
+
+        BigInteger expectedGenesisDeposits = POOL_DEPOSIT.multiply(BigInteger.valueOf(2))
+                .add(KEY_DEPOSIT.multiply(BigInteger.valueOf(2)));
+        verify(adaPotService).createAdaPot(0, 0L);
+        verify(adaPotService).updateAdaPotDeposit(0, expectedGenesisDeposits);
+        verify(adaPotService).updateAdaPot(org.mockito.ArgumentMatchers.eq(0), epochCalculationResultCaptor.capture());
+        assertThat(epochCalculationResultCaptor.getValue().getReserves())
+                .isEqualTo(BigInteger.valueOf(20_000_000_000L)
+                        .subtract(BigInteger.valueOf(3_000_000_000L)));
+    }
+
+    @Test
+    void handleGenesisEpochStake_emptyStakingKeepsPublicNetworkBehaviour() {
+        when(genesisConfig.getMaxLovelaceSupply()).thenReturn(BigInteger.valueOf(20_000_000_000L));
+
+        genesisPoolProcessor.handleGenesisEpochStake(genesisBlockEvent(new GenesisStaking(List.of(), List.of())));
+
+        verify(adaPotService).createAdaPot(0, 0L);
+        verify(adaPotService).updateAdaPotDeposit(0, BigInteger.ZERO);
+        verify(adaPotService).updateAdaPot(org.mockito.ArgumentMatchers.eq(0), epochCalculationResultCaptor.capture());
+        assertThat(epochCalculationResultCaptor.getValue().getReserves())
+                .isEqualTo(BigInteger.valueOf(17_000_000_000L));
+        verifyNoInteractions(depositParamService);
+        verify(poolStorage, never()).save(any());
+        verify(stakingCertificateStorage, never()).saveRegistrations(any());
+        verify(stakingCertificateStorage, never()).saveDelegations(any());
+    }
+
+    private GenesisBlockEvent genesisBlockEvent(GenesisStaking genesisStaking) {
+        return GenesisBlockEvent.builder()
+                .era(Era.Shelley)
+                .epoch(0)
+                .slot(-1)
+                .block(-1)
+                .blockHash("genesis-hash")
+                .blockTime(1_700_000_000L)
+                .genesisStaking(genesisStaking)
+                .genesisBalances(List.of(
+                        new GenesisBalance("addr_test1vr8utk9ldjke5c6kjuvjs23rzuw2n9ptdzqlr36qa74pt4q04dv2q", "tx1", BigInteger.valueOf(1_000_000_000L)),
+                        new GenesisBalance("addr_test1vqq2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3vty2x3tq9ys9fp", "tx2", BigInteger.valueOf(2_000_000_000L))))
+                .build();
+    }
+
+    private GenesisStaking genesisStaking() {
+        return new GenesisStaking(
+                List.of(poolParams(POOL_ID, "e011a14edf73b08a0a27cb98b2c57eb37c780df18fcfcf6785ed5df84a"),
+                        poolParams(POOL_ID_2, "e012a14edf73b08a0a27cb98b2c57eb37c780df18fcfcf6785ed5df84b")),
+                List.of(new GenesisStaking.Stake(STAKE_HASH, POOL_ID),
+                        new GenesisStaking.Stake(STAKE_HASH_2, POOL_ID_2)));
+    }
+
+    private PoolParams poolParams(String poolId, String rewardAccount) {
+        return PoolParams.builder()
+                .operator(poolId)
+                .vrfKeyHash("c2b62ffa92ad18ffc117ea3abeb161a68885000a466f9c71db5e4731d6630061")
+                .pledge(BigInteger.ZERO)
+                .cost(BigInteger.valueOf(340_000_000L))
+                .margin(UnitInterval.fromString("1/5"))
+                .rewardAccount(rewardAccount)
+                .poolOwners(Set.of())
+                .relays(List.of())
+                .build();
+    }
+}

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationServiceTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/EpochRewardCalculationServiceTest.java
@@ -1,10 +1,14 @@
 package com.bloxbean.cardano.yaci.store.adapot.service;
 
+import com.bloxbean.cardano.yaci.core.model.PoolParams;
 import com.bloxbean.cardano.yaci.store.adapot.domain.RewardRest;
 import com.bloxbean.cardano.yaci.store.adapot.domain.UnclaimedRewardRest;
 import com.bloxbean.cardano.yaci.store.adapot.storage.RewardStorage;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.events.GenesisStaking;
 import com.bloxbean.cardano.yaci.store.events.domain.RewardRestType;
 import com.bloxbean.cardano.yaci.store.transaction.storage.TransactionStorageReader;
+import org.cardanofoundation.rewards.calculation.domain.PoolBlock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,6 +19,8 @@ import java.util.List;
 
 import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +31,12 @@ class EpochRewardCalculationServiceTest {
 
     @Mock
     private RewardStorage rewardStorage;
+
+    @Mock
+    private GenesisConfig genesisConfig;
+
+    @Mock
+    private BlockInfoService blockInfoService;
 
     @InjectMocks
     private EpochRewardCalculationService epochRewardCalculationService;
@@ -69,5 +81,46 @@ class EpochRewardCalculationServiceTest {
         assertThat(newTreasuryAmount).isEqualTo(expectedTreasury);
     }
 
+    @Test
+    void includeDirectStartGenesisSlot0Block_addsOneBlockToInferredPool() {
+        when(genesisConfig.getGenesisStaking()).thenReturn(new GenesisStaking(
+                List.of(PoolParams.builder().operator("pool1").build()),
+                List.of()));
+        when(blockInfoService.hasPoolBlockAtSlot(0)).thenReturn(false);
+
+        List<PoolBlock> adjustedBlocks = epochRewardCalculationService.includeDirectStartGenesisSlot0Block(
+                0,
+                0,
+                List.of(PoolBlock.builder().poolId("pool1").blockCount(58).build()));
+
+        assertThat(adjustedBlocks)
+                .extracting(PoolBlock::getPoolId, PoolBlock::getBlockCount)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple("pool1", 59));
+    }
+
+    @Test
+    void includeDirectStartGenesisSlot0Block_doesNotChangePublicOrNonGenesisEpochs() {
+        List<PoolBlock> poolBlocks = List.of(PoolBlock.builder().poolId("pool1").blockCount(58).build());
+
+        assertThat(epochRewardCalculationService.includeDirectStartGenesisSlot0Block(0, 1, poolBlocks))
+                .isSameAs(poolBlocks);
+        assertThat(epochRewardCalculationService.includeDirectStartGenesisSlot0Block(1, 0, poolBlocks))
+                .isSameAs(poolBlocks);
+
+        verify(genesisConfig, never()).getGenesisStaking();
+    }
+
+    @Test
+    void includeDirectStartGenesisSlot0Block_doesNotDoubleCountExistingSlot0Block() {
+        when(genesisConfig.getGenesisStaking()).thenReturn(new GenesisStaking(
+                List.of(PoolParams.builder().operator("pool1").build()),
+                List.of()));
+        when(blockInfoService.hasPoolBlockAtSlot(0)).thenReturn(true);
+
+        List<PoolBlock> poolBlocks = List.of(PoolBlock.builder().poolId("pool1").blockCount(59).build());
+
+        assertThat(epochRewardCalculationService.includeDirectStartGenesisSlot0Block(0, 0, poolBlocks))
+                .isSameAs(poolBlocks);
+    }
 
 }

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotServiceTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotServiceTest.java
@@ -1,0 +1,68 @@
+package com.bloxbean.cardano.yaci.store.adapot.snapshot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DepositSnapshotServiceTest {
+    private DepositSnapshotService depositSnapshotService;
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:deposit_snapshot;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        depositSnapshotService = new DepositSnapshotService(new NamedParameterJdbcTemplate(dataSource));
+
+        jdbcTemplate.execute("DROP TABLE IF EXISTS stake_registration");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS pool");
+        jdbcTemplate.execute("""
+                CREATE TABLE stake_registration (
+                    tx_hash VARCHAR(128),
+                    type VARCHAR(64),
+                    epoch INTEGER
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE pool (
+                    tx_hash VARCHAR(128),
+                    status VARCHAR(64),
+                    amount NUMERIC(38, 0),
+                    epoch INTEGER
+                )
+                """);
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_excludesSyntheticGenesisRowsOnly() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(tx_hash, type, epoch)
+                VALUES
+                    ('Genesis', 'STAKE_REGISTRATION', 0),
+                    ('normal-reg', 'STAKE_REGISTRATION', 0),
+                    ('normal-dereg', 'STAKE_DEREGISTRATION', 0)
+                """);
+        jdbcTemplate.update("""
+                INSERT INTO pool(tx_hash, status, amount, epoch)
+                VALUES
+                    ('Genesis', 'REGISTRATION', 500000000, 0),
+                    ('normal-pool', 'REGISTRATION', 700000000, 0),
+                    ('retired-pool', 'RETIRED', 100000000, 1)
+                """);
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(0);
+
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(600_000_000L));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogm
 cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.2"
 scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0"
 
-cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.0"
+cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.1"
 
 rocks-types="com.bloxbean:rocks-types:0.0.1-preview6"
 


### PR DESCRIPTION
 ## Summary
  - Seed devnet genesis pool/key deposits into epoch-0 AdaPot deposits while keeping reserves as `maxLovelaceSupply - initialGenesisBalances`.
  - Add synthetic `Genesis` pool/stake certificate rows so genesis staking behaves like registered ledger state.
  - Exclude synthetic `Genesis` rows from normal deposit snapshots to avoid double-counting deposits.
  - Account for direct Shelley-start slot-0 pool block when it is not stored as a normal pool-led block.
  - Preserve pool margin as `BigDecimal` to avoid reward calculation drift.
