### PR TITLE
fix(epoch-aggr): add read-only mode support

### DIFF
--- a/aggregates/epoch-aggr/build.gradle
+++ b/aggregates/epoch-aggr/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api project(":stores:blocks")
+    api project(":components:core")
 }
 
 publishing {

--- a/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/processor/EpochProcessor.java
+++ b/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/processor/EpochProcessor.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.store.epochaggr.processor;
 
 import com.bloxbean.cardano.yaci.store.common.aspect.EnableIf;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.epochaggr.service.EpochService;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
 import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
@@ -24,6 +25,7 @@ import static com.bloxbean.cardano.yaci.store.epochaggr.EpochAggrConfiguration.S
 @ConditionalOnProperty(name = "store.epoch-aggr.epoch-calculation-enabled", havingValue = "true", matchIfMissing = false)
 @RequiredArgsConstructor
 @EnableIf(value = STORE_EPOCHAGGR_ENABLED, defaultValue = false)
+@ReadOnly(false)
 public class EpochProcessor {
 
     private final EpochService epochService;

--- a/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/service/EpochService.java
+++ b/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/service/EpochService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.epochaggr.service;
 
 import com.bloxbean.cardano.yaci.store.blocks.domain.Block;
 import com.bloxbean.cardano.yaci.store.blocks.storage.BlockStorage;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
 import com.bloxbean.cardano.yaci.store.epochaggr.domain.Epoch;
 import com.bloxbean.cardano.yaci.store.epochaggr.storage.EpochStorage;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@ReadOnly(false)
 public class EpochService {
     private final EpochStorage epochStorage;
     private final BlockStorage blockStorage;


### PR DESCRIPTION
## Summary

Add `@ReadOnly(false)` support to the `epoch-aggr` module so that write-path components (processor and service) are disabled when `store.read-only-mode=true`.

## Changes

- **EpochProcessor** — annotated with `@ReadOnly(false)` to disable scheduled aggregation and event listeners in read-only mode
- **EpochService** — annotated with `@ReadOnly(false)` to disable the write service in read-only mode
- **build.gradle** — added `components:core` dependency (required for the `@ReadOnly` annotation)
