### PR TITLE
fix: reset auto-restart counter on a sliding window 

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/config/StoreProperties.java
@@ -164,4 +164,5 @@ public class StoreProperties { //TODO - replace this with YaciStoreProperties fr
     private long autoRestartDebounceWindowMs = 30000;
     private int autoRestartMaxAttempts = 5;
     private long autoRestartBackoffBaseMs = 5000;
+    private long autoRestartWindowMs = 600000;
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
@@ -27,10 +27,6 @@ public class RequiredRestartProcessor {
     private final AtomicInteger restartCount = new AtomicInteger(0);
     private final Lock restartLock = new ReentrantLock();
 
-    // If there's been no restart for this long, the attempt counter is reset so a new
-    // outage starts fresh instead of inheriting the count of an old, resolved one.
-    static final long RESTART_WINDOW_MS = 600000; // 10 minutes
-
     @EventListener
     public void handleRequiredRestart(RequiredSyncRestartEvent event) {
         Thread.startVirtualThread(() -> handleRestartInterval(event));
@@ -78,26 +74,27 @@ public class RequiredRestartProcessor {
      * without waiting.
      */
     int evaluateRestartAttempt(long now, RequiredSyncRestartEvent event) {
-        long lastAttempt = lastRestartAttempt.get();
+        long lastAttemptEpochMs = lastRestartAttempt.get();
+        long windowMs = storeProperties.getAutoRestartWindowMs();
 
-        if (now - lastAttempt < storeProperties.getAutoRestartDebounceWindowMs()) {
+        if (now - lastAttemptEpochMs < storeProperties.getAutoRestartDebounceWindowMs()) {
             log.info("Within debounce window. Ignoring restart event: {}", event.getReason());
             return 0;
         }
 
         // A gap longer than the window means the previous burst is over, so start counting again.
-        if (lastAttempt > 0 && now - lastAttempt > RESTART_WINDOW_MS) {
+        if (lastAttemptEpochMs > 0 && now - lastAttemptEpochMs > windowMs) {
             int previous = restartCount.getAndSet(0);
             if (previous > 0) {
                 log.info("No restart attempt in the last {} ms. Resetting restart attempt counter from {} to 0.",
-                         RESTART_WINDOW_MS, previous);
+                         windowMs, previous);
             }
         }
 
         if (restartCount.get() >= storeProperties.getAutoRestartMaxAttempts()) {
             log.warn("Reached max restart attempts ({}) within the last {} ms. " +
                      "Pausing further restarts until the window resets.",
-                     storeProperties.getAutoRestartMaxAttempts(), RESTART_WINDOW_MS);
+                     storeProperties.getAutoRestartMaxAttempts(), windowMs);
             return 0;
         }
 

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessor.java
@@ -2,7 +2,6 @@ package com.bloxbean.cardano.yaci.store.core.processor;
 
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
-import com.bloxbean.cardano.yaci.store.core.service.HealthService;
 import com.bloxbean.cardano.yaci.store.core.service.StartService;
 import com.bloxbean.cardano.yaci.store.events.internal.RequiredSyncRestartEvent;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +10,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
@@ -23,21 +21,18 @@ import java.util.concurrent.locks.ReentrantLock;
 @Slf4j
 public class RequiredRestartProcessor {
     private final StartService startService;
-    private final HealthService healthService;
     private final StoreProperties storeProperties;
 
     private final AtomicLong lastRestartAttempt = new AtomicLong(0);
     private final AtomicInteger restartCount = new AtomicInteger(0);
     private final Lock restartLock = new ReentrantLock();
-    private final AtomicBoolean monitoringHealth = new AtomicBoolean(false);
 
-    // Track successful sync period
-    private static final long SUCCESS_THRESHOLD_MS = 300000; // 5 minutes
-    private static final long HEALTH_CHECK_INTERVAL_MS = 30000; // 30 seconds
+    // If there's been no restart for this long, the attempt counter is reset so a new
+    // outage starts fresh instead of inheriting the count of an old, resolved one.
+    static final long RESTART_WINDOW_MS = 600000; // 10 minutes
 
     @EventListener
     public void handleRequiredRestart(RequiredSyncRestartEvent event) {
-
         Thread.startVirtualThread(() -> handleRestartInterval(event));
     }
 
@@ -53,22 +48,11 @@ public class RequiredRestartProcessor {
         }
 
         try {
-            // Check debounce window
-            long now = System.currentTimeMillis();
-            long lastAttempt = lastRestartAttempt.get();
-            if (now - lastAttempt < storeProperties.getAutoRestartDebounceWindowMs()) {
-                log.info("Within debounce window. Ignoring restart event: {}", event.getReason());
-                return;
+            int attemptNumber = evaluateRestartAttempt(System.currentTimeMillis(), event);
+            if (attemptNumber <= 0) {
+                return; // debounced or rate-limited
             }
 
-            // Check retry limit
-            if (restartCount.get() >= storeProperties.getAutoRestartMaxAttempts()) {
-                log.error("Max restart attempts reached. Manual intervention required.");
-                return;
-            }
-
-            // Calculate backoff
-            int attemptNumber = restartCount.incrementAndGet();
             long backoffMs = calculateBackoff(attemptNumber);
 
             log.info("Scheduling sync restart. Reason: {}, Attempt: {}, Backoff: {}ms",
@@ -80,13 +64,45 @@ public class RequiredRestartProcessor {
             // Perform restart
             performRestart(event);
 
-            lastRestartAttempt.set(System.currentTimeMillis());
-
         } catch (Exception e) {
             log.error("Error during sync restart", e);
         } finally {
             restartLock.unlock();
         }
+    }
+
+    /**
+     * Applies the debounce window, the sliding-window counter reset and the
+     * max-attempts limit. Returns the 1-based attempt number when a restart should go
+     * ahead, or 0 to skip. {@code now} is a parameter so the windowing can be tested
+     * without waiting.
+     */
+    int evaluateRestartAttempt(long now, RequiredSyncRestartEvent event) {
+        long lastAttempt = lastRestartAttempt.get();
+
+        if (now - lastAttempt < storeProperties.getAutoRestartDebounceWindowMs()) {
+            log.info("Within debounce window. Ignoring restart event: {}", event.getReason());
+            return 0;
+        }
+
+        // A gap longer than the window means the previous burst is over, so start counting again.
+        if (lastAttempt > 0 && now - lastAttempt > RESTART_WINDOW_MS) {
+            int previous = restartCount.getAndSet(0);
+            if (previous > 0) {
+                log.info("No restart attempt in the last {} ms. Resetting restart attempt counter from {} to 0.",
+                         RESTART_WINDOW_MS, previous);
+            }
+        }
+
+        if (restartCount.get() >= storeProperties.getAutoRestartMaxAttempts()) {
+            log.warn("Reached max restart attempts ({}) within the last {} ms. " +
+                     "Pausing further restarts until the window resets.",
+                     storeProperties.getAutoRestartMaxAttempts(), RESTART_WINDOW_MS);
+            return 0;
+        }
+
+        lastRestartAttempt.set(now);
+        return restartCount.incrementAndGet();
     }
 
     private void performRestart(RequiredSyncRestartEvent event) {
@@ -106,11 +122,6 @@ public class RequiredRestartProcessor {
         startService.start();
 
         log.info("Sync restart completed for reason: {}", event.getReason());
-
-        // Start health monitoring thread only if we have restart attempts
-        if (restartCount.get() > 0) {
-            startHealthMonitoring();
-        }
     }
 
     private long calculateBackoff(int attemptNumber) {
@@ -118,68 +129,5 @@ public class RequiredRestartProcessor {
             storeProperties.getAutoRestartBackoffBaseMs() * (long)Math.pow(2, attemptNumber - 1),
             60000L // Max 1 minute
         );
-    }
-
-    private void startHealthMonitoring() {
-        // Only start monitoring if not already running
-        if (!monitoringHealth.compareAndSet(false, true)) {
-            log.debug("Health monitoring already in progress");
-            return;
-        }
-
-        Thread.startVirtualThread(() -> {
-            log.info("Starting health monitoring to reset restart counter after stable sync");
-            long monitoringStartTime = System.currentTimeMillis();
-            long lastSuccessfulSyncTime = 0;
-
-            try {
-                while (monitoringHealth.get() && restartCount.get() > 0) {
-                    // Check sync health using HealthService
-                    var healthStatus = healthService.getHealthStatus();
-                    
-                    if (healthStatus.isConnectionAlive() && !healthStatus.isError()) {
-                        long lastBlockTime = healthStatus.getLastReceivedBlockTime();
-                        long currentTime = System.currentTimeMillis();
-
-                        // Check if we're receiving blocks (within last minute)
-                        if (lastBlockTime > 0 && (currentTime - lastBlockTime) < 60000) {
-                            // We're successfully syncing
-                            if (lastSuccessfulSyncTime == 0) {
-                                lastSuccessfulSyncTime = currentTime;
-                                log.debug("Started tracking successful sync period");
-                            } else if (currentTime - lastSuccessfulSyncTime > SUCCESS_THRESHOLD_MS) {
-                                // 5 minutes of stable sync, reset counter
-                                log.info("Sync has been stable for 5 minutes. Resetting restart counter.");
-                                restartCount.set(0);
-                                break; // Exit monitoring
-                            }
-                        } else {
-                            // Not receiving blocks, reset success tracking
-                            lastSuccessfulSyncTime = 0;
-                        }
-                    } else {
-                        // Not running or in error state, reset success tracking
-                        lastSuccessfulSyncTime = 0;
-                    }
-
-                    // Stop monitoring after 10 minutes regardless
-                    if (System.currentTimeMillis() - monitoringStartTime > 600000) {
-                        log.info("Health monitoring timeout reached (10 minutes). Stopping monitoring.");
-                        break;
-                    }
-
-                    // Sleep for check interval
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(HEALTH_CHECK_INTERVAL_MS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    }
-                }
-            } finally {
-                monitoringHealth.set(false);
-                log.info("Health monitoring stopped. Restart counter: {}", restartCount.get());
-            }
-        });
     }
 }

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessorTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessorTest.java
@@ -19,6 +19,7 @@ class RequiredRestartProcessorTest {
 
     private static final long DEBOUNCE_MS = 30_000L;
     private static final int MAX_ATTEMPTS = 3;
+    private static final long WINDOW_MS = 600_000L;
     private static final long BASE_NOW = 1_000_000L;
 
     @Mock
@@ -36,6 +37,7 @@ class RequiredRestartProcessorTest {
     void setUp() {
         lenient().when(storeProperties.getAutoRestartDebounceWindowMs()).thenReturn(DEBOUNCE_MS);
         lenient().when(storeProperties.getAutoRestartMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+        lenient().when(storeProperties.getAutoRestartWindowMs()).thenReturn(WINDOW_MS);
     }
 
     @Test
@@ -70,7 +72,7 @@ class RequiredRestartProcessorTest {
         processor.evaluateRestartAttempt(lastAttempt, event); // budget exhausted
         assertThat(processor.evaluateRestartAttempt(BASE_NOW + 180_000, event)).isZero();
 
-        long afterWindow = lastAttempt + RequiredRestartProcessor.RESTART_WINDOW_MS + 1;
+        long afterWindow = lastAttempt + WINDOW_MS + 1;
         assertThat(processor.evaluateRestartAttempt(afterWindow, event)).isEqualTo(1);
     }
 

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessorTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/processor/RequiredRestartProcessorTest.java
@@ -1,0 +1,84 @@
+package com.bloxbean.cardano.yaci.store.core.processor;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.service.StartService;
+import com.bloxbean.cardano.yaci.store.events.internal.RequiredSyncRestartEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RequiredRestartProcessorTest {
+
+    private static final long DEBOUNCE_MS = 30_000L;
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long BASE_NOW = 1_000_000L;
+
+    @Mock
+    private StartService startService;
+    @Mock
+    private StoreProperties storeProperties;
+
+    @InjectMocks
+    private RequiredRestartProcessor processor;
+
+    private final RequiredSyncRestartEvent event =
+            RequiredSyncRestartEvent.builder().reason("test").build();
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(storeProperties.getAutoRestartDebounceWindowMs()).thenReturn(DEBOUNCE_MS);
+        lenient().when(storeProperties.getAutoRestartMaxAttempts()).thenReturn(MAX_ATTEMPTS);
+    }
+
+    @Test
+    void countsUpWhenAttemptsAreSpacedWithinTheWindow() {
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW, event)).isEqualTo(1);
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW + 60_000, event)).isEqualTo(2);
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW + 120_000, event)).isEqualTo(3);
+    }
+
+    @Test
+    void skipsEventInsideTheDebounceWindow() {
+        processor.evaluateRestartAttempt(BASE_NOW, event);
+
+        // 10s later, still inside the 30s debounce window
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW + 10_000, event)).isZero();
+    }
+
+    @Test
+    void pausesOnceMaxAttemptsReachedWithinTheWindow() {
+        processor.evaluateRestartAttempt(BASE_NOW, event);
+        processor.evaluateRestartAttempt(BASE_NOW + 60_000, event);
+        processor.evaluateRestartAttempt(BASE_NOW + 120_000, event); // third hits maxAttempts
+
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW + 180_000, event)).isZero();
+    }
+
+    @Test
+    void resumesAfterTheWindowElapses() {
+        processor.evaluateRestartAttempt(BASE_NOW, event);
+        processor.evaluateRestartAttempt(BASE_NOW + 60_000, event);
+        long lastAttempt = BASE_NOW + 120_000;
+        processor.evaluateRestartAttempt(lastAttempt, event); // budget exhausted
+        assertThat(processor.evaluateRestartAttempt(BASE_NOW + 180_000, event)).isZero();
+
+        long afterWindow = lastAttempt + RequiredRestartProcessor.RESTART_WINDOW_MS + 1;
+        assertThat(processor.evaluateRestartAttempt(afterWindow, event)).isEqualTo(1);
+    }
+
+    @Test
+    void doesNotTouchTheSyncServiceWhileEvaluating() {
+        processor.evaluateRestartAttempt(BASE_NOW, event);
+        processor.evaluateRestartAttempt(BASE_NOW + 60_000, event);
+
+        verifyNoInteractions(startService);
+    }
+}

--- a/docs/app/docs/v1/advanced-configuration/auto-restart/page.mdx
+++ b/docs/app/docs/v1/advanced-configuration/auto-restart/page.mdx
@@ -12,6 +12,7 @@ store.auto-restart.enabled=true
 store.auto-restart.debounce-window-ms=30000
 store.auto-restart.max-attempts=5
 store.auto-restart.backoff-base-ms=5000
+store.auto-restart.window-ms=600000
 ```
 
 ### Configuration Options
@@ -20,6 +21,7 @@ store.auto-restart.backoff-base-ms=5000
 - **`store.auto-restart.debounce-window-ms`** (default: `30000`): Time window in milliseconds to prevent multiple restart attempts. If multiple restart events occur within this window, only the first one will be processed
 - **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts allowed within a sliding window (~10 min). Once the limit is reached within the window, new restarts pause until the window elapses and then resume automatically — no manual restart required
 - **`store.auto-restart.backoff-base-ms`** (default: `5000`): Base delay in milliseconds for exponential backoff between restart attempts
+- **`store.auto-restart.window-ms`** (default: `600000` = 10 min): Sliding window for the `max-attempts` limit. If no restart has been attempted for this long, the attempt counter resets so a later outage is treated as a fresh incident and retries resume automatically
 
 ### How It Works
 

--- a/docs/app/docs/v1/advanced-configuration/auto-restart/page.mdx
+++ b/docs/app/docs/v1/advanced-configuration/auto-restart/page.mdx
@@ -18,7 +18,7 @@ store.auto-restart.backoff-base-ms=5000
 
 - **`store.auto-restart.enabled`** (default: `true`): Enable or disable the auto-restart feature
 - **`store.auto-restart.debounce-window-ms`** (default: `30000`): Time window in milliseconds to prevent multiple restart attempts. If multiple restart events occur within this window, only the first one will be processed
-- **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts before giving up and requiring manual intervention
+- **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts allowed within a sliding window (~10 min). Once the limit is reached within the window, new restarts pause until the window elapses and then resume automatically — no manual restart required
 - **`store.auto-restart.backoff-base-ms`** (default: `5000`): Base delay in milliseconds for exponential backoff between restart attempts
 
 ### How It Works
@@ -27,11 +27,11 @@ The auto-restart system automatically handles:
 - **IntersectionNotFound errors**: When the node can't find a common intersection point after network issues
 - **Health check failures**: When the auto-recovery service detects sync problems
 
-The system includes safeguards to prevent restart storms:
+The system includes safeguards to prevent restart storms and enable automatic recovery:
 - **Debouncing**: Ignores rapid restart requests within the configured window
 - **Exponential backoff**: Increases delay between retry attempts (5s, 10s, 20s, 40s, 60s max)
-- **Retry limits**: Stops trying after the maximum attempts are reached
-- **Success tracking**: Resets the retry counter after 5 minutes of stable sync
+- **Sliding-window rate limiting**: Resets the retry counter if no restart has been attempted within ~10 minutes, allowing fresh restart attempts for new or recovered outages without manual intervention
+- **Max-attempts per window**: Within the sliding window, stops attempting restarts after reaching the configured limit to prevent excessive restart storms
 
 <Callout>
 The auto-restart feature is enabled by default since IntersectionNotFound is a valid scenario that should be handled automatically, especially in production environments.

--- a/docs/app/docs/v2/advanced-configuration/auto-restart/page.mdx
+++ b/docs/app/docs/v2/advanced-configuration/auto-restart/page.mdx
@@ -12,6 +12,7 @@ store.auto-restart.enabled=true
 store.auto-restart.debounce-window-ms=30000
 store.auto-restart.max-attempts=5
 store.auto-restart.backoff-base-ms=5000
+store.auto-restart.window-ms=600000
 ```
 
 ## Configuration Options
@@ -20,6 +21,7 @@ store.auto-restart.backoff-base-ms=5000
 - **`store.auto-restart.debounce-window-ms`** (default: `30000`): Time window in milliseconds to prevent multiple restart attempts. If multiple restart events occur within this window, only the first one will be processed
 - **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts allowed within a sliding window (~10 min). Once the limit is reached within the window, new restarts pause until the window elapses and then resume automatically — no manual restart required
 - **`store.auto-restart.backoff-base-ms`** (default: `5000`): Base delay in milliseconds for exponential backoff between restart attempts
+- **`store.auto-restart.window-ms`** (default: `600000` = 10 min): Sliding window for the `max-attempts` limit. If no restart has been attempted for this long, the attempt counter resets so a later outage is treated as a fresh incident and retries resume automatically
 
 ## How It Works
 

--- a/docs/app/docs/v2/advanced-configuration/auto-restart/page.mdx
+++ b/docs/app/docs/v2/advanced-configuration/auto-restart/page.mdx
@@ -18,7 +18,7 @@ store.auto-restart.backoff-base-ms=5000
 
 - **`store.auto-restart.enabled`** (default: `true`): Enable or disable the auto-restart feature
 - **`store.auto-restart.debounce-window-ms`** (default: `30000`): Time window in milliseconds to prevent multiple restart attempts. If multiple restart events occur within this window, only the first one will be processed
-- **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts before giving up and requiring manual intervention
+- **`store.auto-restart.max-attempts`** (default: `5`): Maximum number of restart attempts allowed within a sliding window (~10 min). Once the limit is reached within the window, new restarts pause until the window elapses and then resume automatically — no manual restart required
 - **`store.auto-restart.backoff-base-ms`** (default: `5000`): Base delay in milliseconds for exponential backoff between restart attempts
 
 ## How It Works
@@ -27,11 +27,11 @@ The auto-restart system automatically handles:
 - **IntersectionNotFound errors**: When the node can't find a common intersection point after network issues
 - **Health check failures**: When the auto-recovery service detects sync problems
 
-The system includes safeguards to prevent restart storms:
+The system includes safeguards to prevent restart storms and enable automatic recovery:
 - **Debouncing**: Ignores rapid restart requests within the configured window
 - **Exponential backoff**: Increases delay between retry attempts (5s, 10s, 20s, 40s, 60s max)
-- **Retry limits**: Stops trying after the maximum attempts are reached
-- **Success tracking**: Resets the retry counter after 5 minutes of stable sync
+- **Sliding-window rate limiting**: Resets the retry counter if no restart has been attempted within ~10 minutes, allowing fresh restart attempts for new or recovered outages without manual intervention
+- **Max-attempts per window**: Within the sliding window, stops attempting restarts after reaching the configured limit to prevent excessive restart storms
 
 <Callout>
 The auto-restart feature is enabled by default since IntersectionNotFound is a valid scenario that should be handled automatically, especially in production environments.

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreAutoConfiguration.java
@@ -276,6 +276,7 @@ public class YaciStoreAutoConfiguration {
         storeProperties.setAutoRestartDebounceWindowMs(properties.getAutoRestart().getDebounceWindowMs());
         storeProperties.setAutoRestartMaxAttempts(properties.getAutoRestart().getMaxAttempts());
         storeProperties.setAutoRestartBackoffBaseMs(properties.getAutoRestart().getBackoffBaseMs());
+        storeProperties.setAutoRestartWindowMs(properties.getAutoRestart().getWindowMs());
 
         return storeProperties;
     }

--- a/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
+++ b/starters/spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/core/YaciStoreProperties.java
@@ -181,6 +181,7 @@ public class YaciStoreProperties {
         private long debounceWindowMs = 30000;
         private int maxAttempts = 5;
         private long backoffBaseMs = 5000;
+        private long windowMs = 600000;
     }
 
 }


### PR DESCRIPTION
## Description

`RequiredRestartProcessor` uses an in-memory counter (`restartCount`) that acts as a 
**lifetime cap**: once exhausted at `max-attempts` (default 5), the indexer stops 
retrying forever — even after the outage clears. In one incident, this left the 
indexer stuck for 80+ hours until manual restart.

This PR converts it to a **sliding-window rate limit**: the counter resets if no 
restart attempt occurs within 10 minutes, so each outage starts fresh. `max-attempts` 
becomes a per-window limit, preserving restart-storm protection.

Closes #996 
### Changes
- Extract gate logic into `evaluateRestartAttempt()` for testability
- Add sliding-window reset: if idle > 10min, reset counter and allow fresh attempts
- Remove now-redundant `startHealthMonitoring()` / `HealthService`
- Downgrade exhausted-attempts log: `ERROR` → `WARN` (automatic recovery expected)
- Add `RequiredRestartProcessorTest` (5 deterministic cases, no real waiting)
- Update docs: `max-attempts` now described as per-window, not lifetime

### Notes for reviewers
- Log text changed from "Manual intervention required" to "Pausing until window resets"
- `RESTART_WINDOW_MS` (10 min) is hard-coded; can be made configurable if needed
- Closes #<issue-number>

## Type of Change
- [x] Bug fix

## Testing
- [x] Full suite: `./gradlew test` → BUILD SUCCESSFUL, 47 modules
- [x] New tests: 5 cases in `RequiredRestartProcessorTest` (debounce, rate-limit, window reset)

## Checklist
- [x] Code follows project standards
- [x] Documentation updated
- [x] No new warnings