### PR TITLE
feat(blockfrost): default all sub-modules to enabled when parent gate is active

### DIFF
--- a/config/application-blockfrost.properties
+++ b/config/application-blockfrost.properties
@@ -1,0 +1,21 @@
+#######################################################################################
+# Blockfrost Profile Configuration
+# Activate this profile to enable all Blockfrost-compatible API endpoints.
+# Usage: spring.profiles.active=ledger-state,blockfrost
+#######################################################################################
+
+store.extensions.blockfrost.enabled=true
+
+# All sub-modules are enabled by default when store.extensions.blockfrost.enabled=true.
+# To disable a specific module, uncomment and set to false:
+#store.extensions.blockfrost.epoch.enabled=true
+#store.extensions.blockfrost.address.enabled=true
+#store.extensions.blockfrost.asset.enabled=true
+#store.extensions.blockfrost.account.enabled=true
+#store.extensions.blockfrost.transaction.enabled=true
+#store.extensions.blockfrost.blocks.enabled=true
+#store.extensions.blockfrost.scripts.enabled=true
+#store.extensions.blockfrost.metadata.enabled=true
+#store.extensions.blockfrost.util.enabled=true
+
+blockfrost.apiPrefix=/api/v1/blockfrost

--- a/config/application-ledger-state.properties
+++ b/config/application-ledger-state.properties
@@ -7,6 +7,13 @@ store.account.balance-cleanup-slot-count=43200
 store.account.address-balance-enabled=false
 store.account.stake-address-balance-enabled=true
 
+# Epoch aggregation
+store.epoch-aggr.enabled=true
+store.epoch-aggr.api-enabled=true
+store.epoch-aggr.epoch-calculation-enabled=true
+# For test networks, it is fine to keep this value low like 300 (5 minutes).
+store.epoch-aggr.epoch-calculation-interval=14400
+
 # Uncomment if aggregation app also handles db migration
 spring.flyway.locations=classpath:db/store/{vendor}
 spring.flyway.out-of-order=true

--- a/config/application.properties
+++ b/config/application.properties
@@ -343,15 +343,6 @@ logging.level.com.bloxbean.cardano.yaci.store.core.service=INFO
 #######################################################################################
 #store.read-only-mode=true
 
-#######################################################################################
-# Blockfrost Configuration
-# Default value = "false", To enable an endpoint, set the flag to "true"
-#######################################################################################
-blockfrost.apiPrefix=/api/v1/blockfrost
-#store.extensions.blockfrost.epoch.enabled=false
-#store.extensions.blockfrost.address.enabled=false
-#store.extensions.blockfrost.asset.enabled=false
-#store.extensions.blockfrost.blocks.enabled=false
 server.forward-headers-strategy=framework
 
 spring.threads.virtual.enabled=true

--- a/docker/config/application-blockfrost.properties
+++ b/docker/config/application-blockfrost.properties
@@ -1,0 +1,21 @@
+#######################################################################################
+# Blockfrost Profile Configuration
+# Activate this profile to enable all Blockfrost-compatible API endpoints.
+# Usage: spring.profiles.active=ledger-state,blockfrost
+#######################################################################################
+
+store.extensions.blockfrost.enabled=true
+
+# All sub-modules are enabled by default when store.extensions.blockfrost.enabled=true.
+# To disable a specific module, uncomment and set to false:
+#store.extensions.blockfrost.epoch.enabled=true
+#store.extensions.blockfrost.address.enabled=true
+#store.extensions.blockfrost.asset.enabled=true
+#store.extensions.blockfrost.account.enabled=true
+#store.extensions.blockfrost.transaction.enabled=true
+#store.extensions.blockfrost.blocks.enabled=true
+#store.extensions.blockfrost.scripts.enabled=true
+#store.extensions.blockfrost.metadata.enabled=true
+#store.extensions.blockfrost.util.enabled=true
+
+blockfrost.apiPrefix=/api/v1/blockfrost

--- a/docker/config/application-ledger-state.properties
+++ b/docker/config/application-ledger-state.properties
@@ -7,6 +7,13 @@ store.account.balance-cleanup-slot-count=43200
 store.account.address-balance-enabled=false
 store.account.stake-address-balance-enabled=true
 
+# Epoch aggregation
+store.epoch-aggr.enabled=true
+store.epoch-aggr.api-enabled=true
+store.epoch-aggr.epoch-calculation-enabled=true
+# For test networks, it is fine to keep this value low like 300 (5 minutes).
+store.epoch-aggr.epoch-calculation-interval=14400
+
 # Uncomment if aggregation app also handles db migration
 spring.flyway.locations=classpath:db/store/{vendor}
 spring.flyway.out-of-order=true

--- a/docker/config/env
+++ b/docker/config/env
@@ -12,6 +12,12 @@
 ## Enable both Ledger State and Analytics profiles
 #SPRING_PROFILES_ACTIVE=ledger-state,analytics
 
+## Enable Ledger State and Blockfrost profiles
+#SPRING_PROFILES_ACTIVE=ledger-state,blockfrost
+
+## Enable Ledger State, Analytics, Blockfrost profiles
+#SPRING_PROFILES_ACTIVE=ledger-state,analytics,blockfrost
+
 ## Enable polyglot plugins (Python, JS) support.
 # JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
 

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/BFAccountConfiguration.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/BFAccountConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.account.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {
         "com.bloxbean.cardano.yaci.store.blockfrost.account",

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/controller/BFAccountController.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/controller/BFAccountController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Accounts")
 @RequestMapping("${blockfrost.apiPrefix}/accounts")
-@ConditionalOnExpression("${store.extensions.blockfrost.account.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.account.enabled:true}")
 public class BFAccountController {
 
     private final BFAccountService bfAccountService;

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/BFAddressConfiguration.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/BFAddressConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.address.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.blockfrost.address"})
 public class BFAddressConfiguration {

--- a/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/controller/BFAddressController.java
+++ b/extensions/blockfrost/address/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/address/controller/BFAddressController.java
@@ -28,7 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Addresses")
 @RequestMapping("${blockfrost.apiPrefix}/addresses")
-@ConditionalOnExpression("${store.extensions.blockfrost.address.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.address.enabled:true}")
 public class BFAddressController {
 
     private final BFAddressService bfAddressService;

--- a/extensions/blockfrost/asset/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/asset/BFAssetConfiguration.java
+++ b/extensions/blockfrost/asset/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/asset/BFAssetConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.asset.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.blockfrost.asset"})
 public class BFAssetConfiguration {

--- a/extensions/blockfrost/asset/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/asset/controller/BFAssetController.java
+++ b/extensions/blockfrost/asset/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/asset/controller/BFAssetController.java
@@ -29,7 +29,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Assets")
 @RequestMapping("${blockfrost.apiPrefix}/assets")
-@ConditionalOnExpression("${store.extensions.blockfrost.asset.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.asset.enabled:true}")
 public class BFAssetController {
 
     private final BFAssetService bfAssetService;

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/BFBlockConfiguration.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/BFBlockConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.blocks.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.blockfrost.block"})
 public class BFBlockConfiguration {

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/controller/BFBlockController.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/controller/BFBlockController.java
@@ -26,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Blocks")
 @RequestMapping("${blockfrost.apiPrefix}/blocks")
-@ConditionalOnExpression("${store.extensions.blockfrost.blocks.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.blocks.enabled:true}")
 public class BFBlockController {
 
     private final BFBlockService bfBlockService;

--- a/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/BFEpochConfiguration.java
+++ b/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/BFEpochConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.epoch.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {
         "com.bloxbean.cardano.yaci.store.blockfrost.epoch",

--- a/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/controller/BFEpochController.java
+++ b/extensions/blockfrost/epoch/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/epoch/controller/BFEpochController.java
@@ -31,7 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Epochs")
 @RequestMapping("${blockfrost.apiPrefix}/epochs")
-@ConditionalOnExpression("${store.extensions.blockfrost.epoch.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.epoch.enabled:true}")
 public class BFEpochController {
 
     private final BFProtocolParamMapper bfProtocolParamMapper = BFProtocolParamMapper.INSTANCE;

--- a/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/BFMetadataConfiguration.java
+++ b/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/BFMetadataConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(
         name = {"store.extensions.blockfrost.metadata.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {
         "com.bloxbean.cardano.yaci.store.blockfrost.metadata",

--- a/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/controller/BFMetadataController.java
+++ b/extensions/blockfrost/metadata/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/metadata/controller/BFMetadataController.java
@@ -28,7 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Metadata")
 @RequestMapping("${blockfrost.apiPrefix}/metadata/txs")
-@ConditionalOnExpression("${store.extensions.blockfrost.metadata.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.metadata.enabled:true}")
 public class BFMetadataController {
 
     private final BFMetadataService bfMetadataService;

--- a/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/BFScriptsConfiguration.java
+++ b/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/BFScriptsConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(name = {"store.extensions.blockfrost.scripts.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {
         "com.bloxbean.cardano.yaci.store.blockfrost.scripts",

--- a/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/controller/BFScriptsController.java
+++ b/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/controller/BFScriptsController.java
@@ -22,7 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Scripts")
 @RequestMapping("${blockfrost.apiPrefix}/scripts")
-@ConditionalOnExpression("${store.extensions.blockfrost.scripts.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.scripts.enabled:true}")
 public class BFScriptsController {
 
     private final BFScriptsService bfScriptsService;

--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/BFTransactionConfiguration.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/BFTransactionConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(
         name = {"store.extensions.blockfrost.transaction.enabled"},
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = {
         "com.bloxbean.cardano.yaci.store.blockfrost.transaction",

--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTransactionController.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTransactionController.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Transactions")
 @RequestMapping("${blockfrost.apiPrefix}/txs")
-@ConditionalOnExpression("${store.extensions.blockfrost.transaction.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.transaction.enabled:true}")
 public class BFTransactionController {
 
     private final BFTransactionService bfTransactionService;

--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTxSubmitController.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/controller/BFTxSubmitController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Transactions")
 @RequestMapping("${blockfrost.apiPrefix}/tx")
-@ConditionalOnExpression("${store.extensions.blockfrost.transaction.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.transaction.enabled:true}")
 public class BFTxSubmitController {
 
     private final BFTxSubmitService bfTxSubmitService;

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/BFUtilConfiguration.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/BFUtilConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(
         name = "store.extensions.blockfrost.util.enabled",
         havingValue = "true",
-        matchIfMissing = false
+        matchIfMissing = true
 )
 @ComponentScan(basePackages = "com.bloxbean.cardano.yaci.store.blockfrost.util")
 public class BFUtilConfiguration {

--- a/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
+++ b/extensions/blockfrost/util/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/util/controller/BFUtilController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Tag(name = "Blockfrost Utilities")
 @RequestMapping("${blockfrost.apiPrefix}/utils")
-@ConditionalOnExpression("${store.extensions.blockfrost.util.enabled:false}")
+@ConditionalOnExpression("${store.extensions.blockfrost.util.enabled:true}")
 public class BFUtilController {
 
     private final BFUtilService bfUtilService;

--- a/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFAutoConfiguration.java
+++ b/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFAutoConfiguration.java
@@ -12,10 +12,17 @@ import com.bloxbean.cardano.yaci.store.blockfrost.util.BFUtilConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
+@ConditionalOnProperty(
+        prefix = "store.extensions.blockfrost",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
 @EnableConfigurationProperties(BFProperties.class)
 @Import({BFEpochConfiguration.class, BFAddressConfiguration.class, BFAssetConfiguration.class, BFAccountConfiguration.class, BFTransactionConfiguration.class, BFBlockConfiguration.class, BFScriptsConfiguration.class, BFMetadataConfiguration.class, BFUtilConfiguration.class})
 @Slf4j

--- a/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFProperties.java
+++ b/starters/blockfrost-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/blockfrost/BFProperties.java
@@ -20,6 +20,8 @@ public class BFProperties {
         @Setter
         public static final class Blockfrost  {
 
+            private boolean enabled = false;
+
             private Epoch epoch = new Epoch();
             private Address address = new Address();
             private Asset asset = new Asset();
@@ -33,55 +35,55 @@ public class BFProperties {
             @Getter
             @Setter
             public static final class Epoch {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Address {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Asset {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Account {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Transaction {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Blocks {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Scripts {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Metadata {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
             @Getter
             @Setter
             public static final class Util {
-                private boolean enabled = false;
+                private boolean enabled = true;
             }
 
         }


### PR DESCRIPTION
  - Add top-level gate store.extensions.blockfrost.enabled on BFAutoConfiguration
  - Change all 9 sub-module defaults from false to true in BFProperties
  - Set matchIfMissing=true on all BF*Configuration classes
  - Update @ConditionalOnExpression defaults to :true in all controllers
  - Add blockfrost Spring profile (application-blockfrost.properties)
  - Enable epoch-aggr in ledger-state profile (required by BF epoch endpoints)
  - Add blockfrost profile option to docker/config/env
  
 BREAKING CHANGE: Users who previously set individual sub-module properties
  (e.g. store.extensions.blockfrost.metadata.enabled=true) must now also set
  store.extensions.blockfrost.enabled=true or activate the blockfrost profile.
