### PR TITLE
[BF Compatibility]  Fix Blockfrost metadata label ordering for JSON and CBOR endpoints when multiple transactions share the same slot.

### DIFF
--- a/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/service/BFMetadataService.java
+++ b/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/service/BFMetadataService.java
@@ -1,6 +1,5 @@
 package com.bloxbean.cardano.yaci.store.blockfrost.metadata.service;
 
-import com.bloxbean.cardano.yaci.store.api.metadata.service.MetadataService;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.dto.BFMetadataCborDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.dto.BFMetadataJsonDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.dto.BFMetadataLabelDto;
@@ -21,7 +20,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BFMetadataService {
 
-    private final MetadataService metadataService;
     private final BFMetadataStorageReader bfMetadataStorageReader;
     private final BFMetadataMapper bfMetadataMapper;
 
@@ -31,7 +29,7 @@ public class BFMetadataService {
 
 
     public List<BFMetadataJsonDto> getMetadataByLabel(String label, int page, int count, Order order) {
-        List<TxMetadataLabel> metadata = metadataService.getMetadataByLabel(label, page, count, order);
+        List<TxMetadataLabel> metadata = bfMetadataStorageReader.findMetadataByLabel(label, page, count, order);
         if (metadata == null || metadata.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "The requested component has not been found.");
@@ -43,7 +41,7 @@ public class BFMetadataService {
 
 
     public List<BFMetadataCborDto> getMetadataCborByLabel(String label, int page, int count, Order order) {
-        List<TxMetadataLabel> metadata = metadataService.getMetadataByLabel(label, page, count, order);
+        List<TxMetadataLabel> metadata = bfMetadataStorageReader.findMetadataByLabel(label, page, count, order);
         if (metadata == null || metadata.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "The requested component has not been found.");

--- a/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/storage/BFMetadataStorageReader.java
+++ b/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/storage/BFMetadataStorageReader.java
@@ -2,10 +2,12 @@ package com.bloxbean.cardano.yaci.store.blockfrost.metadata.storage;
 
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.dto.BFMetadataLabelDto;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.metadata.domain.TxMetadataLabel;
 
 import java.util.List;
 
 public interface BFMetadataStorageReader {
 
     List<BFMetadataLabelDto> findLabelsWithCount(int page, int count, Order order);
+    List<TxMetadataLabel> findMetadataByLabel(String label, int page, int count, Order order);
 }

--- a/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/storage/impl/BFMetadataStorageReaderImpl.java
+++ b/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/storage/impl/BFMetadataStorageReaderImpl.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.blockfrost.metadata.storage.impl;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.dto.BFMetadataLabelDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.metadata.storage.BFMetadataStorageReader;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.metadata.domain.TxMetadataLabel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -23,6 +24,13 @@ public class BFMetadataStorageReaderImpl implements BFMetadataStorageReader {
 
     private static final Table<?> TX_METADATA = DSL.table(DSL.name("transaction_metadata"));
     private static final Field<String> LABEL = DSL.field(DSL.name("label"), String.class);
+    private static final Field<String> METADATA_TX_HASH = DSL.field(DSL.name("transaction_metadata", "tx_hash"), String.class);
+    private static final Field<Long> METADATA_SLOT = DSL.field(DSL.name("transaction_metadata", "slot"), Long.class);
+    private static final Field<String> BODY = DSL.field(DSL.name("body"), String.class);
+    private static final Field<String> CBOR = DSL.field(DSL.name("cbor"), String.class);
+    private static final Table<?> TRANSACTION = DSL.table(DSL.name("transaction"));
+    private static final Field<String> TRANSACTION_TX_HASH = DSL.field(DSL.name("transaction", "tx_hash"), String.class);
+    private static final Field<Integer> TX_INDEX = DSL.field(DSL.name("transaction", "tx_index"), Integer.class);
 
     private final DSLContext dsl;
 
@@ -41,12 +49,34 @@ public class BFMetadataStorageReaderImpl implements BFMetadataStorageReader {
                 .limit(count)
                 .offset(offset);
 
-        log.debug("[BFMetadataStorageReader] findLabelsWithCount SQL: {}", query.getSQL(ParamType.INLINED));
-
         return query.fetch(record -> BFMetadataLabelDto.builder()
                 .label(record.get(LABEL))
                 .cip10(null)
                 .count(String.valueOf(record.get(cntField)))
+                .build());
+    }
+
+    @Override
+    public List<TxMetadataLabel> findMetadataByLabel(String label, int page, int count, Order order) {
+        int offset = Math.max(page, 0) * count;
+        SortField<Long> slotOrder = order == Order.desc ? METADATA_SLOT.desc() : METADATA_SLOT.asc();
+        SortField<Integer> txIndexOrder = order == Order.desc ? TX_INDEX.desc().nullsLast() : TX_INDEX.asc().nullsLast();
+
+        var query = dsl.select(METADATA_TX_HASH, METADATA_SLOT, LABEL, BODY, CBOR)
+                .from(TX_METADATA)
+                .leftJoin(TRANSACTION)
+                .on(METADATA_TX_HASH.eq(TRANSACTION_TX_HASH))
+                .where(LABEL.eq(label))
+                .orderBy(slotOrder, txIndexOrder)
+                .limit(count)
+                .offset(offset);
+
+        return query.fetch(record -> TxMetadataLabel.builder()
+                .txHash(record.get(METADATA_TX_HASH))
+                .slot(record.get(METADATA_SLOT))
+                .label(record.get(LABEL))
+                .body(record.get(BODY))
+                .cbor(record.get(CBOR))
                 .build());
     }
 }


### PR DESCRIPTION
 ## Summary

  Fix Blockfrost metadata label ordering for JSON and CBOR endpoints when multiple transactions share the same slot.

  ## Changes

  - Add Blockfrost-specific metadata lookup for `/metadata/txs/labels/{label}` and `/metadata/txs/labels/{label}/cbor`.
  - Join `transaction_metadata` with `transaction` by `tx_hash` to access `tx_index`.
  - Order metadata rows by chain position:
    - `asc`: `slot asc, tx_index asc`
    - `desc`: `slot desc, tx_index desc`
  - Keep native metadata API behavior unchanged by avoiding changes to shared `TxMetadataStorageReaderImpl`.

  ## Why
 Using the blockfrost comparator script, the preprod comparison for the metadata module showed that all tested endpoints returned HTTP 200 from both Yaci and Blockfrost, but 5 of 12 endpoint variants still had field/order diffs.

  The accepted `cip10` limitation is already documented in [`metadata_gaps.md`](https://github.com/bloxbean/yaci-store/blob/6630fe66cb830e69446a50d693883da0610717d0/extensions/blockfrost/adr/metadata_gaps.md), but the compare run also exposed a separate ordering issue not covered by that ADR.

  The first visible symptom was different `tx_hash` values at the same array indexes for `order=desc` JSON and CBOR metadata-by-label endpoints. Follow-up checks confirmed those transactions shared the same slot/block
 but had different transaction indexes. Meanwhile, Yaci Store was sorting metadata-by-label rows only by `slot`

 -> The previous implementation sorted metadata-by-label rows only by `slot`. When several transactions shared the same slot, Yaci Store could return a different order than Blockfrost

 ## Testing
- [x] Preprod
- [x] Preview
- [ ] Mainnet