### PR TITLE
docs: add blockfrost api docs

### DIFF
--- a/docs/app/docs/v2/_meta.js
+++ b/docs/app/docs/v2/_meta.js
@@ -4,6 +4,7 @@ export default {
   "usage": "Usage",
   "stores": "Stores",
   "api-reference": "API Reference",
+  "blockfrost": "Blockfrost APIs",
   "plugins": "Plugin Framework",
   "analytics": "Analytics Store",
   "advanced-configuration": "Advanced Configuration",

--- a/docs/app/docs/v2/blockfrost/_meta.js
+++ b/docs/app/docs/v2/blockfrost/_meta.js
@@ -1,0 +1,6 @@
+export default {
+  "overview": "Overview",
+  "configuration": "Configuration",
+  "endpoints": "Supported Endpoints",
+  "indexes": "Database Indexes"
+}

--- a/docs/app/docs/v2/blockfrost/configuration/page.mdx
+++ b/docs/app/docs/v2/blockfrost/configuration/page.mdx
@@ -1,0 +1,93 @@
+import { Callout } from 'nextra/components'
+
+# Configuration
+
+## Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `store.extensions.blockfrost.enabled` | `false` | Master switch. The Blockfrost auto-configuration only loads when this is `true`. |
+| `store.extensions.blockfrost.account.enabled` | `true` | Account / stake-address endpoints (`/accounts`). |
+| `store.extensions.blockfrost.address.enabled` | `true` | Address and address-UTXO endpoints (`/addresses`). |
+| `store.extensions.blockfrost.asset.enabled` | `true` | Native asset and policy endpoints (`/assets`). |
+| `store.extensions.blockfrost.blocks.enabled` | `true` | Block and block-tx endpoints (`/blocks`). |
+| `store.extensions.blockfrost.epoch.enabled` | `true` | Epoch and protocol-parameter endpoints (`/epochs`). |
+| `store.extensions.blockfrost.metadata.enabled` | `true` | Transaction metadata-by-label endpoints (`/metadata/txs`). |
+| `store.extensions.blockfrost.scripts.enabled` | `true` | Script and datum endpoints (`/scripts`). |
+| `store.extensions.blockfrost.transaction.enabled` | `true` | Transaction read endpoints (`/txs`) and tx submit (`/tx/submit`). |
+| `store.extensions.blockfrost.util.enabled` | `true` | Tx execution-units evaluate and xpub-derive utilities (`/utils`). |
+| `blockfrost.apiPrefix` | _(none — required)_ | URL prefix prepended to every Blockfrost controller path. Set by the `blockfrost` profile to `/api/v1/blockfrost`. |
+
+<Callout type="info">
+`store.extensions.blockfrost.enabled` gates the entire extension. When it is `false` (the default), the auto-configuration does not load and the sub-module flags have no effect. When it is `true`, all sub-module flags default to `true`, so a single line is enough to enable the full surface.
+</Callout>
+
+## Profile shortcut
+
+A ready-made profile lives at `config/application-blockfrost.properties` (and the same file under `docker/config/`). Activate it instead of editing your own configuration:
+
+```bash
+SPRING_PROFILES_ACTIVE=ledger-state,blockfrost
+```
+
+The profile sets `store.extensions.blockfrost.enabled=true` and overrides `blockfrost.apiPrefix=/api/v1/blockfrost` so the Blockfrost endpoints don't collide with yaci-store's own `/api/v1/...` controllers.
+
+## API base path
+
+`blockfrost.apiPrefix` is a required property when the extension is enabled — every Blockfrost controller is mapped under `${blockfrost.apiPrefix}`. It has no default; if missing, the application fails to start.
+
+The `blockfrost` profile sets it for you:
+
+```properties
+blockfrost.apiPrefix=/api/v1/blockfrost
+```
+
+Set it explicitly when not using that profile:
+
+```properties
+blockfrost.apiPrefix=/api/v1/blockfrost
+```
+
+<Callout type="info">
+Yaci-store's native stores-api controllers use a separate `apiPrefix` property (`/api/v1` in the bundled apps). Keeping `blockfrost.apiPrefix` distinct (e.g. `/api/v1/blockfrost`) prevents path collisions between the two surfaces.
+</Callout>
+
+## Store dependencies
+
+Blockfrost controllers read from data the underlying yaci-store modules have indexed. The bundled `applications/all` distribution enables every store by default, so no extra wiring is needed.
+<Callout type="info">
+**Recommended: activate `ledger-state` alongside `blockfrost`.** Account info, rewards, and epoch-stake data depend on values that are only computed when the `ledger-state` profile is active. Without it, those endpoints return empty or partial responses.
+
+```bash
+SPRING_PROFILES_ACTIVE=ledger-state,blockfrost
+```
+</Callout>
+
+## Transaction submit
+
+`POST /tx/submit` routes through the `submit` component. It tries backends in this order; the first one configured wins:
+
+1. **Submit API** — set `store.cardano.submit-api-url` (Recommended)
+2. **Ogmios** — set `store.cardano.ogmios-url`.
+3. **Local node-to-client socket** — set `store.cardano.n2c-node-socket-path` (or `store.cardano.n2c-host` + `store.cardano.n2c-port`).
+
+Configuring more than one is fine — the priority above decides which is used. If none is configured, `/tx/submit` returns `500`. See `config/application.properties` for the full submission options.
+
+## Transaction evaluation
+
+`POST /utils/txs/evaluate*` runs through a separate evaluator selected by `store.submit.tx-evaluator-mode`:
+
+| Value | Backend | Requires |
+|---|---|---|
+| `SCALUS` _(default)_ | Local Scalus evaluator embedded in the JVM | None |
+| `OGMIOS` | Remote Ogmios | `store.cardano.ogmios-url` |
+
+The evaluator setting is independent of the submit priority above — for example, you can submit through Submit API while evaluating with Scalus locally.
+
+## Health check
+
+After enabling, confirm the API is reachable (path depends on your `blockfrost.apiPrefix`):
+
+```bash
+curl http://localhost:8080/api/v1/blockfrost/blocks/latest
+```

--- a/docs/app/docs/v2/blockfrost/endpoints/page.mdx
+++ b/docs/app/docs/v2/blockfrost/endpoints/page.mdx
@@ -1,0 +1,100 @@
+import { Callout } from 'nextra/components'
+
+# Supported Endpoints
+
+This page lists which Blockfrost resource groups yaci-store exposes and what each group covers. Per-endpoint request and response contracts follow the [official Blockfrost OpenAPI spec](https://docs.blockfrost.io) — link to the relevant tag from each section below.
+
+All paths are prefixed with `${blockfrost.apiPrefix}`. The `blockfrost` profile sets it to `/api/v1/blockfrost`; the examples below use that value.
+
+<Callout type="info">
+Activate the `ledger-state` Spring profile alongside `blockfrost` for full data coverage. Account, rewards, and epoch-stake data depend on values that are only computed when `ledger-state` is on.
+</Callout>
+
+## Summary
+
+| Group | Base path | Config flag |
+|---|---|---|
+| Blocks | `/blocks` | `store.extensions.blockfrost.blocks.enabled` |
+| Epochs | `/epochs` | `store.extensions.blockfrost.epoch.enabled` |
+| Transactions | `/txs` | `store.extensions.blockfrost.transaction.enabled` |
+| Tx Submit | `/tx/submit` | `store.extensions.blockfrost.transaction.enabled` |
+| Addresses | `/addresses` | `store.extensions.blockfrost.address.enabled` |
+| Accounts | `/accounts` | `store.extensions.blockfrost.account.enabled` |
+| Assets | `/assets` | `store.extensions.blockfrost.asset.enabled` |
+| Scripts | `/scripts` | `store.extensions.blockfrost.scripts.enabled` |
+| Metadata | `/metadata/txs` | `store.extensions.blockfrost.metadata.enabled` |
+| Utilities | `/utils` | `store.extensions.blockfrost.util.enabled` |
+
+## Blocks
+
+Base path: `/blocks` — block lookup by hash, number, slot, or epoch+slot, plus block-relative navigation (`next`, `previous`), block transaction lists (with optional CBOR), and addresses involved in a block.
+
+Includes a `latest` shortcut: `GET /blocks/latest`, `GET /blocks/latest/txs`, `GET /blocks/latest/txs/cbor`.
+
+Reference: [Blockfrost — Cardano Blocks](https://docs.blockfrost.io/#tag/cardano--blocks).
+
+## Epochs
+
+Base path: `/epochs` — epoch info, `latest` shortcut, neighbours (`next`, `previous`), protocol parameters per epoch (and `latest/parameters`), epoch stake by pool, and blocks produced per pool.
+
+Reference: [Blockfrost — Cardano Epochs](https://docs.blockfrost.io/#tag/cardano--epochs).
+
+## Transactions
+
+Base path: `/txs` — transaction details, inputs and outputs, raw CBOR, metadata (JSON and CBOR), redeemers, stake-related certificates, delegations, withdrawals, MIRs, pool updates and retirements, and required signers.
+
+Reference: [Blockfrost — Cardano Transactions](https://docs.blockfrost.io/#tag/cardano--transactions).
+
+## Tx Submit
+
+Base path: `/tx/submit` — `POST` a CBOR-serialized transaction (`Content-Type: application/cbor`). The response body is the transaction hash.
+
+Submission is delegated to the `submit` component. See [Configuration → Transaction submit](/docs/v2/blockfrost/configuration#transaction-submit).
+
+Reference: [Blockfrost — Submit a transaction](https://docs.blockfrost.io/#tag/cardano--transactions/POST/tx/submit).
+
+## Addresses
+
+Base path: `/addresses` — address info (default and `extended`), totals, UTXOs (filterable by asset), and transactions touching the address.
+
+Reference: [Blockfrost — Cardano Addresses](https://docs.blockfrost.io/#tag/cardano--addresses).
+
+<Callout type="warning">
+The internal `address` table is populated only when `store.utxo.save-address=true`. Without it, address-derived endpoints may return empty results for newly indexed data.
+</Callout>
+
+## Accounts
+
+Base path: `/accounts` (stake addresses) — account info, reward history, account history, delegations, registrations, withdrawals, MIRs, the payment addresses linked to a stake account, asset holdings across those addresses, totals, UTXOs, and transactions.
+
+Reference: [Blockfrost — Cardano Accounts](https://docs.blockfrost.io/#tag/cardano--accounts).
+
+## Assets
+
+Base path: `/assets` — list assets, asset details, history, transactions, holding addresses, and per-policy listings.
+
+Reference: [Blockfrost — Cardano Assets](https://docs.blockfrost.io/#tag/cardano--assets).
+
+## Scripts
+
+Base path: `/scripts` — list scripts, script details, JSON or CBOR script body, script redeemers, and datum lookup by datum hash (JSON or CBOR).
+
+Reference: [Blockfrost — Cardano Scripts](https://docs.blockfrost.io/#tag/cardano--scripts).
+
+## Metadata
+
+Base path: `/metadata/txs` — list metadata labels (`/labels`), and look up transactions by label as JSON (`/labels/{label}`) or CBOR (`/labels/{label}/cbor`).
+
+Reference: [Blockfrost — Cardano Metadata](https://docs.blockfrost.io/#tag/cardano--metadata).
+
+## Utilities
+
+Base path: `/utils` — yaci-store-specific helpers that follow Blockfrost conventions:
+
+- `POST /utils/txs/evaluate` — evaluate execution units for a CBOR-serialized transaction. Body: raw CBOR (`Content-Type: application/cbor`). Optional query param: `version` (default `5`).
+- `POST /utils/txs/evaluate/utxos` — same, with an additional UTXO set supplied alongside the transaction. Body: JSON `{ "cbor": "...", "additionalUtxoSet": [...] }`.
+- `GET /utils/addresses/xpub/{xpub}/{role}/{index}` — derive a Shelley address from an xpub, role, and index.
+
+Evaluation requires a configured tx-evaluation backend (Ogmios, or a Scalus-backed local evaluator surfaced through the `submit` component).
+
+Reference: [Blockfrost — Utilities](https://docs.blockfrost.io/#tag/cardano--utilities).

--- a/docs/app/docs/v2/blockfrost/indexes/page.mdx
+++ b/docs/app/docs/v2/blockfrost/indexes/page.mdx
@@ -1,0 +1,36 @@
+import { Callout } from 'nextra/components'
+
+# Database Indexes
+
+Some Blockfrost endpoints — address lookups, asset history, transaction filters — run faster with extra database indexes that are not part of the default index set. These optional indexes ship as `blockfrost-index` and can be applied through the Admin CLI.
+
+<Callout type="info">
+Indexes are recommended for production use. Without them, some endpoints still work but can be slow on large datasets, especially on mainnet.
+</Callout>
+
+## Apply the Blockfrost indexes
+
+Run the Admin CLI after the initial sync is complete:
+
+```bash
+./admin-cli.sh apply-optional-indexes --indexes blockfrost-index
+```
+
+In an interactive Admin CLI prompt, run the same command without the script name:
+
+```bash
+yaci-store> apply-optional-indexes --indexes blockfrost-index
+```
+
+The command reads `blockfrost-index.yml` from the classpath. You can also pass a custom YAML file with `--index-files`.
+
+## When to apply
+
+- Run it once after the initial sync and before exposing the Blockfrost API to clients.
+- Run it again after upgrading if the release adds new Blockfrost indexes.
+- Avoid running it during the initial sync because index creation can slow down writes.
+
+<Callout type="warning">
+`verify-indexes` checks the default `index.yml` and `extra-index.yml` sets. It does not check `blockfrost-index.yml`.
+</Callout>
+

--- a/docs/app/docs/v2/blockfrost/overview/page.mdx
+++ b/docs/app/docs/v2/blockfrost/overview/page.mdx
@@ -1,0 +1,63 @@
+import { Callout } from 'nextra/components'
+
+# Blockfrost APIs
+
+Yaci Store ships REST endpoints whose paths and response shapes follow the [Blockfrost API](https://docs.blockfrost.io).
+<Callout type="info">
+The Blockfrost-compatible API Support is available since **3.0.0-beta3**, and sub-modules now auto-enable with the parent flag.
+</Callout>
+
+## Sub-modules
+
+The Blockfrost extension is composed of nine sub-modules, each backing one resource group:
+
+| Sub-module | Provides |
+|---|---|
+| `address` | Address info, UTXOs, transactions |
+| `account` | Stake-account info, rewards, delegations, history |
+| `asset` | Native assets, policy listings, asset history |
+| `block` | Block lookup, block transactions, block addresses |
+| `epoch` | Epoch info, protocol parameters, epoch stake |
+| `metadata` | Transaction metadata by label |
+| `scripts` | Scripts, datums, redeemers |
+| `transaction` | Transaction details, IO, certificates, withdrawals, and tx submit |
+| `util` | Tx execution-units evaluation and xpub-derived addresses |
+
+Each sub-module loads only when the parent extension is enabled, and can be disabled individually. See [Configuration](/docs/v2/blockfrost/configuration).
+
+## Modules in development
+
+The following Blockfrost modules are still in development and will be added in later Yaci Store releases:
+
+- **Pools**
+- **Governance**
+- **Network**
+
+## Quickstart
+
+**1. Enable the extension** in `application.properties` (or use the bundled `blockfrost` profile, which sets both lines for you):
+
+```properties
+store.extensions.blockfrost.enabled=true
+blockfrost.apiPrefix=/api/v1/blockfrost
+```
+
+`blockfrost.apiPrefix` has no default and is required — without it, the app fails to start.
+
+**2. Start yaci-store** and let it sync.
+
+**3. Test the latest block** to confirm the API is up:
+
+```bash
+curl http://localhost:8080/api/v1/blockfrost/blocks/latest
+```
+
+A JSON response with `hash`, `slot`, `epoch`, etc. means the extension is wired correctly.
+
+## API base path
+
+All Blockfrost controllers are mapped under `${blockfrost.apiPrefix}`. The `blockfrost` profile sets it to `/api/v1/blockfrost` so Blockfrost endpoints stay separate from yaci-store's own `/api/v1/...` controllers. See [Configuration → API base path](/docs/v2/blockfrost/configuration#api-base-path).
+
+## Endpoint contracts
+
+Request and response formats follow the official Blockfrost OpenAPI spec. Use [docs.blockfrost.io](https://docs.blockfrost.io) as the per-endpoint reference; this section only documents what is enabled and how to call it. See [Supported Endpoints](/docs/v2/blockfrost/endpoints) for the endpoint-group map.


### PR DESCRIPTION
## Summary

  Add a new **Blockfrost APIs** section to the v2 docs.

## Changes

  - Add Blockfrost docs navigation under `docs/app/docs/v2/blockfrost/`
  - Add overview page with supported sub-modules and modules in development
  - Add configuration page for enabling the Blockfrost extension and setting `blockfrost.apiPrefix`
  - Add supported endpoints page with base paths and module flags
  - Add database indexes page for applying `blockfrost-index` through Admin CLI
  - Register the new section in `docs/app/docs/v2/_meta.js`