### PR TITLE
 docs: add scope-indexer tutorials for NFT mints and Conway governance

### DIFF
--- a/docs/app/docs/v2/tutorials/_meta.js
+++ b/docs/app/docs/v2/tutorials/_meta.js
@@ -1,3 +1,5 @@
 export default {
-  "tracking-address-utxos": "Tracking UTXOs for a Specific Address"
+  "tracking-address-utxos": "Tracking UTXOs for a Specific Address",
+  "tracking-nft-mints": "Indexing NFT Mints for a Policy",
+  "governance-watch": "A Minimal Conway Governance Indexer"
 }

--- a/docs/app/docs/v2/tutorials/governance-watch/page.mdx
+++ b/docs/app/docs/v2/tutorials/governance-watch/page.mdx
@@ -1,0 +1,381 @@
+---
+title: "A Minimal Conway Governance Indexer"
+---
+
+import { Callout } from 'nextra/components'
+
+# A Minimal Conway Governance Indexer (Governance Watch)
+
+## Introduction
+
+In this tutorial you'll build a **scope indexer** focused entirely on **Cardano governance** (the Conway era / [CIP-1694](https://cips.cardano.org/cip/CIP-1694)). Instead of indexing the whole chain, you'll keep only governance **proposals** and **votes**, and you'll narrow even further to the **action types you care about** — for example, treasury withdrawals and protocol-parameter changes.
+
+**What will you build?**
+By the end of this tutorial, you'll have a running Yaci Store instance that:
+- Synchronizes with the Cardano blockchain
+- Stores **only governance data** (proposals, votes, DReps) — every other store is off
+- Uses an **MVEL filter** to keep only selected governance action types
+- Uses an **MVEL post-action** to log new proposals as they're indexed
+- Lets you compute a live **YES / NO / ABSTAIN tally** per proposal with plain SQL
+
+**Why is this useful?**
+- Treasury and community monitors who want to watch specific governance actions
+- DRep tooling and dashboards that need proposal and vote data without a full chain index
+- Researchers analyzing on-chain participation in CIP-1694 governance
+
+**What you'll learn:**
+- How to scope Yaci Store to the `governance` store only
+- How to write an **MVEL filter** that matches on an enum (`GovActionType`)
+- How to write an **MVEL post-action** that aggregates data in plugin state
+- How to query proposals and tally votes from PostgreSQL
+
+<Callout type="info">
+This tutorial assumes you're comfortable with the basics from [Tracking UTXOs for a Specific Address](/docs/v2/tutorials/tracking-address-utxos) or [Indexing NFT Mints for a Policy](/docs/v2/tutorials/tracking-nft-mints). It introduces a second plugin type (post-actions) and enum-based filtering.
+</Callout>
+
+---
+
+## Prerequisites
+
+- **Docker and Docker Compose** installed
+  - [Install Docker Desktop](https://www.docker.com/products/docker-desktop/) (Mac/Windows) or [Docker Engine](https://docs.docker.com/engine/install/) (Linux)
+- **Basic familiarity with Cardano governance** (proposals, votes, DReps). The [Governance Guide](https://cips.cardano.org/cip/CIP-1694) is a good primer.
+- **Estimated time:** 25-35 minutes
+
+<Callout type="info">
+Governance data only exists from the **Conway era** onward. The **preprod** testnet (protocol magic `1`) is in the Conway era and has active governance, so we'll use it here.
+</Callout>
+
+---
+
+## Step 1: Download Yaci Store
+
+1. Download the Docker distribution from the [Yaci Store releases page](https://github.com/bloxbean/yaci-store/releases) (`yaci-store-docker-<version>.zip`).
+
+2. Extract and enter the folder:
+
+   ```bash
+   unzip yaci-store-docker-<version>.zip
+   cd yaci-store-docker-<version>
+   ```
+
+   The relevant files are `yaci-store.sh`, `psql.sh`, `config/` (with `env`, `application.properties`, `application-plugins.yml`), and `plugins/`.
+
+---
+
+## Step 2: Configure Network Connection
+
+Edit `config/application.properties` and connect to **preprod**:
+
+```properties
+# Cardano Network Configuration
+store.cardano.host=preprod-node.play.dev.cardano.org
+store.cardano.port=3001
+store.cardano.protocol-magic=1
+```
+
+The database settings come pre-configured:
+
+```properties
+spring.datasource.url=jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=yaci_store
+spring.datasource.username=yaci
+spring.datasource.password=dbpass
+```
+
+<Callout type="warning">
+These are development credentials. Change the database password for any production deployment.
+</Callout>
+
+---
+
+## Step 3: Scope to Governance Only
+
+Disable every store except `governance`. That single store captures proposals, votes, DReps, and committee data.
+
+```properties
+# Disable everything we don't need
+store.blocks.enabled=false
+store.transaction.enabled=false
+store.utxo.enabled=false
+store.assets.enabled=false
+store.epoch.enabled=false
+store.mir.enabled=false
+store.script.enabled=false
+store.staking.enabled=false
+store.metadata.enabled=false
+
+# Keep governance — this is our scope
+store.governance.enabled=true
+```
+
+**Choosing a start slot.** Governance proposals are sparse, so syncing from genesis is wasteful. Set a start slot **before** the proposals you want to capture. Proposals submitted earlier than this slot won't be indexed.
+
+```properties
+# Start before the proposals you want to capture.
+# Lower this value to backfill older proposals; raise it to only see new activity.
+store.cardano.sync-start-slot=107754724
+store.cardano.sync-start-blockhash=534d3c2d1c3915523ea8843449dd91fcf4d647719d9ef2dc64a97d47be39447b
+```
+
+<Callout type="info">
+Get a recent preprod slot/block hash from [Cardano Explorer (Preprod)](https://preprod.cardanoscan.io/). To study currently-active proposals, pick a slot from a few epochs back so their submission falls inside your sync window.
+</Callout>
+
+---
+
+## Step 4: Enable the Plugin System
+
+### 4.1 Enable Plugin Loading
+
+In `config/env`, uncomment:
+
+```bash
+JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+```
+
+### 4.2 Turn on Plugins
+
+In `config/application-plugins.yml`:
+
+```yaml
+store:
+  plugins:
+    enabled: true
+```
+
+---
+
+## Step 5: Filter Governance Actions by Type
+
+Now we narrow our scope **inside** the governance domain. The **`governance.gov_action_proposal.save`** extension point runs for every proposal before it's saved. Its domain object is [`GovActionProposal`](/docs/v2/plugins/plugin-api-guide#govactionproposal), whose `type` field is a `GovActionType` enum.
+
+The full set of governance action types is:
+
+| `GovActionType` value          | Meaning                          |
+| ------------------------------ | -------------------------------- |
+| `PARAMETER_CHANGE_ACTION`      | Protocol parameter change        |
+| `HARD_FORK_INITIATION_ACTION`  | Hard fork initiation             |
+| `TREASURY_WITHDRAWALS_ACTION`  | Treasury withdrawal              |
+| `NO_CONFIDENCE`                | Motion of no confidence          |
+| `UPDATE_COMMITTEE`             | Update the constitutional committee |
+| `NEW_CONSTITUTION`             | New constitution                 |
+| `INFO_ACTION`                  | Informational action             |
+
+We'll keep only treasury withdrawals and parameter changes. Replace the contents of `config/application-plugins.yml` with:
+
+```yaml
+store:
+  plugins:
+    enabled: true
+    api-enabled: false
+    metrics:
+      enabled: false
+
+    # Filters run BEFORE data is saved. Keep only the action types we care about.
+    filters:
+      governance.gov_action_proposal.save:
+        - name: "Watch treasury & parameter actions"
+          lang: mvel
+          expression: 'type.name() == "TREASURY_WITHDRAWALS_ACTION" || type.name() == "PARAMETER_CHANGE_ACTION"'
+          exit-on-error: false
+
+    # Post-actions run AFTER data is saved (they cannot modify it).
+    # Here we just log new proposals and keep a running count in plugin state.
+    post-actions:
+      governance.gov_action_proposal.save:
+        - name: "Log new proposals"
+          lang: mvel
+          inline-script: |
+            count = state.get('proposalCount');
+            if (count == null) count = 0;
+            count = count + items.size();
+            state.put('proposalCount', count);
+            for (p : items) {
+                System.out.println("New governance proposal: " + p.type
+                    + " | deposit=" + p.deposit + " | tx=" + p.txHash);
+            }
+          exit-on-error: false
+```
+
+**How this works:**
+- The **filter** keeps a proposal only when its `type` is one of the two we selected. `type` is an enum, so we compare with `type.name()` (the [Plugin API Guide](/docs/v2/plugins/plugin-api-guide#governance-store-extension-points-conway-era) explains enum access). You could also filter by size with `deposit > 50000000000`.
+- The **post-action** receives the saved proposals as `items` (a list of `GovActionProposal`), increments a counter in plugin `state`, and prints each one to the logs.
+
+<Callout type="info">
+**Want to index every proposal type?** Remove the `filters:` block (or widen the expression). The `governance` store on its own is already a scope — the filter simply narrows it further.
+</Callout>
+
+**About votes.** We deliberately don't filter votes, so the `voting_procedure` table captures every vote. When we query, we'll join votes back to the proposals we kept, so only relevant tallies appear.
+
+<Callout type="info">
+To capture only DRep votes (ignoring SPO and committee votes), add a filter on the vote extension point:
+
+```yaml
+      governance.voting_procedure.save:
+        - name: "DRep votes only"
+          lang: mvel
+          expression: 'voterType.name() == "DREP_KEY_HASH" || voterType.name() == "DREP_SCRIPT_HASH"'
+          exit-on-error: false
+```
+
+The `VoterType` enum also includes `CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH`, `CONSTITUTIONAL_COMMITTEE_HOT_SCRIPT_HASH`, and `STAKING_POOL_KEY_HASH`.
+</Callout>
+
+---
+
+## Step 6: Start Yaci Store
+
+```bash
+./yaci-store.sh start
+```
+
+Watch the logs — you'll see your post-action print each new proposal:
+
+```bash
+./yaci-store.sh logs:yaci-store
+```
+
+---
+
+## Step 7: Query Proposals and Tally Votes
+
+1. **Connect to the database**
+
+   ```bash
+   ./psql.sh
+   ```
+
+2. **Set the schema**
+
+   ```sql
+   SET search_path TO yaci_store;
+   ```
+
+3. **List the proposals you captured**
+
+   ```sql
+   SELECT
+     tx_hash,
+     idx           AS proposal_index,
+     type          AS action_type,
+     deposit,
+     return_address,
+     epoch
+   FROM gov_action_proposal
+   ORDER BY slot DESC;
+   ```
+
+   Every row is a treasury-withdrawal or parameter-change proposal (the types our filter kept).
+
+4. **Tally YES / NO / ABSTAIN per proposal**
+
+   Votes reference a proposal by `gov_action_tx_hash` + `gov_action_index`. Join them to your proposals and pivot the `vote` column:
+
+   ```sql
+   SELECT
+     p.tx_hash,
+     p.idx                                                   AS proposal_index,
+     p.type                                                  AS action_type,
+     COUNT(v.*) FILTER (WHERE v.vote = 'YES')                AS yes,
+     COUNT(v.*) FILTER (WHERE v.vote = 'NO')                 AS no,
+     COUNT(v.*) FILTER (WHERE v.vote = 'ABSTAIN')            AS abstain
+   FROM gov_action_proposal p
+   LEFT JOIN voting_procedure v
+     ON v.gov_action_tx_hash = p.tx_hash
+    AND v.gov_action_index   = p.idx
+   GROUP BY p.tx_hash, p.idx, p.type
+   ORDER BY (yes + no + abstain) DESC;
+   ```
+
+5. **Break a tally down by voter type** (DRep vs SPO vs committee)
+
+   ```sql
+   SELECT
+     v.gov_action_tx_hash,
+     v.gov_action_index,
+     v.voter_type,
+     v.vote,
+     COUNT(*) AS votes
+   FROM voting_procedure v
+   GROUP BY v.gov_action_tx_hash, v.gov_action_index, v.voter_type, v.vote
+   ORDER BY v.gov_action_tx_hash, v.voter_type;
+   ```
+
+6. **Exit**
+
+   ```sql
+   \q
+   ```
+
+<Callout type="info">
+No proposals yet? Conway governance activity is sparse on preprod. Lower `store.cardano.sync-start-slot` to backfill older epochs, and confirm `store.governance.enabled=true`.
+</Callout>
+
+---
+
+## Step 8: Understanding Your Setup
+
+### What's happening behind the scenes?
+
+1. **Yaci Store streams blocks** from the Cardano node starting at your slot.
+2. The **governance store** extracts proposals, votes, DReps, and committee changes from each block.
+3. **Before a proposal is saved**, your `governance.gov_action_proposal.save` filter decides whether its `type` is in scope.
+4. **After each save**, your post-action logs the proposal and updates the in-state counter.
+5. Votes flow into `voting_procedure` unfiltered, ready to be tallied with SQL at query time.
+
+### Why tally votes in SQL instead of a plugin?
+
+Yaci Store processes blocks in **parallel batches** during initial sync and can **roll back** near the chain tip. Maintaining a running aggregate inside a plugin would have to handle both carefully. Computing the tally from the `voting_procedure` table with `GROUP BY` is always correct and automatically reflects rollbacks — so we keep the plugin for *filtering and logging*, and let SQL do the *aggregation*.
+
+### Resource usage
+
+Scoping to governance keeps the database tiny and sync fast, since only governance rows are written.
+
+---
+
+## Troubleshooting
+
+### Plugins not loading?
+- Uncommented the loader line in `config/env`?
+- `store.plugins.enabled: true` set?
+- The MVEL `expression` is wrapped in single quotes and uses `type.name()` for the enum.
+
+### No governance data?
+- Confirm you're on **preprod** (Conway era) and `store.governance.enabled=true`.
+- Make sure proposals were submitted **after** your `sync-start-slot`.
+
+### Want to start over?
+
+```bash
+./yaci-store.sh stop
+sudo rm -rf db-data
+./yaci-store.sh start
+```
+
+---
+
+## Next Steps
+
+You've built a focused CIP-1694 governance indexer using an MVEL filter and an MVEL post-action.
+
+### Learn more
+- **[Plugin API Reference — Governance extension points](/docs/v2/plugins/plugin-api-guide#governance-store-extension-points-conway-era)** — `gov_action_proposal.save`, `voting_procedure.save`, `drep.save`, and more
+- **[Write Your First Plugin](/docs/v2/plugins/write-first-plugin)** — filters, pre/post-actions, event handlers, schedulers
+- **[Indexing NFT Mints for a Policy](/docs/v2/tutorials/tracking-nft-mints)** — another scope indexer, using filters on assets and metadata
+
+### Try these modifications
+- **Notify on new proposals:** add an event handler that posts to Discord/Slack via the [HTTP client](/docs/v2/plugins/variables-reference-guide/http-client) when a proposal of interest appears.
+- **Track DRep registrations:** add a filter/post-action on `governance.drep_registration.save` to watch DRep activity.
+- **Persist aggregates:** write per-proposal tallies into a custom table from a scheduled plugin using the [database access](/docs/v2/plugins/variables-reference-guide/database-access) variable.
+
+---
+
+## Summary
+
+In this tutorial, you learned:
+- ✅ How to scope an indexer to the `governance` store only
+- ✅ How to write an **MVEL filter** that matches on the `GovActionType` enum
+- ✅ How to write an **MVEL post-action** that aggregates and logs saved data
+- ✅ How to tally YES / NO / ABSTAIN votes per proposal with SQL
+
+You now have a lightweight, queryable governance database — a focused window into Cardano's on-chain decision making. 🗳️

--- a/docs/app/docs/v2/tutorials/tracking-nft-mints/page.mdx
+++ b/docs/app/docs/v2/tutorials/tracking-nft-mints/page.mdx
@@ -286,7 +286,6 @@ Let's verify only your policy's mints were stored.
    ```sql
    SELECT
      policy,
-     encode(decode(asset_name, 'hex'), 'escape') AS asset_name_ascii,
      asset_name,
      quantity,
      mint_type,

--- a/docs/app/docs/v2/tutorials/tracking-nft-mints/page.mdx
+++ b/docs/app/docs/v2/tutorials/tracking-nft-mints/page.mdx
@@ -1,0 +1,406 @@
+---
+title: "Indexing NFT Mints for a Policy"
+---
+
+import { Callout } from 'nextra/components'
+
+# Indexing NFT Mints for a Specific Policy
+
+## Introduction
+
+In this tutorial you'll build a **scope indexer** with Yaci Store: a lightweight Cardano indexer that captures **only the NFT mints and CIP-25 metadata for a single minting policy**, ignoring everything else on the chain.
+
+**What is a "scope indexer"?**
+Yaci Store can index the whole Cardano blockchain, but most applications only care about a tiny slice of it. Using the **plugin framework**, you can disable the stores you don't need and add a one-line filter so that only the data in your *scope* is ever written to the database. This is exactly what "granular scope indexing" means.
+
+**What will you build?**
+By the end of this tutorial, you'll have a running Yaci Store instance that:
+- Synchronizes with the Cardano blockchain
+- Stores **only the mint events for one NFT policy** (ignoring all other tokens)
+- Keeps the matching **CIP-25 (`721`) metadata** for that collection
+- Stays tiny — megabytes instead of gigabytes
+
+**Why is this useful?**
+- An NFT project wants a private, self-hosted index of just their collection's mint history
+- You need the on-chain metadata JSON for one policy to power a gallery or marketplace
+- You want a cheap, fast alternative to scanning the whole chain or paying an API provider
+
+**What you'll learn:**
+- How to enable only the `assets` and `metadata` stores
+- How to write **MVEL filter plugins** (no scripting files needed — just a one-line expression)
+- How `mintType` and metadata `label` let you scope ingestion precisely
+- How to query your collection's mints and metadata from PostgreSQL
+
+This is the *purest* scope indexer — two stores enabled, two one-line filters, and nothing else. Let's get started!
+
+<Callout type="info">
+New to the plugin framework? You may want to skim the [Write Your First Plugin](/docs/v2/plugins/write-first-plugin) guide first. If you've already done the [Tracking UTXOs for a Specific Address](/docs/v2/tutorials/tracking-address-utxos) tutorial, this one is even simpler — it uses inline MVEL expressions instead of JavaScript files.
+</Callout>
+
+---
+
+## Prerequisites
+
+Before we begin, make sure you have:
+
+- **Docker and Docker Compose** installed on your system
+  - [Install Docker Desktop](https://www.docker.com/products/docker-desktop/) for Mac or Windows
+  - [Install Docker Engine](https://docs.docker.com/engine/install/) for Linux
+- **A minting policy ID** you want to track (a 56-character hex string). You can copy one from any mint transaction on a [preprod explorer](https://preprod.cardanoscan.io/).
+- **Estimated time:** 20-30 minutes
+
+<Callout type="info">
+This tutorial uses the Cardano **preprod** testnet, which is perfect for learning without dealing with real ADA or requiring extensive storage.
+</Callout>
+
+---
+
+## Step 1: Download Yaci Store
+
+First, let's get the Yaci Store Docker distribution.
+
+1. **Download the latest release**
+
+   Visit the [Yaci Store releases page](https://github.com/bloxbean/yaci-store/releases) and download the Docker distribution archive (look for `yaci-store-docker-<version>.zip`).
+
+2. **Extract the archive**
+
+   ```bash
+   unzip yaci-store-docker-<version>.zip
+   cd yaci-store-docker-<version>
+   ```
+
+3. **Explore the directory structure**
+
+   ```
+   yaci-store/
+   ├── yaci-store.sh          # Main script to start/stop Yaci Store
+   ├── admin-cli.sh           # Admin operations
+   ├── psql.sh                # Quick database access
+   ├── compose/               # Docker compose files
+   ├── config/                # Configuration files
+   │   ├── env                # Environment variables
+   │   ├── application.properties
+   │   └── application-plugins.yml
+   └── plugins/               # Where plugins live
+       ├── ext-jars
+       └── scripts
+   ```
+
+<Callout type="info">
+The `yaci-store.sh` script is your main interface. It handles starting, stopping, and managing the Docker containers for you.
+</Callout>
+
+---
+
+## Step 2: Configure Network Connection
+
+Open `config/application.properties` and point Yaci Store at the Cardano **preprod** testnet:
+
+```properties
+# Cardano Network Configuration
+store.cardano.host=preprod-node.play.dev.cardano.org
+store.cardano.port=3001
+store.cardano.protocol-magic=1
+```
+
+The Docker distribution comes pre-configured for database access:
+
+```properties
+spring.datasource.url=jdbc:postgresql://yaci-store-postgres:5432/yaci_store?currentSchema=yaci_store
+spring.datasource.username=yaci
+spring.datasource.password=dbpass
+```
+
+<Callout type="warning">
+These are development credentials. For production use, change the database password!
+</Callout>
+
+---
+
+## Step 3: Scope to Assets and Metadata Only
+
+This is the heart of a scope indexer: turn **off** every store you don't need, and keep **only** the two stores that hold NFT mint and metadata data.
+
+1. **Continue editing `config/application.properties`**
+
+2. **Disable the stores you don't need, and enable `assets` + `metadata`:**
+
+   ```properties
+   # Disable everything we don't need
+   store.blocks.enabled=false
+   store.transaction.enabled=false
+   store.utxo.enabled=false
+   store.epoch.enabled=false
+   store.mir.enabled=false
+   store.script.enabled=false
+   store.staking.enabled=false
+   store.governance.enabled=false
+
+   # Keep these two — this is our scope
+   store.assets.enabled=true
+   store.metadata.enabled=true
+   ```
+
+3. **Set a recent starting point**
+
+   NFT mints are sparse, so syncing from genesis wastes time. Start from a slot **before** your collection's first mint. If you're tracking an ongoing/future drop, you can start near the current tip.
+
+   ```properties
+   # Start syncing from a recent slot (adjust to your collection's first mint)
+   store.cardano.sync-start-slot=107754724
+   store.cardano.sync-start-blockhash=534d3c2d1c3915523ea8843449dd91fcf4d647719d9ef2dc64a97d47be39447b
+   ```
+
+   <Callout type="info">
+   To get a recent preprod slot and block hash, visit [Cardano Explorer (Preprod)](https://preprod.cardanoscan.io/). Mints that happened **before** your start slot will not be captured — choose your start point accordingly.
+   </Callout>
+
+---
+
+## Step 4: Enable the Plugin System
+
+### 4.1 Enable Plugin Loading
+
+Edit `config/env` and uncomment (remove the leading `#`) this line:
+
+```bash
+JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+```
+
+### 4.2 Enable Plugins in Configuration
+
+Open `config/application-plugins.yml` and make sure the plugin system is on:
+
+```yaml
+store:
+  plugins:
+    enabled: true
+```
+
+---
+
+## Step 5: Add the Scope Filters
+
+Unlike the UTXO tutorial, we won't write any JavaScript files. The entire scope is expressed as **two one-line MVEL filter expressions** directly in the configuration.
+
+Yaci Store evaluates a filter `expression` against **each item** before it's saved. If the expression returns `true`, the item is kept; otherwise it's discarded.
+
+We'll use two extension points:
+- **`asset.save`** — runs for every native-asset mint/burn (domain object [`TxAsset`](/docs/v2/plugins/plugin-api-guide#txasset): `policy`, `assetName`, `quantity`, `mintType`)
+- **`metadata.save`** — runs for every transaction metadata label (domain object [`TxMetadataLabel`](/docs/v2/plugins/plugin-api-guide#txmetadatalabel): `label`, `body`)
+
+Open `config/application-plugins.yml` and replace its contents with:
+
+```yaml
+store:
+  plugins:
+    enabled: true
+    api-enabled: false
+    metrics:
+      enabled: false
+
+    # Filters run BEFORE data is saved. Keep only what matches.
+    filters:
+      # Keep only MINT operations for our policy
+      asset.save:
+        - name: "Keep one policy's NFT mints"
+          lang: mvel
+          expression: 'policy == "REPLACE_WITH_YOUR_POLICY_ID" && mintType.name() == "MINT"'
+          exit-on-error: false
+
+      # Keep only CIP-25 (NFT) metadata
+      metadata.save:
+        - name: "Keep CIP-25 metadata"
+          lang: mvel
+          expression: 'label == "721"'
+          exit-on-error: false
+```
+
+Replace `REPLACE_WITH_YOUR_POLICY_ID` with the 56-character hex policy ID you want to track.
+
+**How the filters work:**
+- The `asset.save` filter keeps a row only when its `policy` matches yours **and** the operation is a mint (`mintType` is the `MINT`/`BURN` enum — we compare with `mintType.name() == "MINT"`). Change it to `"BURN"` to track burns instead, or drop that clause to capture both.
+- The `metadata.save` filter keeps the `721` label, which is the [CIP-25](https://cips.cardano.org/cip/CIP-25) standard for NFT metadata.
+
+<Callout type="info">
+The `label == "721"` filter keeps CIP-25 metadata for **all** policies, not just yours. That's usually fine — metadata rows are small. To narrow metadata to a single policy, replace the inline expression with a short MVEL function that inspects the metadata body:
+
+```yaml
+      metadata.save:
+        - name: "Keep CIP-25 metadata for our policy"
+          lang: mvel
+          inline-script: |
+            result = [];
+            for (item : items) {
+                if (item.label == "721" && item.body != null
+                        && item.body.contains("REPLACE_WITH_YOUR_POLICY_ID")) {
+                    result.add(item);
+                }
+            }
+            return result;
+```
+
+The `inline-script` form receives the whole list as `items` and returns the filtered list — use it whenever a one-line `expression` isn't enough.
+</Callout>
+
+---
+
+## Step 6: Start Yaci Store
+
+```bash
+./yaci-store.sh start
+```
+
+This will:
+- Pull the necessary Docker images (first time only)
+- Start the PostgreSQL database
+- Start Yaci Store and begin synchronizing from your configured slot
+
+Watch the logs:
+
+```bash
+./yaci-store.sh logs:yaci-store
+```
+
+---
+
+## Step 7: Query Your Collection
+
+Let's verify only your policy's mints were stored.
+
+1. **Connect to the database**
+
+   ```bash
+   ./psql.sh
+   ```
+
+2. **Set the schema**
+
+   ```sql
+   SET search_path TO yaci_store;
+   ```
+
+3. **List the mints captured for your policy**
+
+   ```sql
+   SELECT
+     policy,
+     encode(decode(asset_name, 'hex'), 'escape') AS asset_name_ascii,
+     asset_name,
+     quantity,
+     mint_type,
+     tx_hash,
+     slot
+   FROM assets
+   ORDER BY slot DESC
+   LIMIT 20;
+   ```
+
+   Because the filter only saved your policy's mints, **every** row here belongs to your collection.
+
+4. **Count the distinct NFTs minted under the policy**
+
+   ```sql
+   SELECT COUNT(DISTINCT asset_name) AS distinct_assets,
+          SUM(quantity)              AS total_minted
+   FROM assets
+   WHERE mint_type = 'MINT';
+   ```
+
+5. **Read the CIP-25 metadata JSON**
+
+   ```sql
+   SELECT tx_hash, slot, body
+   FROM transaction_metadata
+   WHERE label = '721'
+   ORDER BY slot DESC
+   LIMIT 10;
+   ```
+
+   The `body` column holds the raw CIP-25 metadata JSON (name, image, traits, etc.) for each mint transaction.
+
+6. **Exit**
+
+   ```sql
+   \q
+   ```
+
+<Callout type="info">
+No rows yet? The policy may not have minted anything after your `sync-start-slot`. Double-check the policy ID and lower the start slot to a point before the first mint.
+</Callout>
+
+---
+
+## Step 8: Understanding Your Setup
+
+### What's happening behind the scenes?
+
+1. **Yaci Store connects to the Cardano node** and streams blocks from your start slot.
+2. For every block, the **assets store** extracts native-asset mint/burn operations and the **metadata store** extracts transaction metadata.
+3. **Before anything is saved**, your two filters run:
+   - `asset.save` → keep the row only if `policy` matches and it's a `MINT`
+   - `metadata.save` → keep the row only if `label == "721"`
+4. Everything else is discarded and never touches the database.
+
+### Resource usage
+
+Because your scope is one policy:
+- **Database size:** tiny (megabytes)
+- **CPU / memory:** minimal
+- **Sync time:** fast — only matching rows are written
+
+### Customizing for your needs
+
+- **Track multiple policies:** change the `asset.save` expression to `policy == "P1" || policy == "P2"`, or use the `inline-script` form with a list of policies.
+- **Track burns too:** drop the `mintType.name() == "MINT"` clause to capture both mints and burns.
+- **Track fungible tokens:** the same filters work for any native token — just point at a fungible policy.
+
+---
+
+## Troubleshooting
+
+### Plugins not loading?
+- Uncommented the plugin loader line in `config/env`?
+- `store.plugins.enabled: true` in `config/application-plugins.yml`?
+- The MVEL `expression` is valid YAML — keep it wrapped in single quotes.
+
+### No data appearing?
+- Is your `policy` exactly 56 hex characters, with no `0x` prefix?
+- Did your collection mint **after** `store.cardano.sync-start-slot`?
+- Is Yaci Store connected to the network (check the logs)?
+
+### Need to restart from scratch?
+
+```bash
+./yaci-store.sh stop
+sudo rm -rf db-data
+./yaci-store.sh start
+```
+
+---
+
+## Next Steps
+
+Congratulations! You've built a minimal NFT scope indexer with nothing but two MVEL filters.
+
+### Learn more
+- **[Plugin API Reference](/docs/v2/plugins/plugin-api-guide)** — every extension point and domain field, including [`asset.save`](/docs/v2/plugins/plugin-api-guide#assetsave) and [`metadata.save`](/docs/v2/plugins/plugin-api-guide#metadatasave)
+- **[Write Your First Plugin](/docs/v2/plugins/write-first-plugin)** — filters, pre/post-actions, event handlers, and schedulers
+- **[Governance Watch tutorial](/docs/v2/tutorials/governance-watch)** — scope-index Conway-era proposals and votes
+
+### Try these modifications
+- Send a Discord/webhook notification on each new mint using an event handler and the [HTTP client](/docs/v2/plugins/variables-reference-guide/http-client) (see the notification step in the [UTXO tutorial](/docs/v2/tutorials/tracking-address-utxos))
+- Add a `post-action` on `asset.save` that maintains a running mint count in plugin state
+
+---
+
+## Summary
+
+In this tutorial, you learned:
+- ✅ How to scope an indexer to just the `assets` and `metadata` stores
+- ✅ How to write one-line **MVEL filter expressions** for `asset.save` and `metadata.save`
+- ✅ How `mintType` and the CIP-25 `721` label let you narrow ingestion precisely
+- ✅ How to query your collection's mints and metadata from PostgreSQL
+
+You now have a fast, tiny indexer that stores exactly one NFT collection — the essence of granular scope indexing. 🚀


### PR DESCRIPTION
 ## Summary

  Adds two new step-by-step tutorials to the docs site (store.yaci.xyz) that demonstrate Yaci Store's plugin framework for **granular scope indexing** — indexing only a narrow slice of chain data instead of the whole blockchain.
  
  Until now the Tutorials section had a single entry (Tracking UTXOs for a Specific Address). These additions broaden it to three distinct domains (UTXO → assets/metadata → governance) and showcase MVEL-based, no-code plugins as a complement to the existing JavaScript example.

  ## What's added

  - **Indexing NFT Mints for a Policy** (`tracking-nft-mints`) — beginner  flagship. Enables only the `assets` + `metadata` stores and uses two one-line MVEL filter expressions (`asset.save`, `metadata.save`) to keep only one policy's mints and their CIP-25 metadata. The purest scope indexer: two stores, two filters, nothing else.
  - **A Minimal Conway Governance Indexer** (`governance-watch`) — intermediate. Scopes to the `governance` store only, filters proposals by `GovActionType` (MVEL), logs new proposals via an MVEL post-action, and tallies YES/NO/ABSTAIN votes per proposal with SQL.

