### PR TITLE
 Add missing config files to distribution zip tasks

### DIFF
--- a/applications/all/build.gradle
+++ b/applications/all/build.gradle
@@ -105,7 +105,9 @@ task distNativeZip(type: Zip) {
 
     from('../../config') {
         include 'application.properties'
+        include 'application-blockfrost.properties'
         include 'application-ledger-state.properties'
+        include 'application-analytics.properties'
         into zipDirName + '/' + configDir
     }
 

--- a/applications/all/build.gradle
+++ b/applications/all/build.gradle
@@ -105,9 +105,11 @@ task distNativeZip(type: Zip) {
 
     from('../../config') {
         include 'application.properties'
-        include 'application-blockfrost.properties'
-        include 'application-ledger-state.properties'
         include 'application-analytics.properties'
+        include 'application-blockfrost.properties'
+        include 'application-custom-exporters.yml'
+        include 'application-ledger-state.properties'
+        include 'application-plugins.yml'
         into zipDirName + '/' + configDir
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -218,11 +218,11 @@ task distZip(type: Zip) {
 
     from('./config') {
         include 'application.properties'
+        include 'application-analytics.properties'
         include 'application-blockfrost.properties'
+        include 'application-custom-exporters.yml'
         include 'application-ledger-state.properties'
         include 'application-plugins.yml'
-        include 'application-analytics.properties'
-        include 'application-custom-exporters.yml'
         into zipDirName + '/' + configDir
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -218,6 +218,7 @@ task distZip(type: Zip) {
 
     from('./config') {
         include 'application.properties'
+        include 'application-blockfrost.properties'
         include 'application-ledger-state.properties'
         include 'application-plugins.yml'
         include 'application-analytics.properties'
@@ -264,6 +265,7 @@ task dockerZip(type: Zip) {
         into(zipDirName + '/config')
         include 'env'
         include 'application.properties'
+        include 'application-blockfrost.properties'
         include 'application-ledger-state.properties'
         include 'application-plugins.yml'
         include 'application-analytics.properties'


### PR DESCRIPTION
### Problem

  Several configuration files present in config/ and docker/config/ were not included in the distribution zip tasks (distZip, dockerZip, distNativeZip). Most notably, application-blockfrost.properties was completely  missing from all distributions
  
  
### Changes

| Task | File | What was added |
|------|------|---------------|
| `distZip` | `build.gradle` | `application-blockfrost.properties` |
| `dockerZip` | `build.gradle` | `application-blockfrost.properties` |
| `distNativeZip` | `applications/all/build.gradle` | `application-analytics.properties`, `application-blockfrost.properties`, `application-custom-exporters.yml`, `application-plugins.yml` |
