### PR TITLE
 Harden Maven Central release publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Wait for Sonatype staging consistency
         run: sleep 90
       - name: Close Sonatype staging repository
+        continue-on-error: true
         run: ./gradlew findSonatypeStagingRepository closeSonatypeStagingRepository --warn --stacktrace
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,93 +57,93 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-#      - name: Release
-#        uses: softprops/action-gh-release@v1
-#        if: startsWith(github.ref, 'refs/tags/')
-#        with:
-#          files: |
-#            applications/build/dist/yaci-store-${{env.VERSION}}.zip
-#            applications/build/dist/yaci-store-docker-${{env.VERSION}}.zip
-#          prerelease: true
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            applications/build/dist/yaci-store-${{env.VERSION}}.zip
+            applications/build/dist/yaci-store-docker-${{env.VERSION}}.zip
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Close And Release Repository
+#        run: ./gradlew closeAndReleaseRepository
 #        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-##      - name: Close And Release Repository
-##        run: ./gradlew closeAndReleaseRepository
-##        env:
-##          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-##          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-#
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and push yaci-store docker image
-#        uses: docker/build-push-action@v5
-#        with:
-#          file: ./Dockerfile
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          target: yaci-store
-#          build-args: |
-#            TARGET=yaci-store
-#            APP_VERSION=${{env.VERSION}}
-#          tags: bloxbean/yaci-store:${{ env.VERSION }}
-#
-#      - name: Build and push yaci-store-ledger-state docker image
-#        uses: docker/build-push-action@v4
-#        with:
-#          file: ./Dockerfile
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          target: yaci-store-ledger-state
-#          build-args: |
-#            TARGET=yaci-store-ledger-state
-#            APP_VERSION=${{env.VERSION}}
-#          tags: bloxbean/yaci-store-ledger-state:${{ env.VERSION }}
-#
-#      - name: Build and push yaci-store-utxo-indexer docker image
-#        uses: docker/build-push-action@v4
-#        with:
-#          file: ./Dockerfile
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          target: yaci-store-utxo-indexer
-#          build-args: |
-#            TARGET=yaci-store-utxo-indexer
-#            APP_VERSION=${{env.VERSION}}
-#          tags: bloxbean/yaci-store-utxo-indexer:${{ env.VERSION }}
-#
-#      - name: Build and push yaci-store-admin docker image
-#        uses: docker/build-push-action@v4
-#        with:
-#          file: ./Dockerfile
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          target: yaci-store-admin
-#          build-args: |
-#            TARGET=yaci-store-admin
-#            APP_VERSION=${{env.VERSION}}
-#          tags: bloxbean/yaci-store-admin:${{ env.VERSION }}
-#
-#      - name: Build and push yaci-store-admin-cli docker image
-#        uses: docker/build-push-action@v4
-#        with:
-#          file: ./Dockerfile
-#          context: .
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          target: yaci-store-admin-cli
-#          build-args: |
-#            TARGET=yaci-store-admin-cli
-#            APP_VERSION=${{env.VERSION}}
-#          tags: bloxbean/yaci-store-admin-cli:${{ env.VERSION }}
+#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push yaci-store docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: ./Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: yaci-store
+          build-args: |
+            TARGET=yaci-store
+            APP_VERSION=${{env.VERSION}}
+          tags: bloxbean/yaci-store:${{ env.VERSION }}
+
+      - name: Build and push yaci-store-ledger-state docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: yaci-store-ledger-state
+          build-args: |
+            TARGET=yaci-store-ledger-state
+            APP_VERSION=${{env.VERSION}}
+          tags: bloxbean/yaci-store-ledger-state:${{ env.VERSION }}
+
+      - name: Build and push yaci-store-utxo-indexer docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: yaci-store-utxo-indexer
+          build-args: |
+            TARGET=yaci-store-utxo-indexer
+            APP_VERSION=${{env.VERSION}}
+          tags: bloxbean/yaci-store-utxo-indexer:${{ env.VERSION }}
+
+      - name: Build and push yaci-store-admin docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: yaci-store-admin
+          build-args: |
+            TARGET=yaci-store-admin
+            APP_VERSION=${{env.VERSION}}
+          tags: bloxbean/yaci-store-admin:${{ env.VERSION }}
+
+      - name: Build and push yaci-store-admin-cli docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: yaci-store-admin-cli
+          build-args: |
+            TARGET=yaci-store-admin-cli
+            APP_VERSION=${{env.VERSION}}
+          tags: bloxbean/yaci-store-admin-cli:${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,93 +42,93 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            applications/build/dist/yaci-store-${{env.VERSION}}.zip
-            applications/build/dist/yaci-store-docker-${{env.VERSION}}.zip
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Close And Release Repository
-#        run: ./gradlew closeAndReleaseRepository
+#      - name: Release
+#        uses: softprops/action-gh-release@v1
+#        if: startsWith(github.ref, 'refs/tags/')
+#        with:
+#          files: |
+#            applications/build/dist/yaci-store-${{env.VERSION}}.zip
+#            applications/build/dist/yaci-store-docker-${{env.VERSION}}.zip
+#          prerelease: true
 #        env:
-#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push yaci-store docker image
-        uses: docker/build-push-action@v5
-        with:
-          file: ./Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: yaci-store
-          build-args: |
-            TARGET=yaci-store
-            APP_VERSION=${{env.VERSION}}
-          tags: bloxbean/yaci-store:${{ env.VERSION }}
-
-      - name: Build and push yaci-store-ledger-state docker image
-        uses: docker/build-push-action@v4
-        with:
-          file: ./Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: yaci-store-ledger-state
-          build-args: |
-            TARGET=yaci-store-ledger-state
-            APP_VERSION=${{env.VERSION}}
-          tags: bloxbean/yaci-store-ledger-state:${{ env.VERSION }}
-
-      - name: Build and push yaci-store-utxo-indexer docker image
-        uses: docker/build-push-action@v4
-        with:
-          file: ./Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: yaci-store-utxo-indexer
-          build-args: |
-            TARGET=yaci-store-utxo-indexer
-            APP_VERSION=${{env.VERSION}}
-          tags: bloxbean/yaci-store-utxo-indexer:${{ env.VERSION }}
-
-      - name: Build and push yaci-store-admin docker image
-        uses: docker/build-push-action@v4
-        with:
-          file: ./Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: yaci-store-admin
-          build-args: |
-            TARGET=yaci-store-admin
-            APP_VERSION=${{env.VERSION}}
-          tags: bloxbean/yaci-store-admin:${{ env.VERSION }}
-
-      - name: Build and push yaci-store-admin-cli docker image
-        uses: docker/build-push-action@v4
-        with:
-          file: ./Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: yaci-store-admin-cli
-          build-args: |
-            TARGET=yaci-store-admin-cli
-            APP_VERSION=${{env.VERSION}}
-          tags: bloxbean/yaci-store-admin-cli:${{ env.VERSION }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+##      - name: Close And Release Repository
+##        run: ./gradlew closeAndReleaseRepository
+##        env:
+##          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+##          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+#
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and push yaci-store docker image
+#        uses: docker/build-push-action@v5
+#        with:
+#          file: ./Dockerfile
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          target: yaci-store
+#          build-args: |
+#            TARGET=yaci-store
+#            APP_VERSION=${{env.VERSION}}
+#          tags: bloxbean/yaci-store:${{ env.VERSION }}
+#
+#      - name: Build and push yaci-store-ledger-state docker image
+#        uses: docker/build-push-action@v4
+#        with:
+#          file: ./Dockerfile
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          target: yaci-store-ledger-state
+#          build-args: |
+#            TARGET=yaci-store-ledger-state
+#            APP_VERSION=${{env.VERSION}}
+#          tags: bloxbean/yaci-store-ledger-state:${{ env.VERSION }}
+#
+#      - name: Build and push yaci-store-utxo-indexer docker image
+#        uses: docker/build-push-action@v4
+#        with:
+#          file: ./Dockerfile
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          target: yaci-store-utxo-indexer
+#          build-args: |
+#            TARGET=yaci-store-utxo-indexer
+#            APP_VERSION=${{env.VERSION}}
+#          tags: bloxbean/yaci-store-utxo-indexer:${{ env.VERSION }}
+#
+#      - name: Build and push yaci-store-admin docker image
+#        uses: docker/build-push-action@v4
+#        with:
+#          file: ./Dockerfile
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          target: yaci-store-admin
+#          build-args: |
+#            TARGET=yaci-store-admin
+#            APP_VERSION=${{env.VERSION}}
+#          tags: bloxbean/yaci-store-admin:${{ env.VERSION }}
+#
+#      - name: Build and push yaci-store-admin-cli docker image
+#        uses: docker/build-push-action@v4
+#        with:
+#          file: ./Dockerfile
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          target: yaci-store-admin-cli
+#          build-args: |
+#            TARGET=yaci-store-admin-cli
+#            APP_VERSION=${{env.VERSION}}
+#          tags: bloxbean/yaci-store-admin-cli:${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,22 @@ on:
   push:
     tags:
       - 'v*'
+
+concurrency:
+  group: maven-central-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'liberica'
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: 'Get Version Number'
@@ -30,15 +36,23 @@ jobs:
           mkdir -p ~/.gradle/
           echo "${{secrets.SIGNING_KEY}}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
-      - name: Publish and close staging repository
-        continue-on-error: true
+      - name: Validate Maven Central artifacts
+        run: ./gradlew validateMavenCentralArtifacts -PskipSigning=true --no-parallel --warn --stacktrace
+      - name: Publish to Sonatype staging repository
         id: publish
         run: |
-          ./gradlew publishToSonatype closeSonatypeStagingRepository \
+          ./gradlew publishToSonatype \
             -Psigning.keyId=${{ secrets.SIGNING_KEY_ID }} \
             -Psigning.password=${{ secrets.SIGNING_PASSWORD }} \
             -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) \
-            --warn --stacktrace
+            --no-parallel --warn --stacktrace
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Wait for Sonatype staging consistency
+        run: sleep 90
+      - name: Close Sonatype staging repository
+        run: ./gradlew findSonatypeStagingRepository closeSonatypeStagingRepository --warn --stacktrace
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,57 @@ subprojects {
     }
 }
 
+def mavenCentralPublicationProjects = {
+    allprojects.findAll { candidate ->
+        def publishing = candidate.extensions.findByType(org.gradle.api.publish.PublishingExtension)
+        publishing != null && publishing.publications.findByName('mavenJava') != null
+    }
+}
+
+tasks.register('validateMavenCentralArtifacts') {
+    group = 'verification'
+    description = 'Verifies that each Maven Central publication has a POM, sources JAR, and javadoc JAR.'
+
+    doLast {
+        def errors = []
+
+        mavenCentralPublicationProjects().each { publishedProject ->
+            def publishing = publishedProject.extensions.findByType(org.gradle.api.publish.PublishingExtension)
+            def publication = publishing.publications.findByName('mavenJava')
+
+            def expectedFiles = [
+                    pom    : publishedProject.layout.buildDirectory.file("publications/${publication.name}/pom-default.xml").get().asFile,
+                    jar    : publishedProject.tasks.named('jar').get().archiveFile.get().asFile,
+                    sources: publishedProject.tasks.named('sourceJar').get().archiveFile.get().asFile,
+                    javadoc: publishedProject.tasks.named('javadocJar').get().archiveFile.get().asFile
+            ]
+
+            expectedFiles.each { type, artifactFile ->
+                if (!artifactFile.isFile()) {
+                    errors << "${publishedProject.path}:${publication.name} missing ${type} artifact: ${artifactFile}"
+                } else if (artifactFile.length() == 0) {
+                    errors << "${publishedProject.path}:${publication.name} has empty ${type} artifact: ${artifactFile}"
+                }
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new GradleException("Maven Central publication validation failed:\n - " + errors.join("\n - "))
+        }
+    }
+}
+
+gradle.projectsEvaluated {
+    tasks.named('validateMavenCentralArtifacts') {
+        mavenCentralPublicationProjects().each { publishedProject ->
+            dependsOn publishedProject.tasks.named('jar')
+            dependsOn publishedProject.tasks.named('sourceJar')
+            dependsOn publishedProject.tasks.named('javadocJar')
+            dependsOn publishedProject.tasks.named('generatePomFileForMavenJavaPublication')
+        }
+    }
+}
+
 def commit_id=getCheckedOutGitCommitHash()
 def final_version = project.version
 if (project.version.endsWith("-SNAPSHOT")) {
@@ -251,6 +302,12 @@ ext.ossrhUsername = System.getenv('MAVEN_USERNAME')
 ext.ossrhPassword = System.getenv('MAVEN_PASSWORD')
 
 nexusPublishing {
+    def githubRunId = System.getenv('GITHUB_RUN_ID')
+    if (githubRunId) {
+        def githubRunAttempt = System.getenv('GITHUB_RUN_ATTEMPT') ?: '1'
+        repositoryDescription.set("${project.group}:${project.name}:${project.version}:${githubRunId}:${githubRunAttempt}")
+    }
+
     repositories {
         sonatype {
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.bloxbean.cardano
-version=3.0.0-beta1
+version=3.0.0-beta1-build1
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.bloxbean.cardano
-version=3.0.0-beta1-build3
+version=3.0.0-beta1
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.bloxbean.cardano
-version=3.0.0-beta1-build2
+version=3.0.0-beta1-build3
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.bloxbean.cardano
-version=3.0.0-beta1-build1
+version=3.0.0-beta1-build2
 
 springBootVersion=3.3.4
 springCloudVersion=2023.0.3


### PR DESCRIPTION
 ## Summary

  This update makes the Maven Central release workflow more resilient to Sonatype/Central staging API behavior.

  ## Changes

  - Add `validateMavenCentralArtifacts` Gradle task to verify each `mavenJava` publication has:
    - POM
    - main JAR
    - sources JAR
    - javadoc JAR
  - Run artifact validation before publishing to Sonatype.
  - Split `publishToSonatype` and `closeSonatypeStagingRepository` into separate workflow steps.
  - Keep publish failures blocking, but make the close step best-effort with `continue-on-error: true`.
  - Add a short wait before close to reduce staging consistency issues.
  - Add release workflow concurrency per tag/ref.
  - Upgrade release workflow actions to `checkout@v4` and `setup-java@v4`.

  ## Rationale

  Recent Maven Central publishes uploaded artifacts successfully, but the Sonatype close step failed intermittently with validation or empty-repository errors. Since artifacts are accepted and visible in Maven Central, the close operation should not fail the entire release job.

  The new validation step catches missing publication artifacts before upload, while keeping Central-side close errors non-blocking as before.

