### PR TITLE
fix(governance): correct hard fork SPO abstain tally

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
@@ -79,7 +79,10 @@ public final class VoteTallyCalculator {
             totalYesStake = totalYesStake.add(delegateToNoConfidenceDRep);
         }
 
-        BigInteger totalAbstainStake = abstainVote.add(delegateAutoAbstainDRep);
+        BigInteger totalAbstainStake = abstainVote;
+        if (type != GovActionType.HARD_FORK_INITIATION_ACTION) {
+            totalAbstainStake = totalAbstainStake.add(delegateAutoAbstainDRep);
+        }
 
         // In bootstrap phase, all do not vote stake is considered as abstain stake except for HardForkInitiationAction
         if (isInBootstrapPhase && type != GovActionType.HARD_FORK_INITIATION_ACTION) {

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
@@ -83,7 +83,7 @@ class VoteTallyCalculatorTest {
     void computeSPOTalliesPostBootstrapPhaseWhenActionIsNotHardForkInit() {
         VotingData.SPOVotes votes = VotingData.SPOVotes.builder()
                 .yesVoteStake(BigInteger.valueOf(120))
-                .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                .delegateToAutoAbstainDRepStake(BigInteger.valueOf(15))
                 .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
                 .abstainVoteStake(BigInteger.valueOf(50))
                 .doNotVoteStake(BigInteger.valueOf(10))
@@ -93,8 +93,26 @@ class VoteTallyCalculatorTest {
         VoteTallies.SPOTallies tallies = VoteTallyCalculator.computeSPOTallies(votes, GovActionType.UPDATE_COMMITTEE, false);
 
         assertEquals(BigInteger.valueOf(120), tallies.getTotalYesStake());
-        assertEquals(BigInteger.valueOf(50), tallies.getTotalAbstainStake());
-        assertEquals(BigInteger.valueOf(30), tallies.getTotalNoStake());
+        assertEquals(BigInteger.valueOf(65), tallies.getTotalAbstainStake());
+        assertEquals(BigInteger.valueOf(15), tallies.getTotalNoStake());
+    }
+
+    @Test
+    void computeSPOTalliesHardForkInitTreatsNonVotingSPOsAsNoEvenWhenDelegatedToAlwaysAbstain() {
+        VotingData.SPOVotes votes = VotingData.SPOVotes.builder()
+                .yesVoteStake(BigInteger.valueOf(100))
+                .delegateToAutoAbstainDRepStake(BigInteger.valueOf(30))
+                .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                .abstainVoteStake(BigInteger.valueOf(10))
+                .doNotVoteStake(BigInteger.valueOf(20))
+                .totalStake(BigInteger.valueOf(200))
+                .build();
+
+        VoteTallies.SPOTallies tallies = VoteTallyCalculator.computeSPOTallies(votes, GovActionType.HARD_FORK_INITIATION_ACTION, false);
+
+        assertEquals(BigInteger.valueOf(100), tallies.getTotalYesStake());
+        assertEquals(BigInteger.valueOf(10), tallies.getTotalAbstainStake());
+        assertEquals(BigInteger.valueOf(90), tallies.getTotalNoStake());
     }
 
     @Test


### PR DESCRIPTION
 ## Summary

  Fix SPO vote tallying for `HARD_FORK_INITIATION_ACTION`.

  For hard fork initiation proposals, non-voting SPO stake must be treated as `No`, even when the pool reward account delegates to the `AlwaysAbstain` DRep. Yaci Store was incorrectly adding
  `delegateToAutoAbstainDRepStake` to abstain stake for hard fork initiation, which reduced the denominator and could make the SPO threshold pass too early.

  ## Root Cause

  The Conway ledger handles `HardForkInitiation` before default stake pool vote delegation:

  - non-voting SPO + `HardForkInitiation` => counts as `No`
  - non-voting SPO + `DefaultAbstain` applies only for non-hard-fork actions after that branch

  Yaci Store applied `delegateToAutoAbstainDRepStake` unconditionally in `VoteTallyCalculator.computeSPOTallies`, including hard fork initiation actions.

  ## Changes

  - Exclude `delegateToAutoAbstainDRepStake` from SPO abstain stake when the action type is `HARD_FORK_INITIATION_ACTION`.
  - Keep existing default abstain behavior for non-hard-fork actions.
  - Add regression coverage for hard fork initiation and non-hard-fork SPO tally behavior.