### PR TITLE
[Backport] Backport assets-ext  extension to release/2.0.x

### DIFF
--- a/.claude/skills/assets-ext-regression/SKILL.md
+++ b/.claude/skills/assets-ext-regression/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: assets-ext-regression
+description: Run CIP-26 and CIP-68 wire-shape regression tests for the assets-ext extension against the cf-token-metadata-registry V2 API on mainnet. Use when a user wants to verify yaci-store's API output is byte-equivalent to CF, after a code change to assets-ext, or when investigating reported metadata divergences.
+---
+
+# assets-ext regression skill
+
+End-to-end regression for `extensions/assets-ext`. Compares yaci-store's
+CIP-26 and CIP-68 FT API responses against the cf-token-metadata-registry
+**V2 API** on Cardano mainnet, byte-for-byte.
+
+CF V1 endpoints are intentionally not exercised — yaci-store does not persist
+off-chain signatures, so a faithful V1 comparison is impossible.
+
+## When to invoke
+
+- After a code change in `extensions/assets-ext/` that could touch the read path
+  (`AssetsReader`, `Cip26StorageReader`, `Cip68StorageReader`, `TokenQueryService`,
+  any repository or DTO under `cip26/` or `cip68/`).
+- When a user reports a metadata divergence ("token X looks wrong on yaci vs
+  tokens.cardano.org").
+- As a pre-release smoke check before tagging an assets-ext build.
+
+## Inputs you need from the user
+
+Ask only if not already obvious from the conversation context:
+
+1. **Where yaci-store is running** — local port 8081 by default. If it's remote,
+   ask for either an SSH host (so you can suggest a tunnel) or a direct URL.
+2. **Which CF source to compare against**:
+   - **Public** `https://tokens.cardano.org` — works for anyone with internet,
+     but rate-limited (~1 request per 1.5 s; HTTP 429 above that).
+   - **Internal CF mirror** — fast, no rate limit; needs an SSH tunnel. Ask if
+     they have access.
+3. **Do they have SSH+Postgres access to the yaci-store host?** Determines which
+   scripts you can run:
+   - Yes → use the fast DB-enumerated `sweep_cip26_full.py` + `sweep_cip68_ft_full.py`
+     (a few minutes total).
+   - No  → use `verify_against_cf_registry.py` (slower, no DB needed).
+
+Default assumptions if the user just says "run the regression" with no extra
+context: yaci at `http://127.0.0.1:8081`, internal mirror at `http://127.0.0.1:8082`,
+DB host `mczeladka` (matches the developer's existing setup).
+
+## Step-by-step
+
+All commands run from the repository root.
+
+### Step 1 — Confirm yaci is reachable
+
+```sh
+curl -s --max-time 5 http://127.0.0.1:8081/actuator/health | head -c 300
+```
+
+Expect `"status":"UP"` with `assetStoreOffchainSync` present. If the response is
+empty or 404, ask the user how to reach their yaci-store and adjust `--yaci-url`
+on subsequent commands.
+
+### Step 2 — Confirm the CF source is reachable
+
+The cLBC FT subject is a stable mainnet token used throughout these scripts:
+`376efee6953a6af08c41903b781a316553ad279387b8ff1bf5d7c94d0014df10634c4243`.
+
+```sh
+curl -s -w " HTTP %{http_code}\n" -o /dev/null \
+  "${CF_URL}/api/v2/subjects/376efee6953a6af08c41903b781a316553ad279387b8ff1bf5d7c94d0014df10634c4243"
+```
+
+`HTTP 200` means the V2 endpoint is up. `204` means the CF source doesn't have
+that subject (wrong host or non-mainnet). `429` means you're being rate-limited.
+
+### Step 3 — Run the sweeps
+
+**Preferred (DB access + CF mirror — fastest)**:
+
+```sh
+cd extensions/assets-ext/scripts
+
+python3 sweep_cip26_full.py \
+    --yaci-url http://127.0.0.1:8081 \
+    --cf-url   http://127.0.0.1:8082 \
+    --workers  16
+
+python3 sweep_cip68_ft_full.py \
+    --yaci-url http://127.0.0.1:8081 \
+    --cf-url   http://127.0.0.1:8082 \
+    --workers  16
+```
+
+Each script prints a one-line summary at the end and exits `0` if all subjects
+agree, `1` if any diverged. Mainnet baseline: 7,932 CIP-26 + 7,647 CIP-68 FT,
+all agreeing.
+
+**Fallback (no DB access)**:
+
+```sh
+cd extensions/assets-ext/scripts
+python3 verify_against_cf_registry.py --network mainnet \
+    --yaci-url http://127.0.0.1:8081
+```
+
+Enumerates from the CF GitHub registry (clones it once, fast-forwards on
+subsequent runs). Use this when the QA engineer cannot reach the yaci-store DB.
+
+**Public-CF variant (slow but no internal access needed)** — swap `--cf-url` to
+`https://tokens.cardano.org` and add `--cf-throttle-ms 1500 --workers 1`. A
+mainnet full sweep that way takes hours.
+
+### Step 4 — Interpret the result
+
+A passing run looks like:
+
+```
+[setup] yaci=http://127.0.0.1:8081  cf=http://127.0.0.1:8082  workers=16
+[setup] subjects=7932
+
+total=7932  agree=7932  diverged=0  skip=0  elapsed=137.4s
+```
+
+If there are divergences, the script prints up to 20 of them with per-field
+diffs (`field: yaci=… cf=…`). Tell the user:
+
+1. The total and pass rate.
+2. Whether any divergence appears in CIP-26 vs CIP-68 (different bug classes).
+3. **Whether the divergence is in a known-acceptable category** before flagging
+   it as a regression (see "Acceptable divergences" below).
+4. The first few non-acceptable diffs verbatim.
+
+### Step 5 (only if regressions found) — Triage
+
+Common root causes when something fails:
+
+- **All divergences are `logo` field** — almost certainly the spec-vs-CF encoding
+  difference. Not a regression; document and move on.
+- **All divergences point to a single field across many subjects** — likely a
+  serializer or wire-shape bug. Look at `Cip26TokenMetadata.from` / the V2 DTO
+  builders.
+- **Divergences are CIP-68 only, with stale metadata** — historically caused by
+  the `findFirstByPolicyIdAndAssetNameAndLabelOrderBySlotDesc` label filter
+  (fixed). If it resurfaces, check `Cip68MetadataRepository` for a reintroduced
+  `label = :label` clause.
+- **Many `skip` results with `yaci=200,cf=204`** — CF mirror doesn't have the
+  subject. Often means the mirror is on a different network (preprod vs
+  mainnet) or behind on indexing.
+
+## Acceptable divergences
+
+Both scripts surface these by design — they are **not** regressions:
+
+1. **`logo.value` encoding** — CIP-26 spec says base64; CF V2 returns hex.
+   yaci-store passes the spec base64 through unchanged. If a divergence list
+   contains only logo fields, this is expected.
+2. **Multiple registry files claiming the same subject** — affects 3 testnet
+   subjects (BCoin, wUSDT, one other); 0 on mainnet. yaci picks deterministically
+   by filename matching the subject; CF picks via `File.listFiles()` order.
+
+## Notes for the agent
+
+- **Always** report scripts' exit codes back to the user — they're the
+  authoritative pass/fail signal.
+- Do not throttle internal-mirror requests; the mirror is local, throttling just
+  wastes time.
+- The two `sweep_*` scripts use `ssh ... psql` to enumerate from the DB. Pass
+  the right `--db-host` if it's not the default (`mczeladka`).
+- If the user wants to investigate one specific subject, fall back to a direct
+  side-by-side curl:
+  ```sh
+  curl -s "${YACI_URL}/api/v1/tokens/subject/${SUBJ}?show_cips_details=true" | python3 -m json.tool
+  curl -s "${CF_URL}/api/v2/subjects/${SUBJ}?show_cips_details=true"      | python3 -m json.tool
+  ```
+- Scripts and README live at `extensions/assets-ext/scripts/`. The README is the
+  authoritative reference for flag details and is intentionally consistent with
+  this skill — keep them in sync if either changes.

--- a/applications/all/build.gradle
+++ b/applications/all/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':starters:governance-aggr-spring-boot-starter')
 
     implementation project(':starters:admin-spring-boot-starter')
+    implementation project(':starters:assets-ext-spring-boot-starter')
     implementation project(':components:dbutils')
     implementation project(':aggregates:epoch-nonce')
     implementation project(':components:admin-ui')

--- a/applications/all/src/main/resources/application-all.properties
+++ b/applications/all/src/main/resources/application-all.properties
@@ -25,3 +25,9 @@ store.live.enabled=true
 
 store.admin.ui.enabled=true
 store.epoch-nonce.enabled=true
+
+# Assets-ext extension (CIP-26 + CIP-68 + CIP-113 token metadata)
+# Master flag off by default for the standalone build. Set it to true to enable the
+# extension; CIP-26 and CIP-68 then run by default, CIP-113 stays off (pre-mainnet)
+# until store.assets.ext.cip113.enabled=true is set.
+store.assets.ext.enabled=false

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/AddressUtxo.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/AddressUtxo.java
@@ -21,6 +21,9 @@ import java.util.List;
 public class AddressUtxo extends BlockAwareDomain implements Serializable {
     private String txHash;
     private Integer outputIndex;
+    /** Index of the producing transaction within its block (0-based). Populated by the
+     *  utxo processors so downstream consumers can order same-slot updates deterministically. */
+    private Integer txIndex;
     private Long slot;
     private String blockHash;
     private Integer epoch;

--- a/config/application.properties
+++ b/config/application.properties
@@ -345,6 +345,21 @@ logging.level.com.bloxbean.cardano.yaci.store.core.service=INFO
 
 server.forward-headers-strategy=framework
 
+#######################################################################################
+# Assets Extension (CIP-26 + CIP-68 + CIP-113 Token Metadata)
+# Disabled by default. Uncomment the master flag to enable; CIP-26 and CIP-68 are then
+# enabled by default, so the master flag alone gives the default behaviour.
+# CIP-26 git registry auto-detected from store.cardano.protocol-magic.
+# CIP-68 is on-chain and needs no config.
+# CIP-113 registry NFT policy IDs auto-detected from protocol-magic.
+#######################################################################################
+#store.assets.ext.enabled=true
+# CIP-26 and CIP-68 are enabled by default when the master flag is on. To disable one:
+#store.assets.ext.cip26.enabled=false
+#store.assets.ext.cip68.enabled=false
+# CIP-113 is off by default (not yet live on mainnet). To enable:
+#store.assets.ext.cip113.enabled=true
+
 spring.threads.virtual.enabled=true
 
 #######################################################################################

--- a/extensions/assets-ext/README.md
+++ b/extensions/assets-ext/README.md
@@ -1,0 +1,131 @@
+# Assets Extension
+
+Indexes and serves Cardano fungible token metadata from multiple CIP standards. Replaces the need for a standalone
+[cf-token-metadata-registry](https://github.com/cardano-foundation/cf-token-metadata-registry) deployment — consumers
+query a single yaci-store instance and get merged metadata transparently.
+
+## Supported Standards
+
+| Standard | Source | Description |
+|----------|--------|-------------|
+| CIP-26 | Off-chain (GitHub [cardano-token-registry](https://github.com/cardano-foundation/cardano-token-registry)) | Fungible token metadata synced periodically from Git |
+| CIP-68 | On-chain (reference NFT inline datums, label 333) | Fungible token metadata parsed from blockchain |
+| CIP-113 | On-chain (programmable token registry NFTs) | Transfer logic scripts (disabled by default) |
+
+## REST API
+
+All endpoints use the configurable `${apiPrefix}` (default: `/api/v1`).
+
+### Merged Metadata (main API)
+
+The primary API — merges CIP-26 and CIP-68 metadata by configurable priority. Users don't need to know which
+standard provides the data. Response-compatible with cf-token-metadata-registry's subjects API.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/subject/{subject}` | Query merged metadata for a single subject |
+| `POST` | `/subject/query` | Batch query merged metadata (max 100 subjects) |
+
+**Query parameters:**
+
+- `property` (optional, repeatable) — filter which properties to return. When used, `name` and `description` are required.
+- `query_priority` (optional, repeatable) — CIP priority order, e.g. `?query_priority=CIP_68&query_priority=CIP_26`. Default: `CIP_68,CIP_26` (on-chain preferred).
+- `show_cips_details` (optional, default `false`) — include raw per-standard metadata in the response.
+
+**Example:**
+
+```
+GET /api/v1/subject/577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454
+
+{
+  "subject": {
+    "subject": "577f0b...464c4454",
+    "metadata": {
+      "name": { "value": "FLDT", "source": "CIP_68" },
+      "description": { "value": "The official token of FluidTokens", "source": "CIP_68" },
+      "ticker": { "value": "FLDT", "source": "CIP_26" },
+      "decimals": { "value": 6, "source": "CIP_68" },
+      "url": { "value": "https://fluidtokens.com", "source": "CIP_26" }
+    }
+  },
+  "queryPriority": ["CIP_68", "CIP_26"]
+}
+```
+
+**Batch request:**
+
+```
+POST /api/v1/subject/query
+
+{
+  "subjects": ["subject1", "subject2"],
+  "properties": ["name", "description", "ticker"]
+}
+```
+
+### CIP-Specific Endpoints (direct access)
+
+For advanced users who want to query a specific standard directly.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/cip26/{subject}` | CIP-26 off-chain metadata only |
+| `GET` | `/cip68/ft/{policyId}/{assetName}` | CIP-68 fungible token metadata only |
+
+
+## Configuration
+
+```yaml
+store:
+  assets:
+    enabled: true
+
+    cip26:
+      enabled: true                    # Enable GitHub registry sync
+      git-organization: cardano-foundation
+      git-project-name: cardano-token-registry
+      sync-interval-minutes: 60
+
+    cip68:
+      enabled: true                    # Fungible token support (label 333)
+
+    cip113:
+      enabled: false                   # Disabled by default
+      registry-nft-policy-ids: []      # Override auto-detected policy IDs
+
+    query:
+      priority: "CIP_68,CIP_26"       # Default merge priority
+```
+
+## Database Tables
+
+| Table | Description |
+|-------|-------------|
+| `ft_offchain_metadata` | CIP-26 fungible token metadata (subject as PK) |
+| `ft_offchain_logo` | CIP-26 token logos (separated for performance) |
+| `off_chain_sync_state` | GitHub sync progress tracking |
+| `metadata_reference_nft` | CIP-68 on-chain reference NFT metadata (composite PK: policy_id, asset_name, slot). `label` column discriminates FT (333) vs NFT (222) for future use. |
+| `cip113_registry_node` | CIP-113 programmable token registry nodes |
+
+All tables include a `last_synced_at` timestamp for monitoring.
+
+## Health Indicators
+
+Spring Boot Actuator health indicators are provided:
+
+- **Offchain sync** — reports CIP-26 GitHub sync status and last sync time
+- **On-chain connection** — reports blockchain indexer connectivity
+- **On-chain readiness** — reports whether on-chain sync has reached chain tip
+
+Configure Kubernetes probe groups:
+
+```yaml
+management:
+  endpoint:
+    health:
+      group:
+        readiness:
+          include: onchainReadiness, offchainSync
+        liveness:
+          include: onchainConnection
+```

--- a/extensions/assets-ext/build.gradle
+++ b/extensions/assets-ext/build.gradle
@@ -1,0 +1,26 @@
+apply from : "../../publish-common.gradle"
+
+dependencies {
+    api project(":components:common")
+    api project(":components:core")
+    api project(":components:events")
+    api project(":stores:utxo")
+    api project(":components:plugin")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r'
+    implementation 'org.cardanofoundation.metadatatools:cf-tokens-cip26:2.0.0'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yaci Store Assets Extension'
+                description = 'Yaci Store Assets Extension - CIP-26, CIP-68 Token Metadata'
+            }
+        }
+    }
+}

--- a/extensions/assets-ext/build.gradle
+++ b/extensions/assets-ext/build.gradle
@@ -1,5 +1,3 @@
-apply from : "../../publish-common.gradle"
-
 dependencies {
     api project(":components:common")
     api project(":components:core")

--- a/extensions/assets-ext/scripts/README.md
+++ b/extensions/assets-ext/scripts/README.md
@@ -1,0 +1,149 @@
+# assets-ext regression scripts
+
+Three Python scripts that byte-compare yaci-store's assets-ext API output against
+[`cf-token-metadata-registry`](https://github.com/cardano-foundation/cf-token-metadata-registry)'s
+**V2 API** for CIP-26 and CIP-68. Use these whenever you want to verify that a
+yaci-store build serves wire-shape parity with CF.
+
+V1 endpoints are intentionally **not** exercised. CF V1 wraps each property with
+off-chain signatures (`{value, signatures, sequenceNumber}`); yaci-store does not
+persist signatures, so a faithful V1 comparison is impossible.
+
+| Script | Enumerates from | Needs DB access? | Speed | Coverage |
+|---|---|---|---|---|
+| [`verify_against_cf_registry.py`](verify_against_cf_registry.py) | CF GitHub registry (clones the repo) | No | Slow (~30–60 min on mainnet — registry is large) | Every subject in the registry; CIP-26 byte-level, CIP-68 sub-tally for subjects that have both |
+| [`sweep_cip26_full.py`](sweep_cip26_full.py) | yaci-store `cip26_metadata` table | Yes (SSH + Postgres) | Fast (~2 min mainnet at 16 workers against the CF mirror) | Every CIP-26 row in the DB |
+| [`sweep_cip68_ft_full.py`](sweep_cip68_ft_full.py) | yaci-store `cip68_metadata` table (label=333) | Yes (SSH + Postgres) | Fast (~1.5 min mainnet at 16 workers against the CF mirror) | Every distinct CIP-68 fungible token whose history contains a label=333 row |
+
+**Pick by access**: if you can reach yaci-store's database, use the two `sweep_*`
+scripts — they're fast and exhaustive. If you only have HTTP access to yaci, use
+`verify_against_cf_registry.py`.
+
+---
+
+## Prerequisites
+
+- Python ≥ 3.10 (stdlib only — no `pip install` needed for any script).
+- HTTP access to a running yaci-store (default expected at `http://127.0.0.1:8081`).
+- HTTP access to a CF V2 API source — either:
+  - **Public** `https://tokens.cardano.org/api/v2/subjects/{subject}` — rate-limited (~1 req per 1.5 s, AWS ELB returns HTTP 429 above that), or
+  - **Internal CF mirror** at `http://<host>:8080/api/v2/subjects/{subject}` (typically reached via SSH tunnel to port 8082).
+- For the `sweep_*` scripts: SSH access to the host running yaci-store's PostgreSQL instance, plus the DB credentials.
+- For `verify_against_cf_registry.py`: `git` on `PATH` (used to clone/pull the registry).
+
+---
+
+## Step-by-step: QA workflow
+
+> Goal: confirm that the yaci-store under test serves wire-shape parity with CF
+> mainnet's V2 API for CIP-26 and CIP-68 FT.
+
+### 1. Pick which yaci-store you are testing
+
+The scripts expect yaci's HTTP API at `http://127.0.0.1:8081` by default. Either:
+- Run yaci-store locally on port 8081, **or**
+- Tunnel a remote yaci: `ssh -L 8081:localhost:8081 -N <yaci-host>`, **or**
+- Pass `--yaci-url <url>` to each script.
+
+Confirm yaci responds:
+```sh
+curl -s http://127.0.0.1:8081/actuator/health | head -c 200
+```
+
+### 2. Pick which CF V2 source to compare against
+
+**Option A — Public CF mainnet** (no setup, but rate-limited):
+```sh
+CF_URL=https://tokens.cardano.org
+THROTTLE=--cf-throttle-ms=1500
+WORKERS=--workers=1
+```
+
+**Option B — Internal CF mirror** (requires SSH tunnel; no throttle, no rate limit):
+```sh
+ssh -L 8082:localhost:8080 -N <cf-mirror-host>
+CF_URL=http://127.0.0.1:8082
+THROTTLE=
+WORKERS=
+```
+
+Confirm CF responds (cLBC subject is a stable mainnet token, expected `HTTP 200`):
+```sh
+curl -s -w "HTTP %{http_code}\n" -o /dev/null \
+  "${CF_URL}/api/v2/subjects/376efee6953a6af08c41903b781a316553ad279387b8ff1bf5d7c94d0014df10634c4243"
+```
+
+### 3. Run the regressions
+
+**Without DB access** (slower; uses the CF GitHub registry as the subject list):
+
+```sh
+cd extensions/assets-ext/scripts
+python3 verify_against_cf_registry.py --network mainnet --yaci-url http://127.0.0.1:8081
+```
+
+This clones `cardano-foundation/cardano-token-registry`, iterates every subject,
+and reports CIP-26 byte-level agreement plus CIP-68 sub-tally for subjects that
+have both. Use `--help` for the full flag list.
+
+**With DB access** (fast; exhaustive):
+
+```sh
+cd extensions/assets-ext/scripts
+
+# CIP-26 — 7,932 subjects mainnet, ~2 min at 16 workers against the mirror
+python3 sweep_cip26_full.py \
+    --yaci-url http://127.0.0.1:8081 \
+    --cf-url   http://127.0.0.1:8082 \
+    --db-host  <ssh-host-with-pg-access>
+
+# CIP-68 FT — 7,647 subjects mainnet, ~1.5 min at 16 workers
+python3 sweep_cip68_ft_full.py \
+    --yaci-url http://127.0.0.1:8081 \
+    --cf-url   http://127.0.0.1:8082 \
+    --db-host  <ssh-host-with-pg-access>
+```
+
+### 4. Interpret the result
+
+Each script prints a summary line and exits with status `0` on full agreement,
+`1` on any divergence, `2` on setup failure.
+
+```
+total=7932  agree=7932  diverged=0  skip=0  elapsed=137.4s
+```
+
+If `diverged > 0`, the first 20 diverging subjects are printed with a
+per-field diff. Each row identifies the field, yaci's value, and CF's value.
+
+### 5. Known acceptable divergences
+
+These are **expected and not regressions** — both scripts will surface them:
+
+1. **`logo.value` encoding** — CIP-26 spec says base64; CF V2 returns hex
+   (decoded then re-encoded as hex, non-spec). yaci-store passes the spec base64
+   through. If you see *only* logo-encoding differences, that's not a regression.
+2. **Multiple registry files claiming the same subject** — affects 3 testnet
+   subjects, 0 on mainnet. yaci-store deterministically picks the file whose
+   name equals the subject; CF picks non-deterministically.
+
+Any other divergence is worth investigating.
+
+---
+
+## Public CF rate limit
+
+Public `tokens.cardano.org` is fronted by AWS ELB, which returns HTTP 429 after
+roughly 183 requests in a 3-minute window with no `Retry-After` header. Use
+`--cf-throttle-ms 1500 --workers 1` against it. The internal mirror has no rate
+limit — prefer it when available.
+
+---
+
+## See also
+
+- [`SKILL.md`](../../../.claude/skills/assets-ext-regression/SKILL.md) — Claude
+  Code skill that wraps these scripts for one-command QA invocation.
+- [`db/store/README.md`](../src/main/resources/db/store/README.md) — schema
+  documentation for `cip26_metadata` / `cip26_sync_state` / `cip68_metadata` /
+  `cip113_registry_node`.

--- a/extensions/assets-ext/scripts/sweep_cip26_full.py
+++ b/extensions/assets-ext/scripts/sweep_cip26_full.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Full CIP-26 regression sweep: enumerate every subject currently in yaci-store's
+`cip26_metadata` table, then byte-compare each subject's `standards.cip26` block
+between yaci-store and a CF V2 API source.
+
+DB-enumerated (fast and complete) — requires SSH+Postgres access to the host
+running yaci-store. For a setup that needs no DB access, use
+`verify_against_cf_registry.py` instead (slower, registry-enumerated).
+
+Targets the V2 endpoints only on both sides. CF V1 is intentionally not exercised
+because yaci-store does not persist off-chain signatures.
+
+Usage examples
+--------------
+  # Default: yaci on :8081, CF mirror on :8082 (no rate limit), 16 workers
+  python sweep_cip26_full.py
+
+  # Against public CF mainnet (rate-limited — throttle to ~1 req/1.5s)
+  python sweep_cip26_full.py --cf-url https://tokens.cardano.org \\
+                              --cf-throttle-ms 1500 --workers 1
+
+  # Smoke test on first 100 subjects
+  python sweep_cip26_full.py --limit 100
+
+Exit codes
+----------
+  0  all subjects agree
+  1  one or more diverged
+  2  setup error (DB enumeration failed, no subjects returned)
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def enumerate_subjects(args) -> list[str]:
+    """SELECT subject FROM cip26_metadata via ssh+psql."""
+    sql = "SELECT subject FROM cip26_metadata;"
+    cmd = [
+        "ssh", "-o", "ConnectTimeout=5", args.db_host,
+        f'PGPASSWORD={args.db_password} psql -h {args.db_pg_host} -U {args.db_user} '
+        f'-d {args.db_name} -At -c "{sql}"',
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        print(f"[setup] DB enumeration failed: {result.stderr}", file=sys.stderr)
+        sys.exit(2)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def http_get(url: str, timeout: int = 15) -> tuple[int, str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, ""
+    except Exception:
+        return 0, ""
+
+
+def extract_cip26(body: str) -> dict | None:
+    try:
+        return json.loads(body).get("subject", {}).get("standards", {}).get("cip26")
+    except Exception:
+        return None
+
+
+def compare_one(subject: str, args) -> tuple[str, str, int, int, list[str] | None]:
+    if args.cf_throttle_ms > 0:
+        time.sleep(args.cf_throttle_ms / 1000.0)
+
+    yaci_url = f"{args.yaci_url}/api/v1/tokens/subject/{subject}?show_cips_details=true"
+    cf_url = f"{args.cf_url}/api/v2/subjects/{subject}?show_cips_details=true"
+
+    yc, yb = http_get(yaci_url)
+    cc, cb = http_get(cf_url)
+
+    if yc != 200 or cc != 200:
+        return subject, "skip", yc, cc, None
+
+    y_cip = extract_cip26(yb)
+    c_cip = extract_cip26(cb)
+
+    if y_cip == c_cip:
+        return subject, "agree", yc, cc, None
+
+    diffs = []
+    keys = sorted(set(y_cip or {}) | set(c_cip or {}))
+    for k in keys:
+        yv = (y_cip or {}).get(k)
+        cv = (c_cip or {}).get(k)
+        if yv != cv:
+            diffs.append(f"{k}: yaci={yv!r:.120}  cf={cv!r:.120}")
+    return subject, "diverge", yc, cc, diffs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--yaci-url", default="http://127.0.0.1:8081",
+                        help="yaci-store base URL (default: %(default)s)")
+    parser.add_argument("--cf-url", default="http://127.0.0.1:8082",
+                        help="CF V2 API base URL — mirror or https://tokens.cardano.org (default: %(default)s)")
+    parser.add_argument("--workers", type=int, default=16,
+                        help="parallel HTTP workers (default: %(default)s; drop to 1 against public CF)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="limit number of subjects (smoke test)")
+    parser.add_argument("--cf-throttle-ms", type=int, default=0,
+                        help="sleep N ms before each CF GET (public CF needs ~1500)")
+    parser.add_argument("--db-host", default="mczeladka",
+                        help="SSH host to enumerate from (default: %(default)s)")
+    parser.add_argument("--db-pg-host", default="localhost",
+                        help="Postgres host on the SSH target (default: %(default)s)")
+    parser.add_argument("--db-name", default="yaci_store")
+    parser.add_argument("--db-user", default="postgres")
+    parser.add_argument("--db-password", default="postgres")
+    parser.add_argument("--show-diff-limit", type=int, default=20,
+                        help="how many diverged subjects to print in detail (default: %(default)s)")
+    args = parser.parse_args()
+
+    print(f"[setup] yaci={args.yaci_url}  cf={args.cf_url}  workers={args.workers}")
+    subjects = enumerate_subjects(args)
+    if not subjects:
+        print("[setup] no subjects found in cip26_metadata — nothing to compare", file=sys.stderr)
+        return 2
+    if args.limit:
+        subjects = subjects[: args.limit]
+    print(f"[setup] subjects={len(subjects)}")
+
+    stats = {"agree": 0, "diverge": 0, "skip": 0, "skip_codes": {}}
+    diverged: list[tuple[str, list[str]]] = []
+
+    start = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for subj, status, yc, cc, diffs in ex.map(lambda s: compare_one(s, args), subjects):
+            stats[status] += 1
+            if status == "skip":
+                key = f"yaci={yc},cf={cc}"
+                stats["skip_codes"][key] = stats["skip_codes"].get(key, 0) + 1
+            elif status == "diverge":
+                diverged.append((subj, diffs or []))
+    elapsed = time.monotonic() - start
+
+    total = stats["agree"] + stats["diverge"] + stats["skip"]
+    print()
+    print(f"total={total}  agree={stats['agree']}  diverged={stats['diverge']}  "
+          f"skip={stats['skip']}  elapsed={elapsed:.1f}s")
+    if stats["skip"]:
+        print(f"  skip codes: {stats['skip_codes']}")
+    if diverged:
+        print()
+        print(f"first {min(len(diverged), args.show_diff_limit)} of {len(diverged)} diverged subjects:")
+        for subj, diffs in diverged[: args.show_diff_limit]:
+            print(f"  DIVERGED  {subj}")
+            for d in diffs[:5]:
+                print(f"     {d}")
+
+    return 0 if stats["diverge"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extensions/assets-ext/scripts/sweep_cip68_ft_full.py
+++ b/extensions/assets-ext/scripts/sweep_cip68_ft_full.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Full CIP-68 fungible-token regression sweep: enumerate every distinct CIP-68
+reference NFT whose history contains a label=333 row in yaci-store's
+`cip68_metadata` table, derive the user-token (FT) subject for each, and
+byte-compare each subject's `standards.cip68` block between yaci-store and a
+CF V2 API source.
+
+DB-enumerated (fast and complete) — requires SSH+Postgres access to the host
+running yaci-store. For a setup that needs no DB access, use
+`verify_against_cf_registry.py` instead (slower, registry-enumerated; misses
+CIP-68 tokens that don't have a CF GitHub registry entry).
+
+Targets V2 endpoints on both sides. CF V1 is intentionally not exercised.
+
+Usage examples
+--------------
+  # Default: yaci on :8081, CF mirror on :8082 (no rate limit), 16 workers
+  python sweep_cip68_ft_full.py
+
+  # Against public CF mainnet (rate-limited — throttle, drop workers to 1)
+  python sweep_cip68_ft_full.py --cf-url https://tokens.cardano.org \\
+                                 --cf-throttle-ms 1500 --workers 1
+
+  # Smoke test on first 100 subjects
+  python sweep_cip68_ft_full.py --limit 100
+
+Exit codes
+----------
+  0  all subjects agree
+  1  one or more diverged
+  2  setup error (DB enumeration failed, no subjects returned)
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+REF_NFT_PREFIX = "000643b0"
+FT_PREFIX = "0014df10"
+
+
+def enumerate_ft_subjects(args) -> list[tuple[str, str]]:
+    """Return distinct (policy_id, ref_nft_asset_name) pairs that have at least
+    one label=333 row in cip68_metadata."""
+    sql = (
+        "SELECT policy_id, asset_name FROM ("
+        "  SELECT DISTINCT policy_id, asset_name FROM cip68_metadata"
+        f" WHERE asset_name LIKE '{REF_NFT_PREFIX}%' AND label = 333"
+        ") s;"
+    )
+    cmd = [
+        "ssh", "-o", "ConnectTimeout=5", args.db_host,
+        f'PGPASSWORD={args.db_password} psql -h {args.db_pg_host} -U {args.db_user} '
+        f"-d {args.db_name} -At -F'|' -c \"{sql}\"",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        print(f"[setup] DB enumeration failed: {result.stderr}", file=sys.stderr)
+        sys.exit(2)
+    rows = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pol, asset = line.split("|", 1)
+        rows.append((pol, asset))
+    return rows
+
+
+def http_get(url: str, timeout: int = 15) -> tuple[int, str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, ""
+    except Exception:
+        return 0, ""
+
+
+def extract_cip68(body: str) -> dict | None:
+    try:
+        return json.loads(body).get("subject", {}).get("standards", {}).get("cip68")
+    except Exception:
+        return None
+
+
+def compare_one(pol: str, ref_asset: str, args) -> tuple[str, str, int, int, list[str] | None]:
+    if args.cf_throttle_ms > 0:
+        time.sleep(args.cf_throttle_ms / 1000.0)
+
+    # Reference-NFT asset name → user-facing FT asset name (label-prefix swap)
+    ft_asset = FT_PREFIX + ref_asset[len(REF_NFT_PREFIX):]
+    subject = pol + ft_asset
+
+    yaci_url = f"{args.yaci_url}/api/v1/tokens/subject/{subject}?show_cips_details=true"
+    cf_url = f"{args.cf_url}/api/v2/subjects/{subject}?show_cips_details=true"
+
+    yc, yb = http_get(yaci_url)
+    cc, cb = http_get(cf_url)
+
+    if yc != 200 or cc != 200:
+        return subject, "skip", yc, cc, None
+
+    y_cip = extract_cip68(yb)
+    c_cip = extract_cip68(cb)
+
+    if y_cip == c_cip:
+        return subject, "agree", yc, cc, None
+
+    diffs = []
+    keys = sorted(set(y_cip or {}) | set(c_cip or {}))
+    for k in keys:
+        yv = (y_cip or {}).get(k)
+        cv = (c_cip or {}).get(k)
+        if yv != cv:
+            diffs.append(f"{k}: yaci={yv!r:.120}  cf={cv!r:.120}")
+    return subject, "diverge", yc, cc, diffs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--yaci-url", default="http://127.0.0.1:8081",
+                        help="yaci-store base URL (default: %(default)s)")
+    parser.add_argument("--cf-url", default="http://127.0.0.1:8082",
+                        help="CF V2 API base URL — mirror or https://tokens.cardano.org (default: %(default)s)")
+    parser.add_argument("--workers", type=int, default=16,
+                        help="parallel HTTP workers (default: %(default)s; drop to 1 against public CF)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="limit number of subjects (smoke test)")
+    parser.add_argument("--cf-throttle-ms", type=int, default=0,
+                        help="sleep N ms before each CF GET (public CF needs ~1500)")
+    parser.add_argument("--db-host", default="mczeladka",
+                        help="SSH host to enumerate from (default: %(default)s)")
+    parser.add_argument("--db-pg-host", default="localhost")
+    parser.add_argument("--db-name", default="yaci_store")
+    parser.add_argument("--db-user", default="postgres")
+    parser.add_argument("--db-password", default="postgres")
+    parser.add_argument("--show-diff-limit", type=int, default=20,
+                        help="how many diverged subjects to print in detail (default: %(default)s)")
+    args = parser.parse_args()
+
+    print(f"[setup] yaci={args.yaci_url}  cf={args.cf_url}  workers={args.workers}")
+    rows = enumerate_ft_subjects(args)
+    if not rows:
+        print("[setup] no FT reference NFTs found — nothing to compare", file=sys.stderr)
+        return 2
+    if args.limit:
+        rows = rows[: args.limit]
+    print(f"[setup] subjects={len(rows)}")
+
+    stats = {"agree": 0, "diverge": 0, "skip": 0, "skip_codes": {}}
+    diverged: list[tuple[str, list[str]]] = []
+
+    start = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for subj, status, yc, cc, diffs in ex.map(lambda r: compare_one(r[0], r[1], args), rows):
+            stats[status] += 1
+            if status == "skip":
+                key = f"yaci={yc},cf={cc}"
+                stats["skip_codes"][key] = stats["skip_codes"].get(key, 0) + 1
+            elif status == "diverge":
+                diverged.append((subj, diffs or []))
+    elapsed = time.monotonic() - start
+
+    total = stats["agree"] + stats["diverge"] + stats["skip"]
+    print()
+    print(f"total={total}  agree={stats['agree']}  diverged={stats['diverge']}  "
+          f"skip={stats['skip']}  elapsed={elapsed:.1f}s")
+    if stats["skip"]:
+        print(f"  skip codes: {stats['skip_codes']}")
+    if diverged:
+        print()
+        print(f"first {min(len(diverged), args.show_diff_limit)} of {len(diverged)} diverged subjects:")
+        for subj, diffs in diverged[: args.show_diff_limit]:
+            print(f"  DIVERGED  {subj}")
+            for d in diffs[:5]:
+                print(f"     {d}")
+
+    return 0 if stats["diverge"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extensions/assets-ext/scripts/verify_against_cf_registry.py
+++ b/extensions/assets-ext/scripts/verify_against_cf_registry.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+"""
+Verify a running yaci-store assets-ext against the CF preprod token registry.
+
+Both APIs claim CF V2 compatibility (yaci-store explicitly so), so for any
+given subject they MUST return identical responses. Any divergence — at the
+schema level OR in field values — is a contract bug worth reporting.
+
+Workflow
+--------
+1. Maintain a local clone of the upstream registry source so we have a stable
+   list of subjects to test against. (Used only for enumeration — the script
+   does NOT compare API responses to the registry JSON itself; the registry
+   schema differs from the V2 wire format and the two services are the
+   contract surface.) On first run the repo is cloned; subsequent runs
+   fast-forward via `git pull`.
+2. For each subject:
+   - If --check cf or --check both: GET CF V2, classify as 200 / 404 / error.
+   - If --check yaci or --check both: GET yaci, classify same way.
+   - If both checked AND both 200: byte-level diff of the responses.
+3. Per-subject log line + final summary:
+   - per-service presence (matched / missing / errors)
+   - contract agreement (agree / diverged)
+
+Why no V1 comparison
+--------------------
+CF V1 returns each property wrapped with the off-chain signatures from the
+registry JSON (`{"value": "...", "signatures": [...], "sequenceNumber": N}`).
+yaci-store does not persist signatures, so a faithful V1 comparison is not
+possible. V2 is the canonical merged-values endpoint and is what consumers
+actually use.
+
+Reaching yaci-store via SSH
+---------------------------
+yaci-store is assumed to be running on the host reachable as `ssh rosetta-preprod`
+on port 8080. By default this script spawns an SSH tunnel for the duration of
+its run; pass --no-tunnel if you've set one up yourself (e.g. in a separate
+terminal: `ssh -L 8080:localhost:8080 -N rosetta-preprod`).
+
+Usage
+-----
+  python3 verify_assets_ext_cip26.py                       # both, auto-tunnel
+  python3 verify_assets_ext_cip26.py --check cf            # CF only (no SSH tunnel)
+  python3 verify_assets_ext_cip26.py --check yaci          # yaci only
+  python3 verify_assets_ext_cip26.py --limit 25            # smoke test (first 25)
+  python3 verify_assets_ext_cip26.py --subject <hex>       # debug one subject
+  python3 verify_assets_ext_cip26.py --no-tunnel           # external tunnel
+  python3 verify_assets_ext_cip26.py --no-pull             # skip git pull (offline)
+
+Exit codes
+----------
+  0  all subjects match
+  1  one or more subjects differ
+  2  setup error (tunnel failed, GitHub unreachable, yaci-store down, ...)
+"""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import os
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+# CIP-26 spec: subject = policyId (28 bytes / 56 hex) + optional assetName
+# (0-32 bytes / 0-64 hex), total 56-120 lowercase hex chars. CF and yaci-store
+# both reject anything else; we filter client-side so junk entries in the
+# upstream registry don't pollute the run.
+SUBJECT_REGEX = re.compile(r"^[0-9a-f]{56,120}$")
+
+# Per-network config. The two registries differ in three ways:
+#   - repo URL (testnet under input-output-hk; mainnet under cardano-foundation)
+#   - registry subdir name ("registry/" vs "mappings/")
+#   - CF V2 API host (preprod vs mainnet)
+# The dedupe-by-inner-subject logic in list_subjects_from_clone() works for both —
+# preprod has ~90% filename≠subject (per PR #87), mainnet 0%, but the algorithm is
+# correct in both cases.
+NETWORKS = {
+    "preprod": {
+        "repo_url": "https://github.com/input-output-hk/metadata-registry-testnet.git",
+        "registry_subdir": "registry",
+        "cache_subdir": "metadata-registry-testnet",
+        "cf_base": "https://preprod.tokens.cardano.org",
+    },
+    "mainnet": {
+        "repo_url": "https://github.com/cardano-foundation/cardano-token-registry.git",
+        "registry_subdir": "mappings",
+        "cache_subdir": "cardano-token-registry",
+        "cf_base": "https://tokens.cardano.org",
+    },
+}
+DEFAULT_NETWORK = "preprod"
+DEFAULT_YACI_BASE = "http://localhost:8080"
+DEFAULT_SSH_HOST = "rosetta-preprod"
+DEFAULT_REMOTE_PORT = 8080
+DEFAULT_LOCAL_PORT = 8080
+HTTP_TIMEOUT_SECS = 15
+
+
+# ----- HTTP helpers ----------------------------------------------------------
+
+HTTP_RETRY_ATTEMPTS = 5
+HTTP_RETRY_BACKOFFS = (1.0, 2.0, 4.0, 8.0, 16.0)  # seconds before attempts 2-6 (exponential)
+
+# CF mainnet (tokens.cardano.org) is fronted by AWS ELB which rate-limits
+# aggressively. Empirically: ~183 requests / 3 minutes triggers HTTP 429 with
+# no Retry-After header. CF preprod is tolerant by comparison. Sleeping a small
+# amount between CF GETs caps the request rate well under the limit.
+# Set via --cf-throttle-ms (default 0 = no throttle, suitable for preprod).
+CF_THROTTLE_SECS = 0.0
+
+
+def _set_cf_throttle(seconds: float) -> None:
+    global CF_THROTTLE_SECS
+    CF_THROTTLE_SECS = max(0.0, seconds)
+
+
+def http_get_json(url: str, headers: dict | None = None, throttle: float = 0.0) -> tuple[int, Any]:
+    """
+    Returns (status_code, body_or_None).
+
+    A 404 returns (404, None) immediately (no terminal answer).
+    For 5xx, 429 (rate limit), and network-level failures, retries up to
+    HTTP_RETRY_ATTEMPTS times with exponential backoff. 429 honours the
+    Retry-After header when present. The final failure raises (caller catches
+    it as a fetch error). For non-retryable 4xx (other than 404 and 429), the
+    body is parsed if JSON and returned alongside the status.
+
+    `throttle`: seconds to sleep BEFORE the request (rate-limit prevention,
+    not retry backoff). Apply only to the side that's rate-limited (CF).
+    """
+    if throttle > 0:
+        time.sleep(throttle)
+    req = urllib.request.Request(url, headers=headers or {})
+    last_exc: Exception | None = None
+
+    for attempt in range(HTTP_RETRY_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECS) as r:
+                return r.status, json.load(r)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return 404, None
+            # Retry on 5xx and 429. For 429, prefer the Retry-After header if present.
+            should_retry = (500 <= e.code < 600) or e.code == 429
+            if should_retry and attempt < HTTP_RETRY_ATTEMPTS - 1:
+                if e.code == 429:
+                    retry_after = e.headers.get("Retry-After") if e.headers else None
+                    try:
+                        sleep_for = float(retry_after) if retry_after else HTTP_RETRY_BACKOFFS[attempt]
+                    except (TypeError, ValueError):
+                        sleep_for = HTTP_RETRY_BACKOFFS[attempt]
+                    # Cap at 60s so a hostile Retry-After doesn't stall the run forever.
+                    sleep_for = min(sleep_for, 60.0)
+                else:
+                    sleep_for = HTTP_RETRY_BACKOFFS[attempt]
+                time.sleep(sleep_for)
+                last_exc = e
+                continue
+            # Final non-2xx — return status + body so caller can decide.
+            body_text = e.read().decode("utf-8", errors="replace") if e.fp else ""
+            try:
+                return e.code, json.loads(body_text)
+            except Exception:
+                return e.code, None
+        except (urllib.error.URLError, TimeoutError, socket.timeout) as e:
+            last_exc = e
+            if attempt < HTTP_RETRY_ATTEMPTS - 1:
+                time.sleep(HTTP_RETRY_BACKOFFS[attempt])
+                continue
+            raise
+
+    # Unreachable in practice — the loop either returns or raises — but keep
+    # mypy/static analyzers happy.
+    raise last_exc if last_exc else RuntimeError("http_get_json: unreachable")
+
+
+def ensure_registry_clone(cache_dir: pathlib.Path, repo_url: str, no_pull: bool) -> pathlib.Path:
+    """
+    Ensures cache_dir contains an up-to-date clone of the registry repo.
+    Clones on first run, fast-forwards on subsequent runs (unless --no-pull).
+    """
+    cache_dir.parent.mkdir(parents=True, exist_ok=True)
+    git_dir = cache_dir / ".git"
+
+    if git_dir.is_dir():
+        if no_pull:
+            print(f"[setup] using cached registry clone at {cache_dir} (no pull)")
+            return cache_dir
+        print(f"[setup] updating registry clone at {cache_dir} (git pull)")
+        subprocess.run(
+            ["git", "-C", str(cache_dir), "pull", "--ff-only", "--quiet"],
+            check=True,
+        )
+        return cache_dir
+
+    print(f"[setup] cloning {repo_url} → {cache_dir}")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "--quiet", repo_url, str(cache_dir)],
+        check=True,
+    )
+    return cache_dir
+
+
+def list_subjects_from_clone(repo_dir: pathlib.Path, registry_subdir: str) -> list[str]:
+    """
+    Returns the deduplicated list of real subjects from the local registry clone.
+
+    Filenames are NOT always a reliable subject source — preprod has ~90%
+    filename≠subject mismatch (per PR #87), mainnet has 0%. We always read
+    each JSON, extract the inner `subject` value (the actual on-chain
+    identifier), and deduplicate; on mainnet that's a no-op, on preprod it
+    collapses 5,526 files down to ~519 real subjects.
+
+    Files that fail to parse, or have no `subject` field, are skipped with a
+    warning.
+    """
+    registry_dir = repo_dir / registry_subdir
+    if not registry_dir.is_dir():
+        raise RuntimeError(f"{registry_subdir}/ directory not found in {repo_dir}")
+
+    subjects: set[str] = set()
+    skipped_unparseable = 0
+    invalid_subjects: set[str] = set()
+    for path in registry_dir.iterdir():
+        if not (path.is_file() and path.suffix == ".json"):
+            continue
+        try:
+            inner = json.loads(path.read_text()).get("subject")
+        except Exception:
+            skipped_unparseable += 1
+            continue
+        if not isinstance(inner, str) or not inner:
+            skipped_unparseable += 1
+            continue
+        if not SUBJECT_REGEX.match(inner):
+            # Junk entries in the upstream registry — too short, too long, or
+            # non-hex. CF and yaci both reject these; comparing them produces
+            # noise. Track and log but exclude.
+            invalid_subjects.add(inner)
+            continue
+        subjects.add(inner)
+
+    if skipped_unparseable:
+        print(f"[warn] skipped {skipped_unparseable} registry file(s) with "
+              f"missing/invalid `subject` field", file=sys.stderr)
+    if invalid_subjects:
+        print(f"[setup] filtered {len(invalid_subjects)} subject(s) that don't "
+              f"match the CIP-26 spec (56-120 lowercase hex chars):",
+              file=sys.stderr)
+        for s in sorted(invalid_subjects):
+            preview = s if len(s) <= 60 else s[:57] + "..."
+            print(f"          {preview}", file=sys.stderr)
+    return sorted(subjects)
+
+
+# ----- SSH tunnel ------------------------------------------------------------
+
+def port_is_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def open_ssh_tunnel(ssh_host: str, local_port: int, remote_port: int) -> subprocess.Popen:
+    """Spawns `ssh -L local:localhost:remote -N <host>` and waits for it to be ready."""
+    if port_is_open("127.0.0.1", local_port):
+        raise RuntimeError(
+            f"Port {local_port} is already in use locally. "
+            f"Pass --no-tunnel if you already have a tunnel running, "
+            f"or pass --local-port to choose a different local port."
+        )
+
+    cmd = [
+        "ssh",
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "ServerAliveInterval=30",
+        "-L", f"{local_port}:localhost:{remote_port}",
+        "-N", ssh_host,
+    ]
+    print(f"[setup] opening SSH tunnel: {' '.join(cmd)}")
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    atexit.register(_cleanup_tunnel, proc)
+
+    # Wait up to 10 s for the tunnel to come up.
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+            raise RuntimeError(f"SSH exited unexpectedly: {stderr.strip()}")
+        if port_is_open("127.0.0.1", local_port):
+            return proc
+        time.sleep(0.2)
+    proc.terminate()
+    raise RuntimeError(f"SSH tunnel to {ssh_host} did not come up within 10s")
+
+
+def _cleanup_tunnel(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# ----- Pre-flight checks -----------------------------------------------------
+
+def preflight(yaci_base: str, cf_base: str, check_cf: bool, check_yaci: bool) -> None:
+    if check_yaci:
+        # Accept any HTTP response from yaci-store — even 503 means "alive but
+        # at least one health indicator is DOWN", which is fine for our
+        # purposes because the API endpoints still serve in that state.
+        health_url = f"{yaci_base}/actuator/health"
+        print(f"[check] yaci-store    : GET {health_url}")
+        try:
+            status, body = http_get_json(health_url)
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace") if e.fp else ""
+            try:
+                body = json.loads(body_text)
+                health_status = body.get("status", "?")
+            except Exception:
+                health_status = "?"
+            print(f"          HTTP {e.code}, health={health_status!r} — continuing "
+                  f"(API endpoints are independent of aggregate health)")
+        else:
+            print(f"          HTTP {status}, "
+                  f"status={(body or {}).get('status')!r}")
+
+    if check_cf:
+        print(f"[check] CF API        : GET {cf_base}/api/v2/subjects")
+        # Use a known-bogus subject so we get a deterministic 404 fast — proves
+        # the host responds at all without depending on a specific entry.
+        status, _ = http_get_json(f"{cf_base}/api/v2/subjects/00")
+        if status not in (200, 404):
+            raise RuntimeError(f"CF API unexpected status: {status}")
+        print("          reachable")
+
+
+# ----- Diff logic ------------------------------------------------------------
+
+DIFF_VALUE_MAX_CHARS = 80
+
+
+def _short(v: Any) -> str:
+    """repr() but truncated for readability — base64 logos otherwise blow up the output."""
+    s = repr(v)
+    if len(s) > DIFF_VALUE_MAX_CHARS:
+        return s[: DIFF_VALUE_MAX_CHARS - 3] + "..."
+    return s
+
+
+def subset_diff(expected: Any, actual: Any, label_actual: str, path: str = "") -> list[str]:
+    """
+    Returns a list of human-readable diff strings.
+
+    Asymmetric: every field in `expected` must appear in `actual` with the same
+    value. Fields in `actual` but not in `expected` are tolerated (services
+    may add e.g. `type`, `extensions.cip113`).
+
+    `label_actual` is used in the diff message ("missing in <label>", etc.).
+    """
+    diffs: list[str] = []
+
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        for key in sorted(expected):
+            sub = f"{path}.{key}" if path else key
+            if key not in actual:
+                diffs.append(f"  {sub}: missing in {label_actual} "
+                             f"(registry has {_short(expected[key])})")
+            else:
+                diffs.extend(subset_diff(expected[key], actual[key], label_actual, sub))
+        return diffs
+
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            diffs.append(f"  {path}: list length differs "
+                         f"(registry={len(expected)}, {label_actual}={len(actual)})")
+            return diffs
+        for i, (e_item, a_item) in enumerate(zip(expected, actual)):
+            diffs.extend(subset_diff(e_item, a_item, label_actual, f"{path}[{i}]"))
+        return diffs
+
+    if type(expected) != type(actual):
+        diffs.append(f"  {path}: type differs (registry={type(expected).__name__} "
+                     f"{_short(expected)}, {label_actual}={type(actual).__name__} "
+                     f"{_short(actual)})")
+        return diffs
+
+    if expected != actual:
+        diffs.append(f"  {path}: registry={_short(expected)} vs "
+                     f"{label_actual}={_short(actual)}")
+    return diffs
+
+
+# ----- Per-subject comparison -----------------------------------------------
+
+@dataclass
+class ServiceResult:
+    """
+    Per-service presence tally — does the service have a 200 response for each
+    subject the registry says exists?
+    """
+    matched: list[str] = field(default_factory=list)            # 200 OK
+    missing: list[str] = field(default_factory=list)            # 404 (registry has it, service doesn't)
+    fetch_errors: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class ContractResult:
+    """
+    CF-vs-yaci contract agreement tally — when both services return 200 for
+    the same subject, are the responses byte-equivalent? Any diff is a
+    contract bug since both APIs claim CF V2 compatibility.
+    """
+    matched: list[str] = field(default_factory=list)
+    diverged: list[tuple[str, list[str]]] = field(default_factory=list)
+
+
+@dataclass
+class Cip68Result:
+    """
+    CIP-68 sub-tally — derived from `standards.cip68` blocks in the
+    show_cips_details responses. We only count subjects where AT LEAST ONE
+    side reports CIP-68 data; the rest of the universe is CIP-26-only and
+    out of scope here.
+
+    `cf_only` / `yaci_only` flag tokens that one service knows as CIP-68 but
+    the other doesn't — typically chain-sync gaps, not contract bugs.
+    """
+    agree: list[str] = field(default_factory=list)
+    diverged: list[tuple[str, list[str]]] = field(default_factory=list)
+    cf_only: list[str] = field(default_factory=list)
+    yaci_only: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Result:
+    cf: ServiceResult = field(default_factory=ServiceResult)
+    yaci: ServiceResult = field(default_factory=ServiceResult)
+    contract: ContractResult = field(default_factory=ContractResult)
+    cip68: Cip68Result = field(default_factory=Cip68Result)
+
+
+def _fetch(url: str, label: str, subject: str, bucket: ServiceResult
+           ) -> tuple[str | None, Any]:
+    """
+    Returns (status_token, body). status_token is one of
+    "OK" | "MISSING" | None (None means a fetch error was already recorded).
+    Applies CF_THROTTLE_SECS only to the CF side (yaci is local, no rate limit).
+    """
+    throttle = CF_THROTTLE_SECS if label == "cf" else 0.0
+    try:
+        status, body = http_get_json(url, throttle=throttle)
+    except Exception as e:
+        bucket.fetch_errors.append((subject, str(e)))
+        return None, None
+    if status not in (200, 404):
+        bucket.fetch_errors.append((subject, f"HTTP {status}"))
+        return None, None
+    if status == 404:
+        bucket.missing.append(subject)
+        return "MISSING", None
+    bucket.matched.append(subject)
+    return "OK", body
+
+
+def compare_subject(
+    subject: str,
+    yaci_base: str,
+    cf_base: str,
+    result: Result,
+    check_cf: bool,
+    check_yaci: bool,
+) -> None:
+    cf_token, cf_body = (None, None)
+    yaci_token, yaci_body = (None, None)
+
+    # show_cips_details=true exposes the per-CIP raw blocks under
+    # subject.standards.{cip26,cip68}, which is what we need for the CIP-68
+    # comparison. The merged metadata at the top level still reflects the
+    # query priority and stays comparable byte-for-byte.
+    if check_cf:
+        cf_url = f"{cf_base}/api/v2/subjects/{subject}?show_cips_details=true"
+        cf_token, cf_body = _fetch(cf_url, "cf", subject, result.cf)
+    if check_yaci:
+        yaci_url = f"{yaci_base}/api/v1/tokens/subject/{subject}?show_cips_details=true"
+        yaci_token, yaci_body = _fetch(yaci_url, "yaci", subject, result.yaci)
+
+    cf_label = (f"cf={cf_token}" if check_cf and cf_token else
+                "cf=ERR" if check_cf else "cf=skipped")
+    yaci_label = (f"yaci={yaci_token}" if check_yaci and yaci_token else
+                  "yaci=ERR" if check_yaci else "yaci=skipped")
+
+    contract_label = ""
+    diffs: list[str] = []
+    cip68_label = ""
+    cip68_diffs: list[str] = []
+    if check_cf and check_yaci and cf_token == "OK" and yaci_token == "OK":
+        # Both APIs return 200 → they MUST agree byte-for-byte (both claim CF
+        # V2 compat). Any diff is a contract bug.
+        diffs = subset_diff(cf_body, yaci_body, "yaci")
+        if diffs:
+            result.contract.diverged.append((subject, diffs))
+            contract_label = f"   DIVERGED({len(diffs)})"
+        else:
+            result.contract.matched.append(subject)
+            contract_label = "   AGREE"
+
+        # CIP-68 sub-comparison: pull standards.cip68 from each side and diff.
+        # Only count subjects where at least one side reports CIP-68 data.
+        cf_cip68 = _extract_cip68(cf_body)
+        yaci_cip68 = _extract_cip68(yaci_body)
+        cip68_label, cip68_diffs = _compare_cip68(subject, cf_cip68, yaci_cip68, result.cip68)
+
+    print(f"  [{subject[:16]}…] {cf_label:<14} {yaci_label:<16}{contract_label:<22}{cip68_label}")
+    for line in diffs:
+        print(line)
+    for line in cip68_diffs:
+        print(f"   [cip68]{line}")
+
+
+def _extract_cip68(body: Any) -> Any:
+    """Pull subject.standards.cip68 out of a V2 show_cips_details response, or None."""
+    if not isinstance(body, dict):
+        return None
+    subject = body.get("subject")
+    if not isinstance(subject, dict):
+        return None
+    standards = subject.get("standards")
+    if not isinstance(standards, dict):
+        return None
+    cip68 = standards.get("cip68")
+    return cip68 if isinstance(cip68, dict) else None
+
+
+def _compare_cip68(subject: str, cf_cip68: Any, yaci_cip68: Any,
+                   bucket: Cip68Result) -> tuple[str, list[str]]:
+    """
+    Compares the CIP-68 standards block between CF and yaci.
+    Returns (label, diff_lines). label is empty when neither side has CIP-68
+    data; otherwise one of "  cip68=AGREE / DIVERGED(n) / cf-only / yaci-only".
+    """
+    has_cf = cf_cip68 is not None
+    has_yaci = yaci_cip68 is not None
+    if not has_cf and not has_yaci:
+        return "", []
+    if has_cf and not has_yaci:
+        bucket.cf_only.append(subject)
+        return "  cip68=cf-only", []
+    if has_yaci and not has_cf:
+        bucket.yaci_only.append(subject)
+        return "  cip68=yaci-only", []
+    # Both sides have CIP-68 — must agree byte-for-byte.
+    diffs = subset_diff(cf_cip68, yaci_cip68, "yaci")
+    if diffs:
+        bucket.diverged.append((subject, diffs))
+        return f"  cip68=DIVERGED({len(diffs)})", diffs
+    bucket.agree.append(subject)
+    return "  cip68=AGREE", []
+
+
+# ----- Main ------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--network", choices=tuple(NETWORKS.keys()), default=DEFAULT_NETWORK,
+                        help=f"Which Cardano network to verify against (default: {DEFAULT_NETWORK}). "
+                             f"Switches the CF V2 API host AND the registry repo.")
+    parser.add_argument("--yaci-url", default=DEFAULT_YACI_BASE,
+                        help=f"Base URL for yaci-store (default: {DEFAULT_YACI_BASE})")
+    parser.add_argument("--ssh-host", default=DEFAULT_SSH_HOST,
+                        help=f"SSH host for tunnel (default: {DEFAULT_SSH_HOST})")
+    parser.add_argument("--remote-port", type=int, default=DEFAULT_REMOTE_PORT,
+                        help=f"Remote port to forward (default: {DEFAULT_REMOTE_PORT})")
+    parser.add_argument("--local-port", type=int, default=DEFAULT_LOCAL_PORT,
+                        help=f"Local port for the tunnel (default: {DEFAULT_LOCAL_PORT})")
+    parser.add_argument("--no-tunnel", action="store_true",
+                        help="Don't open an SSH tunnel; assume yaci-url is reachable as-is")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Only check the first N subjects (smoke test)")
+    parser.add_argument("--subject", default=None,
+                        help="Compare just one specific subject (skips registry listing)")
+    parser.add_argument("--repo-cache", default=None,
+                        help="Local clone path for the registry "
+                             "(default: <script_dir>/.cache/<repo-name-for-network>)")
+    parser.add_argument("--no-pull", action="store_true",
+                        help="Skip `git pull` on the registry clone (offline mode)")
+    parser.add_argument("--check", choices=("cf", "yaci", "both"), default="both",
+                        help="Which downstream(s) to verify against the registry. "
+                             "'cf' skips yaci (and the SSH tunnel); 'yaci' skips CF.")
+    parser.add_argument("--output-file", default=None,
+                        help="Write the full diff report as JSON to this file")
+    parser.add_argument("--cf-throttle-ms", type=int, default=0,
+                        help="Sleep this many ms before each CF API call. Default 0 "
+                             "(fine for preprod). For mainnet use 250-500 to stay under "
+                             "the AWS ELB rate limit (HTTP 429 fires at ~60 req/min sustained).")
+    args = parser.parse_args()
+    check_cf = args.check in ("cf", "both")
+    check_yaci = args.check in ("yaci", "both")
+    netcfg = NETWORKS[args.network]
+    cf_base = netcfg["cf_base"]
+    repo_url = netcfg["repo_url"]
+    registry_subdir = netcfg["registry_subdir"]
+    if args.repo_cache is None:
+        args.repo_cache = str(pathlib.Path(__file__).parent / ".cache" / netcfg["cache_subdir"])
+    _set_cf_throttle(args.cf_throttle_ms / 1000.0)
+    print(f"[setup] network={args.network}  cf_base={cf_base}  repo={repo_url}  "
+          f"cf-throttle={args.cf_throttle_ms}ms")
+
+    # SSH tunnel is only needed when yaci is in the check set and the user
+    # is using the default localhost URL (not pointing at an already-reachable host).
+    if check_yaci and not args.no_tunnel and args.yaci_url == DEFAULT_YACI_BASE:
+        try:
+            open_ssh_tunnel(args.ssh_host, args.local_port, args.remote_port)
+        except Exception as e:
+            print(f"[error] SSH tunnel setup failed: {e}", file=sys.stderr)
+            return 2
+        # Override yaci-url to point at the tunnel.
+        args.yaci_url = f"http://127.0.0.1:{args.local_port}"
+
+    try:
+        preflight(args.yaci_url, cf_base, check_cf=check_cf, check_yaci=check_yaci)
+    except Exception as e:
+        print(f"[error] preflight failed: {e}", file=sys.stderr)
+        return 2
+
+    # Always set up the local registry clone — needed both for listing and for
+    # the per-subject ground-truth lookup, even with --subject.
+    try:
+        repo_dir = ensure_registry_clone(pathlib.Path(args.repo_cache), repo_url, args.no_pull)
+    except subprocess.CalledProcessError as e:
+        print(f"[error] git command failed: {e}", file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"[error] registry clone setup failed: {e}", file=sys.stderr)
+        return 2
+
+    if args.subject:
+        subjects = [args.subject]
+        print(f"\n[run] comparing 1 subject")
+    else:
+        try:
+            all_subjects = list_subjects_from_clone(repo_dir, registry_subdir)
+        except Exception as e:
+            print(f"[error] could not list subjects from local clone: {e}",
+                  file=sys.stderr)
+            return 2
+        subjects = all_subjects[: args.limit] if args.limit else all_subjects
+        print(f"\n[run] comparing {len(subjects)} subject(s) "
+              f"(of {len(all_subjects)} total in registry)")
+
+    print(f"     {'subject':<18} {'cf':<14} {'yaci':<16}contract")
+    result = Result()
+    for subject in subjects:
+        compare_subject(subject, args.yaci_url, cf_base, result,
+                        check_cf=check_cf, check_yaci=check_yaci)
+
+    def fmt_svc(svc: ServiceResult) -> str:
+        return (f"matched={len(svc.matched)} "
+                f"missing={len(svc.missing)} "
+                f"errors={len(svc.fetch_errors)}")
+
+    print(f"\n{'-' * 60}")
+    print(f"Subjects examined: {len(subjects)}")
+    if check_cf:
+        print(f"  CF {args.network:<12}: {fmt_svc(result.cf)}")
+    if check_yaci:
+        print(f"  yaci-store      : {fmt_svc(result.yaci)}")
+    if check_cf and check_yaci:
+        print(f"  CF vs yaci      : agree={len(result.contract.matched)} "
+              f"diverged={len(result.contract.diverged)}")
+        cip68_total = (len(result.cip68.agree) + len(result.cip68.diverged)
+                       + len(result.cip68.cf_only) + len(result.cip68.yaci_only))
+        print(f"  CIP-68 standards: total={cip68_total} "
+              f"agree={len(result.cip68.agree)} "
+              f"diverged={len(result.cip68.diverged)} "
+              f"cf-only={len(result.cip68.cf_only)} "
+              f"yaci-only={len(result.cip68.yaci_only)}")
+    print(f"{'-' * 60}")
+
+    if args.output_file:
+        report = {
+            "network": args.network,
+            "yaci_url": args.yaci_url,
+            "cf_url": cf_base,
+            "registry_repo": repo_url,
+            "cf": {
+                "matched": result.cf.matched,
+                "missing": result.cf.missing,
+                "fetch_errors": [{"subject": s, "error": e}
+                                 for s, e in result.cf.fetch_errors],
+            },
+            "yaci": {
+                "matched": result.yaci.matched,
+                "missing": result.yaci.missing,
+                "fetch_errors": [{"subject": s, "error": e}
+                                 for s, e in result.yaci.fetch_errors],
+            },
+            "contract": {
+                "agree": result.contract.matched,
+                "diverged": [{"subject": s, "diffs": d}
+                             for s, d in result.contract.diverged],
+            },
+            "cip68": {
+                "agree": result.cip68.agree,
+                "diverged": [{"subject": s, "diffs": d}
+                             for s, d in result.cip68.diverged],
+                "cf_only": result.cip68.cf_only,
+                "yaci_only": result.cip68.yaci_only,
+            },
+        }
+        with open(args.output_file, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"Full report written to {args.output_file}")
+
+    cf_bad = check_cf and bool(result.cf.missing or result.cf.fetch_errors)
+    yaci_bad = check_yaci and bool(result.yaci.missing or result.yaci.fetch_errors)
+    contract_bad = check_cf and check_yaci and bool(result.contract.diverged)
+    cip68_bad = check_cf and check_yaci and bool(
+        result.cip68.diverged or result.cip68.cf_only or result.cip68.yaci_only)
+    return 1 if (cf_bad or yaci_bad or contract_bad or cip68_bad) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/AssetsExtConfiguration.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/AssetsExtConfiguration.java
@@ -1,0 +1,49 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReaderImpl;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26MetadataRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service.Cip68TokenService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReaderImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+// Master gate, blockfrost-extension pattern (see BFAutoConfiguration): the master flag is
+// OFF by default (matchIfMissing = false), so enabling the single store.assets.ext.enabled
+// flag is the one opt-in an operator needs. The per-CIP sub-flags then default ON
+// (matchIfMissing = true) for CIP-26 and CIP-68, so the master flag alone gives the default
+// behaviour. CIP-113 is the one exception — it stays OFF by default (matchIfMissing = false)
+// until it is live on mainnet.
+@ConditionalOnProperty(
+        name = "store.assets.ext.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+@ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.extensions.assetstore"})
+@EnableJpaRepositories(basePackages = {"com.bloxbean.cardano.yaci.store.extensions.assetstore"})
+@EntityScan(basePackages = {"com.bloxbean.cardano.yaci.store.extensions.assetstore"})
+@EnableTransactionManagement
+@EnableScheduling
+public class AssetsExtConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Cip26StorageReader cip26StorageReader(Cip26MetadataRepository cip26MetadataRepository) {
+        return new Cip26StorageReaderImpl(cip26MetadataRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Cip68StorageReader cip68StorageReader(Cip68TokenService cip68TokenService) {
+        return new Cip68StorageReaderImpl(cip68TokenService);
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/AssetsExtStoreProperties.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/AssetsExtStoreProperties.java
@@ -1,0 +1,82 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore;
+
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Plain properties POJO for the assets-ext extension module.
+ * <p>
+ * Bean is created by the starter's AutoConfiguration, which maps
+ * {@code store.assets.ext.*} Spring Boot properties into this object.
+ * This follows the yaci-store convention of keeping {@code @Value} annotations
+ * out of extension modules.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AssetsExtStoreProperties {
+
+    @Builder.Default
+    private Cip26 cip26 = new Cip26();
+
+    @Builder.Default
+    private Cip113 cip113 = new Cip113();
+
+    @Builder.Default
+    private String defaultQueryPriority = "CIP_68,CIP_26";
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Cip26 {
+        // Disabled by default — the off-chain GitHub registry is a separate
+        // trust source from the chain itself. Projects that want it must opt
+        // in explicitly via store.assets.ext.cip26.enabled=true.
+        @Builder.Default
+        private boolean enabled = false;
+
+        // Null means "let Cip26NetworkDefaults pick the per-network default".
+        @Nullable
+        @Builder.Default
+        private String gitOrganization = null;
+
+        @Nullable
+        @Builder.Default
+        private String gitProjectName = null;
+
+        @Nullable
+        @Builder.Default
+        private String gitMappingsFolder = null;
+
+        @Builder.Default
+        private String gitTmpFolder = "/tmp";
+
+        @Builder.Default
+        private boolean forceClone = false;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Cip113 {
+        // Disabled by default — CIP-113 isn't officially live on mainnet yet.
+        // When false, Cip113Configuration skips loading the per-network policy
+        // ID file at all (no misleading "policy IDs resolved" log line, and
+        // Cip113Configuration.isEnabled() correctly reports false to the
+        // storage reader).
+        @Builder.Default
+        private boolean enabled = false;
+
+        @Builder.Default
+        private List<String> registryNftPolicyIds = new ArrayList<>();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip26MetadataController.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip26MetadataController.java
@@ -1,0 +1,66 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("${apiPrefix}/tokens")
+@RequiredArgsConstructor
+@Tag(name = "CIP-26 Metadata", description = "Off-chain fungible token metadata from the GitHub cardano-token-registry")
+@Slf4j
+public class Cip26MetadataController {
+
+    private final Cip26StorageReader cip26StorageReader;
+
+    @Operation(operationId = "getCip26MetadataBySubject",
+            summary = "Get CIP-26 off-chain metadata by subject",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Metadata found"),
+                    @ApiResponse(responseCode = "404", description = "Subject not found in CIP-26 registry")
+            })
+    @GetMapping(path = "/cip26/{subject}", produces = {"application/json;charset=utf-8"})
+    public ResponseEntity<Cip26Metadata> getMetadataBySubject(
+            @Parameter(description = "The subject identifier (policy ID + asset name hex)")
+            @PathVariable("subject")
+            @Pattern(regexp = TokenPatterns.SUBJECT_REGEX,
+                    message = "subject must be 56-120 hex characters (policyId + assetName)")
+            String subject) {
+
+        return cip26StorageReader.findBySubject(subject)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Operation(operationId = "getCip26MetadataByPolicyAndAssetName",
+            summary = "Get CIP-26 off-chain metadata by policy ID and asset name",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Metadata found"),
+                    @ApiResponse(responseCode = "404", description = "Not found in CIP-26 registry")
+            })
+    @GetMapping(path = "/cip26/{policyId}/{assetName}", produces = {"application/json;charset=utf-8"})
+    public ResponseEntity<Cip26Metadata> getMetadataByPolicyAndAssetName(
+            @Parameter(description = "The policy ID (56 hex characters)")
+            @PathVariable("policyId")
+            @Pattern(regexp = TokenPatterns.POLICY_ID_REGEX,
+                    message = "policyId must be exactly 56 hex characters")
+            String policyId,
+            @Parameter(description = "The asset name (hex-encoded)")
+            @PathVariable("assetName")
+            @Pattern(regexp = TokenPatterns.ASSET_NAME_REGEX,
+                    message = "assetName must be 0-64 hex characters")
+            String assetName) {
+
+        return cip26StorageReader.findBySubject(policyId + assetName)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip68MetadataController.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip68MetadataController.java
@@ -1,0 +1,72 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.Cip68Constants;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("${apiPrefix}/tokens")
+@RequiredArgsConstructor
+@Tag(name = "CIP-68 Metadata", description = "On-chain fungible token metadata parsed from CIP-68 reference NFT inline datums")
+@Slf4j
+public class Cip68MetadataController {
+
+    private final Cip68StorageReader cip68StorageReader;
+
+    @Operation(operationId = "getCip68FungibleTokenMetadataBySubject",
+            summary = "Get CIP-68 fungible token metadata by subject",
+            description = "The subject is the fungible token unit (policyId + 0014df10 + hex name). "
+                    + "The CIP-68 reference NFT prefix is resolved automatically.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Fungible token metadata found"),
+                    @ApiResponse(responseCode = "404", description = "No CIP-68 reference NFT found for this subject")
+            })
+    @GetMapping(path = "/cip68/ft/{subject}", produces = {"application/json;charset=utf-8"})
+    public ResponseEntity<FungibleTokenMetadata> getFungibleTokenMetadataBySubject(
+            @Parameter(description = "The fungible token subject (policyId + 0014df10 + hex asset name)")
+            @PathVariable("subject")
+            @Pattern(regexp = TokenPatterns.SUBJECT_REGEX,
+                    message = "subject must be 56-120 hex characters (policyId + assetName)")
+            String subject) {
+
+        return cip68StorageReader.findBySubject(subject)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Operation(operationId = "getCip68FungibleTokenMetadata",
+            summary = "Get CIP-68 fungible token metadata by policy ID and asset name",
+            description = "The asset name is the raw token name (hex) WITHOUT the CIP-68 label prefix. "
+                    + "The reference NFT prefix (000643b0) is prepended automatically.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Fungible token metadata found"),
+                    @ApiResponse(responseCode = "404", description = "No CIP-68 reference NFT found for this policy/asset")
+            })
+    @GetMapping(path = "/cip68/ft/{policyId}/{rawAssetName}", produces = {"application/json;charset=utf-8"})
+    public ResponseEntity<FungibleTokenMetadata> getFungibleTokenMetadata(
+            @Parameter(description = "The policy ID (56 hex characters)")
+            @PathVariable("policyId")
+            @Pattern(regexp = TokenPatterns.POLICY_ID_REGEX,
+                    message = "policyId must be exactly 56 hex characters")
+            String policyId,
+            @Parameter(description = "The raw asset name (hex) without CIP-68 label prefix")
+            @PathVariable("rawAssetName")
+            @Pattern(regexp = TokenPatterns.CIP68_RAW_ASSET_NAME_REGEX,
+                    message = "rawAssetName must be 0-56 hex characters (CIP-68 label is prepended automatically)")
+            String rawAssetName) {
+
+        String referenceNftAssetName = Cip68Constants.REFERENCE_TOKEN_PREFIX + rawAssetName;
+        return cip68StorageReader.findByPolicyIdAndAssetName(policyId, referenceNftAssetName)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenMetadataSubjectController.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenMetadataSubjectController.java
@@ -1,0 +1,147 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.QueryPriority;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.*;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService.BatchPrefetchData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.PostConstruct;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Subjects API — multi-standard token metadata with priority-based merging.
+ * <p>
+ * Merges metadata from multiple CIP standards into a single response:
+ * <ul>
+ *   <li><b>CIP-26</b> — offchain metadata synced from the GitHub cardano-token-registry</li>
+ *   <li><b>CIP-68</b> — on-chain reference NFT metadata parsed from inline datums</li>
+ *   <li><b>CIP-113</b> — programmable token extensions (transfer logic scripts, when enabled)</li>
+ * </ul>
+ *
+ * <p><b>Query Priority:</b>
+ * When the same property (e.g. {@code name}) exists in both CIP-26 and CIP-68, the standard
+ * with higher priority wins. The default order is {@code CIP_68, CIP_26} (on-chain preferred),
+ * configurable per-request via the {@code query_priority} parameter or globally via
+ * {@code store.assets.ext.default-query-priority}.
+ *
+ * @see TokenQueryService
+ */
+@RestController
+@RequestMapping("${apiPrefix}/tokens")
+@RequiredArgsConstructor
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Token Metadata Subjects",
+        description = "Multi-standard merged metadata API for token subjects")
+@Slf4j
+public class TokenMetadataSubjectController {
+
+    private static final List<String> ALL_PROPERTIES = List.of();
+
+    private static final List<String> REQUIRED_PROPERTIES = List.of("name", "description");
+
+    private final TokenQueryService tokenQueryService;
+    private final AssetsExtStoreProperties assetsStoreProperties;
+
+    private List<QueryPriority> defaultQueryPriority;
+
+    @PostConstruct
+    void init() {
+        String priority = assetsStoreProperties.getDefaultQueryPriority();
+        defaultQueryPriority = java.util.Arrays.stream(priority.split(","))
+                .map(String::trim)
+                .map(QueryPriority::valueOf)
+                .toList();
+    }
+
+    @Operation(operationId = "getSubject", summary = "Query either all or a subset of properties of a given subject",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Merged metadata found"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Required properties (name, description) missing from filter"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Subject not found or has no valid metadata")
+            })
+    @GetMapping(path = "/subject/{subject}", produces = {"application/json;charset=utf-8"})
+    public ResponseEntity<SubjectResponse> getSubject(
+            @Parameter(description = "the concatenation of policy id and asset name (if any) to query")
+            @PathVariable("subject")
+            @Pattern(regexp = TokenPatterns.SUBJECT_REGEX,
+                    message = "subject must be 56-120 hex characters (policyId + assetName)")
+            String subject,
+            @Parameter(description = "the list of properties to be returned in the response, if none specified, all properties will be returned")
+            @RequestParam(value = "property", required = false) List<String> properties,
+            @Parameter(description = "the CIP priority: if the same property is present in multiple standards, the one with highest priority is returned")
+            @RequestParam(value = "query_priority", required = false) List<QueryPriority> priorities,
+            @Parameter(description = "whether all the CIP specific properties should be returned in the response. False by default")
+            @RequestParam(value = "show_cips_details", defaultValue = "false", required = false) Boolean showCipsDetails) {
+
+        // Per-request line at DEBUG, not INFO — at any real RPS the previous INFO level
+        // floods logs without operator value (the request is also recorded by the access log
+        // for any deployment that wants per-request observability).
+        log.debug("subject: {}, properties: {}, priorities: {}, showCipsDetails: {}",
+                subject,
+                properties != null ? String.join(",", properties) : "",
+                priorities != null ? priorities.stream().map(QueryPriority::name).collect(Collectors.joining(",")) : "",
+                showCipsDetails);
+
+        List<String> queryProperties = properties != null ? properties : ALL_PROPERTIES;
+        validateProperties(queryProperties);
+        List<QueryPriority> queryPriority = priorities != null ? priorities : defaultQueryPriority;
+        boolean includeCipsDetails = Boolean.TRUE.equals(showCipsDetails);
+
+        List<String> stringPriorities = queryPriority.stream().map(QueryPriority::name).toList();
+        return tokenQueryService.querySubject(subject, queryPriority, queryProperties, includeCipsDetails)
+                .map(result -> ResponseEntity.ok(new SubjectResponse(result, stringPriorities)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Operation(operationId = "getSubjects", summary = "Query either all or a subset of properties of the given subjects",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Batch results (subjects without valid metadata are excluded)")
+            })
+    @PostMapping(value = "/subject/query", produces = {"application/json;charset=utf-8"}, consumes = {"application/json;charset=utf-8"})
+    public ResponseEntity<SubjectBatchResponse> getSubjects(
+            @Parameter(name = "body", required = true, schema = @Schema)
+            @Valid @RequestBody BatchRequest body,
+            @Parameter(description = "the CIP priority: if the same property is present in multiple standards, the one with highest priority is returned")
+            @RequestParam(value = "query_priority", required = false) List<QueryPriority> priorities,
+            @Parameter(description = "whether all the CIP specific properties should be returned in the response. False by default")
+            @RequestParam(value = "show_cips_details", defaultValue = "false", required = false) Boolean showCipsDetails) {
+
+        List<String> queryProperties = body.getProperties() != null ? body.getProperties() : ALL_PROPERTIES;
+        validateProperties(queryProperties);
+        List<QueryPriority> queryPriority = priorities != null ? priorities : defaultQueryPriority;
+        boolean includeCipsDetails = Boolean.TRUE.equals(showCipsDetails);
+
+        BatchPrefetchData prefetchData = tokenQueryService.prefetchBatch(body.getSubjects(), queryProperties);
+
+        List<Subject> subjects = body.getSubjects()
+                .stream()
+                .map(subject -> tokenQueryService.querySubjectBatch(
+                        subject, queryPriority, queryProperties, prefetchData, includeCipsDetails))
+                .filter(s -> !s.metadata().isEmpty() && s.metadata().isValid())
+                .toList();
+
+        List<String> stringPriorities = queryPriority.stream().map(QueryPriority::name).toList();
+        return ResponseEntity.ok(new SubjectBatchResponse(subjects, stringPriorities));
+    }
+
+    private void validateProperties(List<String> queryProperties) {
+        if (!queryProperties.isEmpty() && !queryProperties.containsAll(REQUIRED_PROPERTIES)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "When filtering properties, 'name' and 'description' are required and must be included");
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenPatterns.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenPatterns.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+/**
+ * Regex patterns for {@code jakarta.validation.constraints.Pattern} applied to controller
+ * path variables and DTO fields. Centralised so the same constants can be referenced from
+ * multiple controllers and tests.
+ * <p>
+ * Values must be compile-time constants so they can appear in annotation element values.
+ */
+public final class TokenPatterns {
+
+    /**
+     * Subject = policyId (28 bytes / 56 hex chars) + optional assetName (up to 32 bytes / 64 hex chars).
+     * Total length: 56..120 hex characters.
+     */
+    public static final String SUBJECT_REGEX = "^[0-9a-fA-F]{56,120}$";
+
+    /** Policy id — Blake2b-224 hash, exactly 56 hex characters. */
+    public static final String POLICY_ID_REGEX = "^[0-9a-fA-F]{56}$";
+
+    /** Asset name — 0..32 bytes, hex-encoded (0..64 characters). */
+    public static final String ASSET_NAME_REGEX = "^[0-9a-fA-F]{0,64}$";
+
+    /**
+     * CIP-68 "raw" asset name — the hex asset name <em>without</em> the 4-byte reference NFT
+     * label prefix. The controller prepends the label before querying, so the raw name can be
+     * at most 32 - 4 = 28 bytes (0..56 hex characters).
+     */
+    public static final String CIP68_RAW_ASSET_NAME_REGEX = "^[0-9a-fA-F]{0,56}$";
+
+    private TokenPatterns() {
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/BatchRequest.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/BatchRequest.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller.TokenPatterns;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchRequest {
+
+    @JsonProperty("subjects")
+    @Valid
+    @Size(min = 1, max = 100, message = "subjects list must contain between 1 and 100 entries")
+    @Schema(name = "subjects", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<@Pattern(regexp = TokenPatterns.SUBJECT_REGEX,
+            message = "subject must be 56-120 hex characters (policyId + assetName)") String> subjects = new ArrayList<>();
+
+    @JsonProperty("properties")
+    @Valid
+    @Schema(name = "properties")
+    private List<String> properties = null;
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Extension.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Extension.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Marker interface for API extensions.
+ * Each CIP standard that enriches the Subject response implements this interface.
+ * Extensions are serialized into the {@code extensions} map keyed by their CIP identifier.
+ */
+@Schema(description = "Base type for CIP extensions.",
+        oneOf = {ProgrammableTokenCip113.class})
+public interface Extension {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/LongProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/LongProperty.java
@@ -1,0 +1,4 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+public record LongProperty(Long value, String source) implements Property<Long> {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Metadata.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Metadata.java
@@ -1,0 +1,78 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+public record Metadata(StringProperty name, StringProperty description, StringProperty ticker, LongProperty decimals,
+                       StringProperty logo, StringProperty url, LongProperty version) {
+
+    private static final Metadata EMPTY_METADATA = Metadata.builder().build();
+
+    public static Metadata empty() {
+        return EMPTY_METADATA;
+    }
+
+    public Metadata merge(Metadata that) {
+        return new Metadata(name != null ? name : that.name(),
+                description != null ? description : that.description(),
+                ticker != null ? ticker : that.ticker(),
+                decimals != null ? decimals : that.decimals(),
+                logo != null ? logo : that.logo(),
+                url != null ? url : that.url(),
+                version != null ? version : that.version());
+    }
+
+    /**
+     * Build a Metadata from a CIP-26 Cip26Metadata entity, applying property filtering.
+     *
+     * @param entity     the CIP-26 entity
+     * @param logo       the logo string (from Cip26Metadata.logo), or null if not available / not requested
+     * @param properties the list of properties to include; empty means all
+     */
+    public static Metadata from(Cip26Metadata entity, @Nullable String logo, List<String> properties) {
+        StringProperty nameProp = include("name", properties) && entity.getName() != null
+                ? new StringProperty(entity.getName(), QueryPriority.CIP_26.name()) : null;
+        StringProperty descProp = include("description", properties) && entity.getDescription() != null
+                ? new StringProperty(entity.getDescription(), QueryPriority.CIP_26.name()) : null;
+        StringProperty tickerProp = include("ticker", properties) && entity.getTicker() != null
+                ? new StringProperty(entity.getTicker(), QueryPriority.CIP_26.name()) : null;
+        LongProperty decimalsProp = include("decimals", properties) && entity.getDecimals() != null
+                ? new LongProperty(entity.getDecimals(), QueryPriority.CIP_26.name()) : null;
+        StringProperty logoProp = include("logo", properties) && logo != null
+                ? new StringProperty(logo, QueryPriority.CIP_26.name()) : null;
+        StringProperty urlProp = include("url", properties) && entity.getUrl() != null
+                ? new StringProperty(entity.getUrl(), QueryPriority.CIP_26.name()) : null;
+
+        return new Metadata(nameProp, descProp, tickerProp, decimalsProp, logoProp, urlProp, null);
+    }
+
+    public static Metadata from(FungibleTokenMetadata cip68TokenMetadata) {
+        StringProperty nameProp = cip68TokenMetadata.name() != null ? new StringProperty(cip68TokenMetadata.name(), QueryPriority.CIP_68.name()) : null;
+        StringProperty descProp = cip68TokenMetadata.description() != null ? new StringProperty(cip68TokenMetadata.description(), QueryPriority.CIP_68.name()) : null;
+        StringProperty tickerProp = cip68TokenMetadata.ticker() != null ? new StringProperty(cip68TokenMetadata.ticker(), QueryPriority.CIP_68.name()) : null;
+        LongProperty decimalsProp = cip68TokenMetadata.decimals() != null ? new LongProperty(cip68TokenMetadata.decimals(), QueryPriority.CIP_68.name()) : null;
+        StringProperty logoProp = cip68TokenMetadata.logo() != null ? new StringProperty(cip68TokenMetadata.logo(), QueryPriority.CIP_68.name()) : null;
+        StringProperty urlProp = cip68TokenMetadata.url() != null ? new StringProperty(cip68TokenMetadata.url(), QueryPriority.CIP_68.name()) : null;
+        LongProperty versionProp = cip68TokenMetadata.version() != null ? new LongProperty(cip68TokenMetadata.version(), QueryPriority.CIP_68.name()) : null;
+
+        return new Metadata(nameProp, descProp, tickerProp, decimalsProp, logoProp, urlProp, versionProp);
+    }
+
+    public boolean isEmpty() {
+        return this.equals(EMPTY_METADATA);
+    }
+
+    public boolean isValid() {
+        return this.name != null && this.description != null;
+    }
+
+    private static boolean include(String propertyName, List<String> properties) {
+        return properties.isEmpty() || properties.contains(propertyName);
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Property.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Property.java
@@ -1,0 +1,9 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+public interface Property<T> {
+
+    T value();
+
+    String source();
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/QueryPriority.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/QueryPriority.java
@@ -1,0 +1,7 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+public enum QueryPriority {
+
+    CIP_26, CIP_68
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Standards.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Standards.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.Cip26TokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+
+public record Standards(Cip26TokenMetadata cip26, FungibleTokenMetadata cip68) {
+
+    public static Standards empty() {
+        return new Standards(null, null);
+    }
+
+    public Standards merge(Standards that) {
+        Cip26TokenMetadata finalCip26 = cip26 != null ? cip26 : that.cip26();
+        FungibleTokenMetadata finalCip68 = cip68 != null ? cip68 : that.cip68();
+        return new Standards(finalCip26, finalCip68);
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/StringProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/StringProperty.java
@@ -1,0 +1,4 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+public record StringProperty(String value, String source) implements Property<String> {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Subject.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/Subject.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "A token subject with its metadata, standards details, and optional extensions from additional CIPs")
+public record Subject(
+
+        @Schema(description = "The subject identifier -- concatenation of policy ID and asset name (hex)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String subject,
+
+        @Schema(description = "Token type: NATIVE for standard tokens, PROGRAMMABLE for tokens with on-chain transfer logic (e.g. CIP-113)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        TokenType type,
+
+        @Schema(description = "Merged display metadata from CIP-26/CIP-68 based on query priority",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Metadata metadata,
+
+        @Schema(description = "Raw per-standard metadata, only present when show_cips_details=true",
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Standards standards,
+
+        @Schema(description = "Additional on-chain properties from CIP extensions. "
+                + "Each key is a CIP identifier (e.g. 'cip113'). "
+                + "Omitted when the token has no extensions.",
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Map<String, Extension> extensions) {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/SubjectBatchResponse.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/SubjectBatchResponse.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Batch subject query response.")
+public record SubjectBatchResponse(
+        @Schema(description = "List of subjects with valid metadata (subjects without name+description are excluded).")
+        List<Subject> subjects,
+
+        @Schema(description = "The CIP priority order that was used for this query.")
+        List<String> queryPriority
+) {}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/SubjectResponse.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/SubjectResponse.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Single subject query response with the resolved query priority.")
+public record SubjectResponse(
+        @Schema(description = "The merged subject with metadata and extensions.")
+        Subject subject,
+
+        @Schema(description = "The CIP priority order that was used for this query.")
+        List<String> queryPriority
+) {}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/TokenType.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/TokenType.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Token type classification based on on-chain constraints.")
+public enum TokenType {
+    @Schema(description = "Standard Cardano token with no on-chain transfer logic.")
+    NATIVE,
+
+    @Schema(description = "Token with on-chain transfer validation rules (e.g. CIP-113).")
+    PROGRAMMABLE
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/AnnotatedSignature.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/AnnotatedSignature.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Detached signature over a single CIP-26 property value.
+ * <p>
+ * Ported from {@code cf-token-metadata-registry} ({@code AnnotatedSignature}) so that
+ * yaci-store's {@code standards.cip26} block matches the CF V2 wire shape exactly when
+ * {@code show_cips_details=true}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnnotatedSignature {
+
+    @JsonProperty("signature")
+    @Schema(name = "signature", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String signature;
+
+    @JsonProperty("publicKey")
+    @Schema(name = "publicKey", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String publicKey;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/Cip26TokenMetadata.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/Cip26TokenMetadata.java
@@ -1,0 +1,232 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.DecimalsProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.DescriptionProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.LogoProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.NameProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.TickerProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.UrlProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Signature;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * CIP-26 metadata DTO returned under {@code standards.cip26} when {@code show_cips_details=true}.
+ * <p>
+ * Shape ported 1:1 from {@code cf-token-metadata-registry}'s
+ * {@code api.model.rest.Cip26Metadata} so yaci-store and the CF V2 API produce
+ * byte-for-byte equivalent JSON for this block. Each well-known property is wrapped
+ * in a {@link TokenMetadataProperty} envelope ({@code value}/{@code signatures}/{@code sequenceNumber})
+ * — the data already lives in {@code ft_offchain_metadata.properties} (the original
+ * CIP-26 mapping JSON), so we just lift it through.
+ * <p>
+ * Named {@code Cip26TokenMetadata} (not {@code Cip26Metadata}) to avoid colliding with
+ * the JPA entity in {@code cip26.storage.impl.model.Cip26Metadata}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Cip26TokenMetadata {
+
+    @JsonProperty("subject")
+    @Schema(name = "subject", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String subject;
+
+    @JsonProperty("policy")
+    @Schema(name = "policy")
+    private String policy;
+
+    @JsonProperty("name")
+    @Valid
+    @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
+    private NameProperty name;
+
+    @JsonProperty("description")
+    @Valid
+    @Schema(name = "description", requiredMode = Schema.RequiredMode.REQUIRED)
+    private DescriptionProperty description;
+
+    @JsonProperty("url")
+    @Valid
+    @Schema(name = "url")
+    private UrlProperty url;
+
+    @JsonProperty("ticker")
+    @Valid
+    @Schema(name = "ticker")
+    private TickerProperty ticker;
+
+    @JsonProperty("decimals")
+    @Valid
+    @Schema(name = "decimals")
+    private DecimalsProperty decimals;
+
+    @JsonProperty("logo")
+    @Valid
+    @Schema(name = "logo")
+    private LogoProperty logo;
+
+    @JsonProperty("updated")
+    @Valid
+    @Schema(name = "updated")
+    private Date updated;
+
+    @JsonProperty("updatedBy")
+    @Valid
+    @Schema(name = "updatedBy")
+    private String updatedBy;
+
+    @Builder.Default
+    private Map<String, TokenMetadataProperty<?>> additionalProperties = new HashMap<>();
+
+    @JsonAnySetter
+    public void propertiesSetter(final String propertyName, final TokenMetadataProperty<?> property) {
+        // Jackson never invokes @JsonAnySetter with a null/blank key (JSON object keys are
+        // strings and the parser rejects empty keys upstream), so no defensive validation
+        // is needed here. Null property → key removal, mirroring the previous behaviour.
+        if (property != null) {
+            this.additionalProperties.put(propertyName, property);
+        } else {
+            this.additionalProperties.remove(propertyName);
+        }
+    }
+
+    @JsonAnyGetter
+    public Map<String, TokenMetadataProperty<?>> propertiesGetter() {
+        return getAdditionalProperties();
+    }
+
+    /**
+     * Build a {@code Cip26TokenMetadata} from yaci's persisted CIP-26 entity.
+     * <p>
+     * The original CIP-26 mapping JSON (with {@code Item} envelopes carrying signatures
+     * and sequence numbers) is stored verbatim on the entity's {@code properties} column,
+     * so we lift the envelopes straight through. The {@code logo} comes from the separate
+     * {@code Cip26Metadata} table — we re-wrap it using the logo's stored {@code Item} from
+     * the same mapping JSON to preserve signatures, while substituting the table copy as
+     * the canonical value.
+     *
+     * @param entity   the CIP-26 JPA entity
+     * @param logoB64  base64-encoded logo string (from {@code Cip26Metadata}), or null
+     */
+    public static Cip26TokenMetadata from(
+            com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata entity,
+            @Nullable String logoB64) {
+        if (entity == null) {
+            return null;
+        }
+
+        Mapping mapping = entity.getProperties();
+        Cip26TokenMetadataBuilder builder = Cip26TokenMetadata.builder()
+                .subject(entity.getSubject())
+                .policy(entity.getPolicy());
+
+        if (mapping != null) {
+            builder.name(stringProperty(mapping.name(), NameProperty::new));
+            builder.description(stringProperty(mapping.description(), DescriptionProperty::new));
+            builder.url(stringProperty(mapping.url(), UrlProperty::new));
+            builder.ticker(stringProperty(mapping.ticker(), TickerProperty::new));
+            builder.decimals(decimalsProperty(mapping.decimals()));
+            if (logoB64 != null) {
+                // Preserve signatures from mapping.logo() but use the canonical base64 string from Cip26Metadata.
+                builder.logo(logoProperty(mapping.logo(), logoB64));
+            }
+        }
+
+        // CF's preprod V2 API does not emit `updated` / `updatedBy` (the fields end up null
+        // and are suppressed by NON_NULL inclusion). Yaci has the data on the entity, but
+        // populating these would diverge from CF's wire shape — so leave them null to match.
+        // Keep the fields on the DTO so the structure stays compatible if CF ever starts
+        // emitting them.
+
+        return builder.build();
+    }
+
+    private static <P extends TokenMetadataProperty<String>> P stringProperty(Item item, Supplier<P> ctor) {
+        if (item == null || item.value() == null) {
+            return null;
+        }
+        P property = ctor.get();
+        property.setValue(item.value());
+        property.setSignatures(toSignatures(item.signatures()));
+        property.setSequenceNumber(sequenceNumberOf(item));
+        return property;
+    }
+
+    private static DecimalsProperty decimalsProperty(Item item) {
+        if (item == null || item.value() == null) {
+            return null;
+        }
+        BigDecimal value;
+        try {
+            value = new BigDecimal(item.value());
+        } catch (NumberFormatException e) {
+            log.warn("Invalid decimals value '{}'", item.value());
+            return null;
+        }
+        DecimalsProperty property = new DecimalsProperty();
+        property.setValue(value);
+        property.setSignatures(toSignatures(item.signatures()));
+        property.setSequenceNumber(sequenceNumberOf(item));
+        return property;
+    }
+
+    private static LogoProperty logoProperty(@Nullable Item itemForSignatures, String logoB64) {
+        LogoProperty property = new LogoProperty();
+        property.setValue(logoB64);
+        property.setSignatures(itemForSignatures != null ? toSignatures(itemForSignatures.signatures()) : null);
+        property.setSequenceNumber(itemForSignatures != null ? sequenceNumberOf(itemForSignatures) : null);
+        return property;
+    }
+
+    // Preserves the registry source distinction CF passes through verbatim:
+    //   field absent in JSON → Jackson parses as null → emit null
+    //   "signatures": []     → Jackson parses as empty list → emit []
+    //   "signatures": [...]  → emit the mapped list
+    // Collapsing null and [] to a single value (either way) produces ~37 subject
+    // divergences against CF preprod where the inconsistency is registry-driven,
+    // not yaci's choice — the only spec-correct answer is byte-faithful pass-through.
+    @Nullable
+    private static List<AnnotatedSignature> toSignatures(@Nullable List<Signature> signatures) {
+        if (signatures == null) {
+            return null;
+        }
+        return signatures.stream()
+                .map(s -> new AnnotatedSignature(s.signature(), s.publicKey()))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    // Null pass-through when the registry entry has no sequenceNumber. Returning
+    // BigDecimal.ZERO instead would falsely advertise "version 0" — which is a valid
+    // sequenceNumber in CIP-26 — so we'd be conflating "unknown" with "first version".
+    @Nullable
+    private static BigDecimal sequenceNumberOf(Item item) {
+        return item.sequenceNumber() != null ? BigDecimal.valueOf(item.sequenceNumber()) : null;
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/TokenMetadataProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/TokenMetadataProperty.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Generic CIP-26 signed-property envelope: a property {@code value} plus its detached
+ * {@code signatures} and a monotonic {@code sequenceNumber}.
+ * <p>
+ * Ported from {@code cf-token-metadata-registry} ({@code TokenMetadataProperty}) so that
+ * yaci-store's {@code standards.cip26} block matches the CF V2 wire shape exactly. Yaci
+ * persists the full envelope in {@code ft_offchain_metadata.properties} (a JSON column),
+ * so populating these fields is just a copy from {@link com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenMetadataProperty<T> {
+
+    // Null when the registry entry has no off-chain signature data — matches CF V2,
+    // which emits "signatures": null rather than an empty array. yaci does not
+    // persist signatures, so this is null in practice for every property.
+    @JsonProperty("signatures")
+    @Valid
+    @Nullable
+    @Schema(name = "signatures", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<AnnotatedSignature> signatures;
+
+    @JsonProperty("sequenceNumber")
+    @Valid
+    @Nullable
+    @DecimalMin("0")
+    @Schema(name = "sequenceNumber", requiredMode = Schema.RequiredMode.REQUIRED)
+    private BigDecimal sequenceNumber;
+
+    @JsonProperty("value")
+    private T value;
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/DecimalsProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/DecimalsProperty.java
@@ -1,0 +1,26 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class DecimalsProperty extends TokenMetadataProperty<BigDecimal> {
+    @Valid
+    @DecimalMin("0")
+    @DecimalMax("255")
+    @Schema(name = "value", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public BigDecimal getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/DescriptionProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/DescriptionProperty.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class DescriptionProperty extends TokenMetadataProperty<String> {
+    @Valid
+    @Size(max = 500)
+    @Schema(name = "value", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/LogoProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/LogoProperty.java
@@ -1,0 +1,27 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Logo property — value is a base64-encoded PNG, per CIP-26 spec.
+ * <p>
+ * Differs from CF's {@code LogoProperty extends TokenMetadataProperty<byte[]>}: yaci uses
+ * {@code String} so the already-base64 string from the registry passes through unchanged.
+ * Wire shape is identical (Jackson serializes both as a base64 text node), so consumers
+ * see the same JSON. CF returns hex-encoded bytes today; yaci stays spec-compliant on
+ * base64. The user explicitly accepted that as the only divergence.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class LogoProperty extends TokenMetadataProperty<String> {
+    @Schema(name = "value", description = "base64-encoded PNG", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/NameProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/NameProperty.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class NameProperty extends TokenMetadataProperty<String> {
+    @Valid
+    @Size(min = 1, max = 50)
+    @Schema(name = "value", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/TickerProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/TickerProperty.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class TickerProperty extends TokenMetadataProperty<String> {
+    @Valid
+    @Size(min = 2, max = 9)
+    @Schema(name = "value", example = "QUID", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/UrlProperty.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/wellknownproperties/UrlProperty.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class UrlProperty extends TokenMetadataProperty<String> {
+    @Valid
+    @Pattern(regexp = "^https://")
+    @Size(max = 250)
+    @Schema(name = "value", example = "https://www.iohk.io", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/service/TokenQueryService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/service/TokenQueryService.java
@@ -1,0 +1,241 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.QueryPriority;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.*;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.Cip26TokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.Cip113StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Core query and merge logic for multi-standard token metadata.
+ * <p>
+ * Merges CIP-26 and CIP-68 metadata based on a configurable priority order,
+ * and appends CIP-113 extensions when applicable.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenQueryService {
+
+    private static final ResolvedMetadata IDENTITY = new ResolvedMetadata(Metadata.empty(), Standards.empty());
+
+    private final Cip26StorageReader cip26StorageReader;
+    private final Cip68StorageReader cip68StorageReader;
+    private final Cip113StorageReader cip113StorageReader;
+
+    /**
+     * Query and merge metadata for a single subject.
+     *
+     * @param subject         the subject identifier (policyId + assetName hex)
+     * @param queryPriority   ordered list of CIP standards to query
+     * @param queryProperties list of properties to include (empty means all)
+     * @param showCipsDetails whether to include raw per-standard metadata
+     * @return the merged Subject, or empty if no valid metadata found
+     */
+    public Optional<Subject> querySubject(String subject,
+                                          List<QueryPriority> queryPriority,
+                                          List<String> queryProperties,
+                                          boolean showCipsDetails) {
+
+        ResolvedMetadata resolved = queryPriority.stream()
+                .reduce(IDENTITY, combineStandards(subject, queryProperties), aggregateResults());
+
+        if (resolved.metadata().isEmpty() || !resolved.metadata().isValid()) {
+            return Optional.empty();
+        }
+
+        Map<String, Extension> extensions = buildExtensions(subject);
+        TokenType type = extensions.isEmpty() ? TokenType.NATIVE : TokenType.PROGRAMMABLE;
+
+        return Optional.of(new Subject(subject, type, resolved.metadata(),
+                showCipsDetails ? resolved.standards() : null,
+                extensions.isEmpty() ? null : extensions));
+    }
+
+    /**
+     * Query and merge metadata for a single subject in batch context,
+     * using pre-fetched data maps to avoid N+1 queries.
+     */
+    public Subject querySubjectBatch(String subject,
+                                     List<QueryPriority> queryPriority,
+                                     List<String> queryProperties,
+                                     BatchPrefetchData prefetchData,
+                                     boolean showCipsDetails) {
+
+        ResolvedMetadata resolved = queryPriority.stream()
+                .reduce(IDENTITY, combineStandardsBatch(subject, queryProperties, prefetchData), aggregateResults());
+
+        Map<String, Extension> extensions = new LinkedHashMap<>();
+        ProgrammableTokenCip113 cip113 = prefetchData.cip113Map().get(AssetType.fromUnit(subject).policyId());
+        if (cip113 != null) {
+            extensions.put(ProgrammableTokenCip113.EXTENSION_KEY, cip113);
+        }
+
+        TokenType type = extensions.isEmpty() ? TokenType.NATIVE : TokenType.PROGRAMMABLE;
+
+        return new Subject(subject, type, resolved.metadata(),
+                showCipsDetails ? resolved.standards() : null,
+                extensions.isEmpty() ? null : extensions);
+    }
+
+    /**
+     * Pre-fetch all data for a batch of subjects in bulk queries to avoid N+1.
+     * Issues at most 4 queries regardless of batch size:
+     * CIP-26 metadata, CIP-26 logos, CIP-68 reference NFTs, CIP-113 registry nodes.
+     */
+    public BatchPrefetchData prefetchBatch(List<String> subjects, List<String> queryProperties) {
+        // CIP-113: one query for all distinct policy IDs
+        List<String> policyIds = subjects.stream()
+                .map(s -> AssetType.fromUnit(s).policyId())
+                .distinct()
+                .toList();
+        Map<String, ProgrammableTokenCip113> cip113Map = cip113StorageReader.findByPolicyIds(policyIds);
+
+        // CIP-26: one query for all metadata, one query for all logos
+        Map<String, Cip26Metadata> cip26MetadataMap = cip26StorageReader.findBySubjects(subjects).stream()
+                .collect(Collectors.toMap(Cip26Metadata::getSubject, Function.identity()));
+
+        boolean needLogos = queryProperties.isEmpty() || queryProperties.contains("logo");
+        Map<String, String> cip26LogoMap = needLogos
+                ? cip26StorageReader.findLogosBySubjects(subjects)
+                : Map.of();
+
+        // CIP-68: one query for all fungible token subjects, result keyed by the original subject.
+        // Non-fungible subjects are silently filtered inside findBySubjects, so passing the full
+        // batch is safe and avoids a double prefix-check here.
+        Map<String, FungibleTokenMetadata> cip68MetadataMap = cip68StorageReader.findBySubjects(subjects, queryProperties);
+
+        return new BatchPrefetchData(cip113Map, cip26MetadataMap, cip26LogoMap, cip68MetadataMap);
+    }
+
+    /**
+     * Pre-fetched data for batch operations. Eliminates N+1 queries.
+     */
+    public record BatchPrefetchData(
+            Map<String, ProgrammableTokenCip113> cip113Map,
+            Map<String, Cip26Metadata> cip26MetadataMap,
+            Map<String, String> cip26LogoMap,
+            Map<String, FungibleTokenMetadata> cip68MetadataMap) {
+    }
+
+    private Optional<ResolvedMetadata> findMetadata(String subject, List<String> properties, QueryPriority priority) {
+        return switch (priority) {
+            case CIP_26 -> findCip26Metadata(subject, properties);
+            case CIP_68 -> findCip68Metadata(subject, properties);
+        };
+    }
+
+    private Optional<ResolvedMetadata> findCip26Metadata(String subject, List<String> properties) {
+        return cip26StorageReader.findBySubject(subject)
+                .map(entity -> {
+                    // Only fetch logo if all properties requested or logo explicitly requested
+                    String logo = (properties.isEmpty() || properties.contains("logo"))
+                            ? cip26StorageReader.findLogoBySubject(subject).orElse(null)
+                            : null;
+                    return new ResolvedMetadata(
+                            Metadata.from(entity, logo, properties),
+                            new Standards(Cip26TokenMetadata.from(entity, logo), null));
+                });
+    }
+
+    private Optional<ResolvedMetadata> findCip68Metadata(String subject, List<String> properties) {
+        return cip68StorageReader.findBySubject(subject, properties)
+                .map(cip68TokenMetadata -> new ResolvedMetadata(
+                        Metadata.from(cip68TokenMetadata),
+                        new Standards(null, cip68TokenMetadata)));
+    }
+
+    private static BinaryOperator<ResolvedMetadata> aggregateResults() {
+        return (thisPair, thatPair) -> {
+            Metadata metadata = thisPair.metadata().merge(thatPair.metadata());
+            Standards standards = thisPair.standards().merge(thatPair.standards());
+            return new ResolvedMetadata(metadata, standards);
+        };
+    }
+
+    private BiFunction<ResolvedMetadata, QueryPriority, ResolvedMetadata> combineStandards(String subject, List<String> properties) {
+        return (accumulated, priority) -> findMetadata(subject, properties, priority)
+                .map(found -> new ResolvedMetadata(
+                        accumulated.metadata().merge(found.metadata()),
+                        accumulated.standards().merge(found.standards())))
+                .orElse(accumulated);
+    }
+
+    private BiFunction<ResolvedMetadata, QueryPriority, ResolvedMetadata> combineStandardsBatch(
+            String subject, List<String> properties, BatchPrefetchData prefetchData) {
+        return (accumulated, priority) -> findMetadataBatch(subject, properties, priority, prefetchData)
+                .map(found -> new ResolvedMetadata(
+                        accumulated.metadata().merge(found.metadata()),
+                        accumulated.standards().merge(found.standards())))
+                .orElse(accumulated);
+    }
+
+    private Optional<ResolvedMetadata> findMetadataBatch(String subject, List<String> properties,
+                                                               QueryPriority priority, BatchPrefetchData prefetchData) {
+        return switch (priority) {
+            case CIP_26 -> findCip26MetadataBatch(subject, properties, prefetchData);
+            case CIP_68 -> findCip68MetadataBatch(subject, prefetchData);
+        };
+    }
+
+    private Optional<ResolvedMetadata> findCip26MetadataBatch(String subject, List<String> properties,
+                                                                    BatchPrefetchData prefetchData) {
+        Cip26Metadata entity = prefetchData.cip26MetadataMap().get(subject);
+        if (entity == null) {
+            return Optional.empty();
+        }
+        String logo = (properties.isEmpty() || properties.contains("logo"))
+                ? prefetchData.cip26LogoMap().get(subject)
+                : null;
+        return Optional.of(new ResolvedMetadata(
+                Metadata.from(entity, logo, properties),
+                new Standards(Cip26TokenMetadata.from(entity, logo), null)));
+    }
+
+    /**
+     * Looks up CIP-68 metadata from the pre-fetched batch map keyed by fungible-token subject.
+     * Property filtering was already applied when the map was built in {@link #prefetchBatch}.
+     */
+    private Optional<ResolvedMetadata> findCip68MetadataBatch(String subject, BatchPrefetchData prefetchData) {
+        FungibleTokenMetadata cip68TokenMetadata = prefetchData.cip68MetadataMap().get(subject);
+        if (cip68TokenMetadata == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ResolvedMetadata(
+                Metadata.from(cip68TokenMetadata),
+                new Standards(null, cip68TokenMetadata)));
+    }
+
+    private Map<String, Extension> buildExtensions(String subject) {
+        Map<String, Extension> extensions = new LinkedHashMap<>();
+        cip113StorageReader.findByPolicyId(AssetType.fromUnit(subject).policyId())
+                .ifPresent(cip113 -> extensions.put(ProgrammableTokenCip113.EXTENSION_KEY, cip113));
+
+        return extensions;
+    }
+
+    /**
+     * Merged result of a query-priority reduce: the {@link Metadata} view assembled from one
+     * or more standards, plus the raw per-standard {@link Standards} breakdown. Named after
+     * its role (the resolved metadata for a subject) rather than "pair" so the accessors
+     * {@link #metadata()} and {@link #standards()} read at call sites.
+     */
+    private record ResolvedMetadata(Metadata metadata, Standards standards) {
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/Cip113Configuration.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/Cip113Configuration.java
@@ -1,0 +1,129 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.NetworkType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * CIP-113 programmable token configuration.
+ * <p>
+ * Disabled by default — CIP-113 is not yet officially live on mainnet.
+ * Enable explicitly via {@code store.assets.ext.cip113.enabled=true}; otherwise
+ * the processor and rollback-processor beans are not registered. The storage
+ * reader is always registered and returns empty when {@link #isEnabled()} is false
+ * (i.e. when no registry NFT policy IDs are configured).
+ * <p>
+ * Registry NFT policy IDs are maintained per-network in property files:
+ * <ul>
+ *   <li>{@code cip113/cip113-mainnet.properties}</li>
+ *   <li>{@code cip113/cip113-preprod.properties}</li>
+ *   <li>{@code cip113/cip113-preview.properties}</li>
+ * </ul>
+ * The correct file is loaded based on {@code store.cardano.protocol-magic}.
+ * Users can override via {@code store.assets.ext.cip113.registry-nft-policy-ids}
+ * if needed.
+ */
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class Cip113Configuration {
+
+    private static final Map<NetworkType, String> NETWORK_PROPERTY_FILES = Map.of(
+            NetworkType.MAINNET, "cip113/cip113-mainnet.properties",
+            NetworkType.PREPROD, "cip113/cip113-preprod.properties",
+            NetworkType.PREVIEW, "cip113/cip113-preview.properties"
+    );
+
+    private final StoreProperties storeProperties;
+    private final AssetsExtStoreProperties assetsStoreProperties;
+
+    @Getter
+    private Set<String> registryNftPolicyIdSet;
+
+    @PostConstruct
+    public void init() {
+        // When CIP-113 is disabled (the default until the standard is live on
+        // mainnet), don't load anything: leaves registryNftPolicyIdSet empty so
+        // isEnabled() correctly reports false, the storage reader short-circuits
+        // every query, and no misleading "policy IDs resolved" log line fires.
+        // When the operator flips the master flag on (and restarts), the load
+        // runs and the line shows up — but only when it's actually relevant.
+        if (!assetsStoreProperties.getCip113().isEnabled()) {
+            registryNftPolicyIdSet = Set.of();
+            log.info("CIP-113 disabled (store.assets.ext.cip113.enabled=false); skipping registry NFT policy ID load");
+            return;
+        }
+
+        if (hasUserOverride()) {
+            registryNftPolicyIdSet = assetsStoreProperties.getCip113().getRegistryNftPolicyIds().stream()
+                    .filter(id -> !id.isBlank())
+                    .collect(Collectors.toUnmodifiableSet());
+        } else {
+            registryNftPolicyIdSet = loadFromPropertyFile();
+        }
+
+        NetworkType network = NetworkType.fromProtocolMagic(storeProperties.getProtocolMagic());
+        String networkName = network != null ? network.name() : "UNKNOWN (magic=" + storeProperties.getProtocolMagic() + ")";
+        log.info("CIP-113 registry NFT policy IDs resolved: network={}, count={}, ids={}",
+                networkName, registryNftPolicyIdSet.size(), registryNftPolicyIdSet);
+    }
+
+    public boolean isEnabled() {
+        return !registryNftPolicyIdSet.isEmpty();
+    }
+
+    public boolean isMonitoredPolicyId(String policyId) {
+        return registryNftPolicyIdSet.contains(policyId);
+    }
+
+    private boolean hasUserOverride() {
+        List<String> userPolicyIds = assetsStoreProperties.getCip113().getRegistryNftPolicyIds();
+        return userPolicyIds != null && !userPolicyIds.isEmpty()
+                && userPolicyIds.stream().anyMatch(id -> !id.isBlank());
+    }
+
+    private Set<String> loadFromPropertyFile() {
+        NetworkType network = NetworkType.fromProtocolMagic(storeProperties.getProtocolMagic());
+        if (network == null) {
+            log.warn("Unknown network (protocol-magic={}), CIP-113 will be disabled", storeProperties.getProtocolMagic());
+            return Set.of();
+        }
+
+        String propertyFile = NETWORK_PROPERTY_FILES.get(network);
+        if (propertyFile == null) {
+            log.info("No CIP-113 property file for network {}", network);
+            return Set.of();
+        }
+
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(propertyFile)) {
+            if (is == null) {
+                log.warn("CIP-113 property file not found: {}", propertyFile);
+                return Set.of();
+            }
+            Properties props = new Properties();
+            props.load(is);
+            String ids = props.getProperty("registry-nft-policy-ids", "");
+            if (ids.isBlank()) {
+                return Set.of();
+            }
+
+            return Arrays.stream(ids.split(","))
+                    .map(String::trim)
+                    .filter(id -> !id.isEmpty())
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (IOException e) {
+            log.warn("Failed to load CIP-113 property file {}: {}", propertyFile, e.getMessage());
+            return Set.of();
+        }
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/model/Cip113CredentialType.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/model/Cip113CredentialType.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model;
+
+/**
+ * Aiken {@code Credential} discriminator for CIP-113 transfer-logic-script fields.
+ * <p>
+ * The on-chain Aiken type is {@code Credential = VerificationKey(hash) | Script(hash)}.
+ * Both variants carry a 28-byte Blake2b-224 hash, so the hash column alone cannot
+ * distinguish them after persistence — this enum captures the constructor variant so
+ * downstream consumers can validate transfer logic correctly (vkey signatures vs
+ * script-witness execution have very different verification semantics).
+ */
+public enum Cip113CredentialType {
+    /** {@code VerificationKey(hash)} — Constr alternative 0. The hash is a vkey hash. */
+    VKEY,
+    /** {@code Script(hash)} — Constr alternative 1. The hash is a Plutus script hash. */
+    SCRIPT
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/model/ProgrammableTokenCip113.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/model/ProgrammableTokenCip113.java
@@ -1,0 +1,59 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Extension;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+
+@Schema(description = "CIP-113 programmable token metadata. Present when the token's policy ID is "
+        + "registered in an on-chain CIP-113 programmable token registry.")
+public record ProgrammableTokenCip113(
+
+        @JsonProperty("transfer_logic_script")
+        @Nullable
+        @Schema(description = "Blake2b-224 hash of the credential that validates every transfer of this token. "
+                + "Verification depends on the companion {@code transfer_logic_script_type}: vkey-credentials "
+                + "are checked via signature presence, script-credentials run on-chain via the withdraw-zero "
+                + "pattern. Null when the registry node does not specify a transfer logic credential.",
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String transferLogicScript,
+
+        @JsonProperty("transfer_logic_script_type")
+        @Nullable
+        @Schema(description = "Aiken Credential discriminator for transfer_logic_script: 'VKEY' = "
+                + "VerificationKey hash; 'SCRIPT' = Plutus script hash. Non-null iff transfer_logic_script "
+                + "is non-null.",
+                nullable = true,
+                allowableValues = {"VKEY", "SCRIPT"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Cip113CredentialType transferLogicScriptType,
+
+        @JsonProperty("third_party_transfer_logic_script")
+        @Nullable
+        @Schema(description = "Blake2b-224 hash of the credential for issuer operations (freeze, seize, burn). "
+                + "Not all programmable token substandards require this.",
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String thirdPartyTransferLogicScript,
+
+        @JsonProperty("third_party_transfer_logic_script_type")
+        @Nullable
+        @Schema(description = "Aiken Credential discriminator for third_party_transfer_logic_script. "
+                + "Non-null iff third_party_transfer_logic_script is non-null.",
+                nullable = true,
+                allowableValues = {"VKEY", "SCRIPT"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Cip113CredentialType thirdPartyTransferLogicScriptType,
+
+        @JsonProperty("global_state_policy_id")
+        @Nullable
+        @Schema(description = "Optional policy ID for global state (e.g. a denylist NFT). Null when absent.",
+                nullable = true)
+        String globalStatePolicyId
+
+) implements Extension {
+
+    public static final String EXTENSION_KEY = "cip113";
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/parser/Cip113RegistryNodeParser.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/parser/Cip113RegistryNodeParser.java
@@ -1,0 +1,314 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.parser;
+
+import com.bloxbean.cardano.client.exception.CborDeserializationException;
+import com.bloxbean.cardano.client.plutus.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Parses CIP-113 registry node inline datums.
+ * <p>
+ * The datum is an Aiken {@code RegistryNode} record serialized as
+ * {@code Constr 0 [key, next, transfer_logic_script, third_party_transfer_logic_script, global_state_cs]}:
+ * <ol>
+ *   <li>{@code key} — {@code ByteArray}. Empty (head sentinel), a 28-byte policy id of a
+ *       registered programmable token, or a tail sentinel of up to 32 bytes.</li>
+ *   <li>{@code next} — {@code ByteArray}. Non-empty pointer to the next node's {@code key}
+ *       in the sorted linked list.</li>
+ *   <li>{@code transfer_logic_script} — optional {@code Credential}. See "Absent credential
+ *       encoding" below.</li>
+ *   <li>{@code third_party_transfer_logic_script} — optional {@code Credential}. Same shape.</li>
+ *   <li>{@code global_state_cs} — {@code ByteArray}. Empty bytes mean "no global-state NFT";
+ *       28 bytes are a real currency symbol.</li>
+ * </ol>
+ *
+ * <h2>Absent credential encoding</h2>
+ * Although the Aiken type signature declares the two credential fields as non-optional
+ * {@code Credential}, real CIP-113 registry datums in the wild encode "no credential" using
+ * one of these conventions:
+ * <ul>
+ *   <li>A plain {@code BytesPlutusData(h'')} where a {@code Credential} Constr would normally sit.</li>
+ *   <li>A {@code Credential} Constr whose inner byte string is empty.</li>
+ * </ul>
+ * Both are normalised to {@code null} in the parsed output. Any other deviation from the
+ * expected shape or byte-length is rejected with a warning and {@link Optional#empty()}.
+ *
+ * <h2>Non-enforced invariant</h2>
+ * The sort invariant {@code key < next} is NOT checked here because materialized tail-sentinel
+ * nodes in some aiken-linked-list implementations legitimately violate it. The on-chain
+ * minting policy is the source of truth for that invariant.
+ */
+@Component
+@Slf4j
+public class Cip113RegistryNodeParser {
+
+    /** Exact number of fields in a well-formed {@code RegistryNode} datum. */
+    private static final int EXPECTED_FIELD_COUNT = 5;
+
+    /** Aiken compiles {@code RegistryNode{…}} to {@code Constr 0}; no other alternative is valid. */
+    private static final long REGISTRY_NODE_CONSTR_ALTERNATIVE = 0L;
+
+    /** Aiken {@code Credential} alternatives: {@code VerificationKey}=0, {@code Script}=1. */
+    private static final long CREDENTIAL_VKEY_ALTERNATIVE = 0L;
+    private static final long CREDENTIAL_SCRIPT_ALTERNATIVE = 1L;
+
+    /** Blake2b-224 hash length — 28 bytes for policy ids, script hashes, and vkey hashes. */
+    private static final int HASH_BYTE_LEN = 28;
+
+    /**
+     * Maximum accepted byte length for the {@code key} and {@code next} fields.
+     * <p>
+     * Real policy ids are 28 bytes (head sentinel is 0 bytes). Some aiken-linked-list
+     * implementations materialize a tail sentinel whose key is conventionally 32 bytes
+     * (all {@code 0xFF}). 32 bytes is therefore the tightest defensible upper bound —
+     * matches the DB column length ({@code VARCHAR(64)} = 64 hex chars = 32 bytes).
+     */
+    private static final int MAX_KEY_BYTE_LEN = 32;
+
+    /**
+     * Hard cap on the size of the serialized inline datum <em>before</em> it reaches the
+     * recursive CBOR decoder. A well-formed CIP-113 {@code RegistryNode} encodes to roughly
+     * 200–400 bytes (≤ 800 hex chars) in the worst realistic case. 4096 hex chars (2048
+     * bytes) gives ~10× margin while tightly bounding the input fed to
+     * {@code PlutusData.deserialize} — prevents the library-layer DoS classes (deeply
+     * nested Constr → {@link StackOverflowError}; CBOR pre-allocation bomb →
+     * {@link OutOfMemoryError}) from ever reaching the recursive decoder at all.
+     */
+    private static final int MAX_DATUM_HEX_LEN = 4096;
+
+    /**
+     * Parsed registry node fields. Byte-string fields are lowercase hex. {@code key} and
+     * {@code next} are always non-null; the optional script/policy fields are null when the
+     * corresponding on-chain field encodes "absent" (empty bytes — see class javadoc for the
+     * exact encoding).
+     * <p>
+     * For each transfer-logic-script field, the {@code *Type} companion records the Aiken
+     * {@code Credential} discriminator ({@link Cip113CredentialType#VKEY} vs
+     * {@link Cip113CredentialType#SCRIPT}). The hash and its type are populated together —
+     * both null when the credential is absent, both non-null when present.
+     */
+    public record ParsedRegistryNode(String key,
+                                     String next,
+                                     @Nullable String transferLogicScript,
+                                     @Nullable Cip113CredentialType transferLogicScriptType,
+                                     @Nullable String thirdPartyTransferLogicScript,
+                                     @Nullable Cip113CredentialType thirdPartyTransferLogicScriptType,
+                                     @Nullable String globalStatePolicyId) {
+
+        /**
+         * @return true if this is the head sentinel of the sorted linked list (empty {@code key}).
+         */
+        public boolean isHeadSentinel() {
+            return key.isEmpty();
+        }
+    }
+
+    /**
+     * Result of parsing one of the two transfer-logic credential fields. Either both
+     * fields are non-null (a real credential is present), or both are null (the on-chain
+     * field encodes "absent credential").
+     */
+    private record OptionalCredential(@Nullable String hash, @Nullable Cip113CredentialType type) {
+        static final OptionalCredential ABSENT = new OptionalCredential(null, null);
+    }
+
+    public Optional<ParsedRegistryNode> parse(String inlineDatum) {
+        if (inlineDatum == null || inlineDatum.isBlank()) {
+            return Optional.empty();
+        }
+
+        // Hard size cap BEFORE we touch HexUtil or the recursive CBOR decoder.
+        // This is the only parser-layer defence against library-layer DoS (deep nesting
+        // or pre-allocation bombs) — those attacks execute inside PlutusData.deserialize
+        // and manifest as Error instances (not RuntimeException), which our catch clause
+        // deliberately does not swallow. Bounding the input at 4096 hex chars keeps the
+        // decoder's working set small enough that neither class of attack is realistic.
+        if (inlineDatum.length() > MAX_DATUM_HEX_LEN) {
+            log.warn("CIP-113 registry node: inline datum too large ({} hex chars, max {})",
+                    inlineDatum.length(), MAX_DATUM_HEX_LEN);
+            return Optional.empty();
+        }
+
+        try {
+            PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString(inlineDatum));
+
+            // Invariant #1: root must be a Constr with alternative 0.
+            if (!(plutusData instanceof ConstrPlutusData constr)) {
+                log.warn("CIP-113 registry node: expected root ConstrPlutusData, got {}",
+                        plutusData.getClass().getSimpleName());
+                return Optional.empty();
+            }
+            if (constr.getAlternative() != REGISTRY_NODE_CONSTR_ALTERNATIVE) {
+                log.warn("CIP-113 registry node: expected Constr alternative {}, got {}",
+                        REGISTRY_NODE_CONSTR_ALTERNATIVE, constr.getAlternative());
+                return Optional.empty();
+            }
+
+            // Invariant #2: exactly 5 fields.
+            List<PlutusData> fields = constr.getData().getPlutusDataList();
+            if (fields.size() != EXPECTED_FIELD_COUNT) {
+                log.warn("CIP-113 registry node: expected {} fields, got {}",
+                        EXPECTED_FIELD_COUNT, fields.size());
+                return Optional.empty();
+            }
+
+            // Invariant #3: key — ByteString, 0 to 32 bytes (head sentinel, real policy, or tail sentinel).
+            byte[] keyBytes = extractByteArray(fields.getFirst());
+            if (keyBytes == null || keyBytes.length > MAX_KEY_BYTE_LEN) {
+                log.warn("CIP-113 registry node: invalid 'key' field (expected ByteString of length 0..{} bytes)",
+                        MAX_KEY_BYTE_LEN);
+                return Optional.empty();
+            }
+
+            // Invariant #4: next — ByteString, 1 to 32 bytes (must be non-empty).
+            byte[] nextBytes = extractByteArray(fields.get(1));
+            if (nextBytes == null || nextBytes.length == 0 || nextBytes.length > MAX_KEY_BYTE_LEN) {
+                log.warn("CIP-113 registry node: invalid 'next' field (expected ByteString of length 1..{} bytes)",
+                        MAX_KEY_BYTE_LEN);
+                return Optional.empty();
+            }
+
+            // Invariant #5: transfer_logic_script — optional Credential (null when empty bytes).
+            OptionalCredential transferLogic = extractOptionalCredential(fields.get(2), "transfer_logic_script");
+
+            // Invariant #6: third_party_transfer_logic_script — optional Credential.
+            OptionalCredential thirdPartyTransferLogic = extractOptionalCredential(
+                    fields.get(3), "third_party_transfer_logic_script");
+
+            // Invariant #7: global_state_cs — ByteString, 0 bytes (null) or exactly 28 bytes.
+            String globalStatePolicyId = extractOptionalGlobalStateCs(fields.get(4));
+
+            return Optional.of(new ParsedRegistryNode(
+                    HexUtil.encodeHexString(keyBytes),
+                    HexUtil.encodeHexString(nextBytes),
+                    transferLogic.hash(),
+                    transferLogic.type(),
+                    thirdPartyTransferLogic.hash(),
+                    thirdPartyTransferLogic.type(),
+                    globalStatePolicyId));
+
+        } catch (InvalidDatumException e) {
+            log.warn("CIP-113 registry node rejected: {}", e.getMessage());
+            return Optional.empty();
+        } catch (CborDeserializationException | RuntimeException e) {
+            // Narrowed from catch(Exception): we deliberately let Error (OOM, etc.) propagate.
+            // Covers CborDeserializationException from PlutusData.deserialize on malformed CBOR,
+            // plus IllegalArgumentException from HexUtil on bad hex input.
+            log.warn("Failed to parse CIP-113 registry node datum: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns the raw bytes if {@code data} is a {@link BytesPlutusData}, or {@code null}
+     * if it is any other PlutusData variant. An empty byte array is a valid return value
+     * (distinguishes "wrong type" from "empty bytes").
+     */
+    @Nullable
+    private byte[] extractByteArray(PlutusData data) {
+        if (data instanceof BytesPlutusData bytes) {
+            return bytes.getValue();
+        }
+        return null;
+    }
+
+    /**
+     * Extracts an optional credential (hash + Aiken {@code Credential} discriminator) from one
+     * of the two script fields.
+     * <p>
+     * Accepts:
+     * <ul>
+     *   <li>An Aiken {@code Credential} Constr ({@code VerificationKey} alt 0 or {@code Script}
+     *       alt 1) wrapping a 28-byte ByteString → returns the 56-hex-char hash and the
+     *       matching {@link Cip113CredentialType}.</li>
+     *   <li>{@code BytesPlutusData(h'')} (plain empty bytes, off-spec but convention in the
+     *       wild) → returns {@link OptionalCredential#ABSENT}.</li>
+     *   <li>A {@code Credential} Constr whose inner ByteString is empty → returns
+     *       {@link OptionalCredential#ABSENT}.</li>
+     * </ul>
+     * Throws {@link InvalidDatumException} for any other shape or a wrong inner byte length,
+     * which causes the enclosing {@link #parse(String)} to reject the whole datum.
+     */
+    private OptionalCredential extractOptionalCredential(PlutusData data, String fieldName) {
+        // Off-spec tolerance: plain BytesPlutusData in place of a Credential Constr.
+        // Empty bytes are accepted as "absent credential"; non-empty plain bytes are malformed.
+        if (data instanceof BytesPlutusData bytes) {
+            if (bytes.getValue().length == 0) {
+                return OptionalCredential.ABSENT;
+            }
+            throw new InvalidDatumException("'" + fieldName
+                    + "' is a non-empty ByteString (expected Credential Constr or empty bytes)");
+        }
+        if (!(data instanceof ConstrPlutusData constr)) {
+            throw new InvalidDatumException("'" + fieldName
+                    + "' must be Credential Constr or empty ByteString, got "
+                    + data.getClass().getSimpleName());
+        }
+        long alt = constr.getAlternative();
+        Cip113CredentialType type;
+        if (alt == CREDENTIAL_VKEY_ALTERNATIVE) {
+            type = Cip113CredentialType.VKEY;
+        } else if (alt == CREDENTIAL_SCRIPT_ALTERNATIVE) {
+            type = Cip113CredentialType.SCRIPT;
+        } else {
+            throw new InvalidDatumException("'" + fieldName
+                    + "' Credential has invalid alternative " + alt + " (expected 0 or 1)");
+        }
+        List<PlutusData> inner = constr.getData().getPlutusDataList();
+        if (inner.size() != 1) {
+            throw new InvalidDatumException("'" + fieldName
+                    + "' Credential must have exactly 1 inner field, got " + inner.size());
+        }
+        byte[] hash = extractByteArray(inner.getFirst());
+        if (hash == null) {
+            throw new InvalidDatumException("'" + fieldName + "' Credential inner must be a ByteString");
+        }
+        // Also tolerate an explicitly wrapped empty-hash as "absent credential".
+        if (hash.length == 0) {
+            return OptionalCredential.ABSENT;
+        }
+        if (hash.length != HASH_BYTE_LEN) {
+            throw new InvalidDatumException("'" + fieldName
+                    + "' Credential inner hash must be " + HASH_BYTE_LEN + " bytes, got " + hash.length);
+        }
+        return new OptionalCredential(HexUtil.encodeHexString(hash), type);
+    }
+
+    /**
+     * Extracts the optional {@code global_state_cs} currency symbol. Empty bytes → null;
+     * exactly 28 bytes → hex; anything else throws {@link InvalidDatumException}.
+     */
+    @Nullable
+    private String extractOptionalGlobalStateCs(PlutusData data) {
+        byte[] bytes = extractByteArray(data);
+        if (bytes == null) {
+            throw new InvalidDatumException(
+                    "'global_state_cs' must be a ByteString, got " + data.getClass().getSimpleName());
+        }
+        if (bytes.length == 0) {
+            return null;
+        }
+        if (bytes.length != HASH_BYTE_LEN) {
+            throw new InvalidDatumException("'global_state_cs' must be 0 or " + HASH_BYTE_LEN
+                    + " bytes, got " + bytes.length);
+        }
+
+        return HexUtil.encodeHexString(bytes);
+    }
+
+    /** Thrown from helpers to bail out of {@link #parse(String)} with a descriptive reason. */
+    private static final class InvalidDatumException extends RuntimeException {
+        InvalidDatumException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113Processor.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113Processor.java
@@ -1,0 +1,74 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.processor;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNode;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.parser.Cip113RegistryNodeParser;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository.Cip113RegistryNodeRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.service.Cip113RegistryService;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressUtxoEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "store.assets.ext.cip113.enabled", havingValue = "true", matchIfMissing = false)
+public class Cip113Processor {
+
+    private final Cip113Configuration cip113Configuration;
+    private final Cip113RegistryNodeParser registryNodeParser;
+    private final Cip113RegistryNodeRepository cip113RegistryNodeRepository;
+    private final Cip113RegistryService cip113RegistryService;
+
+    @EventListener
+    @Transactional
+    public void processTransaction(AddressUtxoEvent addressUtxoEvent) {
+        if (!cip113Configuration.isEnabled()) {
+            return;
+        }
+
+        Long slot = addressUtxoEvent.getMetadata().getSlot();
+
+        List<Cip113RegistryNode> entities = addressUtxoEvent.getTxInputOutputs()
+                .stream()
+                .flatMap(txInputOutput -> txInputOutput.getOutputs().stream())
+                .filter(utxo -> utxo.getInlineDatum() != null && cip113RegistryService.containsRegistryNode(utxo))
+                .map(utxo -> toEntity(utxo, slot))
+                .flatMap(Optional::stream)
+                .toList();
+
+        if (!entities.isEmpty()) {
+            cip113RegistryNodeRepository.saveAll(entities);
+            entities.forEach(e -> log.info("Indexed CIP-113 registry node: key={}, slot={}, txHash={}",
+                    e.getKey(), e.getSlot(), e.getTxHash()));
+        }
+    }
+
+    private Optional<Cip113RegistryNode> toEntity(AddressUtxo utxo, Long slot) {
+        return registryNodeParser.parse(utxo.getInlineDatum())
+                .map(parsed -> Cip113RegistryNode.builder()
+                        .key(parsed.key())
+                        .slot(slot)
+                        .txHash(utxo.getTxHash())
+                        .txIndex(utxo.getTxIndex())
+                        .transferLogicScript(parsed.transferLogicScript())
+                        .transferLogicScriptType(parsed.transferLogicScriptType())
+                        .thirdPartyTransferLogicScript(parsed.thirdPartyTransferLogicScript())
+                        .thirdPartyTransferLogicScriptType(parsed.thirdPartyTransferLogicScriptType())
+                        .globalStatePolicyId(parsed.globalStatePolicyId())
+                        .next(parsed.next())
+                        .datum(utxo.getInlineDatum())
+                        .lastSyncedAt(LocalDateTime.now())
+                        .build());
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113RollbackProcessor.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113RollbackProcessor.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.processor;
+
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository.Cip113RegistryNodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "store.assets.ext.cip113.enabled", havingValue = "true", matchIfMissing = false)
+public class Cip113RollbackProcessor {
+
+    private final Cip113RegistryNodeRepository cip113RegistryNodeRepository;
+    private final Cip113Configuration cip113Configuration;
+
+    @EventListener
+    @Transactional
+    public void handleRollbackEvent(RollbackEvent rollbackEvent) {
+        if (!cip113Configuration.isEnabled()) {
+            return;
+        }
+        int count = cip113RegistryNodeRepository.deleteBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
+        log.info("Rollback -- {} cip113_registry_node records", count);
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/service/Cip113RegistryService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/service/Cip113RegistryService.java
@@ -1,0 +1,38 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.service;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+
+/**
+ * CIP-113 registry node detection service.
+ * <p>
+ * Only depends on {@link Cip113Configuration} (not on repositories) — follows the
+ * yaci-store convention that services use StorageReader interfaces, not repositories directly.
+ * Query methods live in {@link com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.Cip113StorageReaderImpl}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Cip113RegistryService {
+
+    private final Cip113Configuration cip113Configuration;
+
+    /**
+     * Check if a UTxO contains a CIP-113 registry node NFT.
+     */
+    public boolean containsRegistryNode(AddressUtxo utxo) {
+        if (!cip113Configuration.isEnabled()) {
+            return false;
+        }
+
+        return utxo.getAmounts().stream()
+                .anyMatch(amt -> amt.getQuantity().equals(BigInteger.ONE)
+                        && cip113Configuration.isMonitoredPolicyId(amt.getPolicyId()));
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReader.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReader.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Read-only access to CIP-113 programmable token registry data.
+ * <p>
+ * CIP-113 registry nodes are NFTs on-chain that declare transfer validation scripts
+ * for token policies. Each entry maps a policy ID to its transfer logic scripts.
+ */
+public interface Cip113StorageReader {
+
+    /**
+     * Get the latest CIP-113 registry state for a policy ID.
+     *
+     * @param policyId the policy ID to look up
+     * @return the programmable token info (transfer scripts) if the policy is registered
+     */
+    Optional<ProgrammableTokenCip113> findByPolicyId(String policyId);
+
+    /**
+     * Batch lookup CIP-113 registry nodes for multiple policy IDs.
+     * Returns the latest state per policy, using a single optimized query.
+     *
+     * @param policyIds the policy IDs to look up
+     * @return map of policyId to CIP-113 info for registered policies (unregistered policies are omitted)
+     */
+    Map<String, ProgrammableTokenCip113> findByPolicyIds(Collection<String> policyIds);
+
+    /**
+     * Check if a policy ID is registered as a CIP-113 programmable token.
+     *
+     * @param policyId the policy ID to check
+     * @return true if a registry node exists for this policy
+     */
+    boolean isProgrammableToken(String policyId);
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReaderImpl.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReaderImpl.java
@@ -1,0 +1,76 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNode;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository.Cip113RegistryNodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only access to the CIP-113 programmable-token registry.
+ *
+ * <p><b>Naming note:</b> this reader is deliberately named in policy-ID terms even though the
+ * underlying column is {@code key} (see {@link Cip113RegistryNode} — the registry's
+ * {@code key} is a policy ID for real rows, a linked-list marker for sentinel rows). The
+ * reader contract with API callers is <i>"give me the programmable-token data for this
+ * token's policy ID"</i>, so its public methods speak policy IDs and translate to
+ * {@code key = ?} lookups internally. Sentinels are never matched because no real token has
+ * an empty or 32-byte-of-{@code 0xFF} policy ID.
+ */
+@Component
+@RequiredArgsConstructor
+public class Cip113StorageReaderImpl implements Cip113StorageReader {
+
+    private final Cip113RegistryNodeRepository cip113RegistryNodeRepository;
+    private final Cip113Configuration cip113Configuration;
+
+    @Override
+    public Optional<ProgrammableTokenCip113> findByPolicyId(String policyId) {
+        if (!cip113Configuration.isEnabled()) {
+            return Optional.empty();
+        }
+        return cip113RegistryNodeRepository.findFirstByKeyOrderBySlotDescTxIndexDesc(policyId)
+                .map(Cip113StorageReaderImpl::toDto);
+    }
+
+    @Override
+    public Map<String, ProgrammableTokenCip113> findByPolicyIds(Collection<String> policyIds) {
+        if (!cip113Configuration.isEnabled() || policyIds.isEmpty()) {
+            return Map.of();
+        }
+        return cip113RegistryNodeRepository.findLatestByKeys(policyIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        Cip113RegistryNode::getKey,
+                        Cip113StorageReaderImpl::toDto
+                ));
+    }
+
+    @Override
+    public boolean isProgrammableToken(String policyId) {
+        return findByPolicyId(policyId).isPresent();
+    }
+
+    static ProgrammableTokenCip113 toDto(Cip113RegistryNode entity) {
+        String transferLogic = entity.getTransferLogicScript();
+        String thirdParty = entity.getThirdPartyTransferLogicScript();
+        String globalState = entity.getGlobalStatePolicyId();
+        boolean transferLogicAbsent = transferLogic == null || transferLogic.isEmpty();
+        boolean thirdPartyAbsent = thirdParty == null || thirdParty.isEmpty();
+
+        return new ProgrammableTokenCip113(
+                transferLogicAbsent ? null : transferLogic,
+                transferLogicAbsent ? null : entity.getTransferLogicScriptType(),
+                thirdPartyAbsent ? null : thirdParty,
+                thirdPartyAbsent ? null : entity.getThirdPartyTransferLogicScriptType(),
+                (globalState == null || globalState.isEmpty()) ? null : globalState
+        );
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/model/Cip113RegistryNode.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/model/Cip113RegistryNode.java
@@ -1,0 +1,152 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import jakarta.persistence.*;
+import lombok.*;
+import jakarta.annotation.Nullable;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cip113_registry_node")
+@IdClass(Cip113RegistryNodeId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+// Business-key equals/hashCode: all three PK components are app-assigned and non-null at
+// construction, so they're stable across the transient → managed → detached lifecycle.
+// Lombok's generated equals uses `instanceof` (proxy-safe for lazy-loaded associations).
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Cip113RegistryNode {
+
+    /**
+     * The {@code key} field of the CIP-113 registry node datum.
+     *
+     * <h2>Dual role — read carefully</h2>
+     *
+     * The registry is stored on-chain as a sorted linked list (see the aiken-linked-list library).
+     * That means {@code key} serves two purposes depending on which row you are looking at:
+     *
+     * <ul>
+     *   <li><b>Real registration rows</b> — {@code key} is the 28-byte (56-hex) policy ID of the
+     *       programmable token being registered. The CIP-113 spec (Aiken source: {@code registry_node.ak})
+     *       describes the field as <i>"the key (currency symbol) of the programmable token policy"</i>,
+     *       and in Cardano <i>currency symbol = policy ID</i>. This is the vast majority of rows
+     *       and is what callers normally look up.</li>
+     *   <li><b>Sentinel rows</b> — the head and tail of the sorted linked list are marker rows
+     *       that store a non-policy-ID value in the {@code key} slot. They exist because a sorted
+     *       linked list needs boundaries so that inserts and deletes can always reference a node
+     *       "before the first real entry" or "after the last real entry". They are not registrations.</li>
+     * </ul>
+     *
+     * <h2>Distinguishing the three cases by length</h2>
+     *
+     * <ul>
+     *   <li><b>empty string (0 hex)</b> — head sentinel. <i>Not</i> a policy ID.</li>
+     *   <li><b>exactly 56 hex chars</b> — real registered programmable token policy ID.</li>
+     *   <li><b>58–64 hex chars</b> — tail sentinel. <i>Not</i> a policy ID. The aiken-linked-list
+     *       implementation in use on preprod materializes a 30-byte (60-hex) sentinel of
+     *       {@code 0xFF}; the upper bound of 32 bytes (64 hex) is kept for safety since the exact
+     *       length is a library-level convention, not a CIP-113 protocol guarantee.</li>
+     * </ul>
+     *
+     * {@code VARCHAR(64)} is the tightest bound that fits all three — DO NOT shrink to 56,
+     * even though real policy IDs are exactly 56 hex, because that would reject sentinel rows.
+     *
+     * <h2>Why the column is not named {@code policy_id}</h2>
+     *
+     * Naming it {@code policy_id} would overclaim what is stored: two rows per registry (head
+     * and tail sentinels) do not hold policy IDs. The column name {@code key} matches the
+     * on-chain Aiken datum field and the parsed record field ({@code ParsedRegistryNode.key()}).
+     *
+     * <h2>Column quoting</h2>
+     *
+     * {@code KEY} is a reserved word in H2 and MySQL (but not PostgreSQL). The surrounding
+     * backticks in {@code @Column(name = "`key`")} trigger Hibernate's proprietary identifier
+     * quoting — at SQL generation time Hibernate applies the dialect-appropriate quote character
+     * (double quotes for PostgreSQL / H2, backticks for MySQL).
+     */
+    @Id
+    @Column(name = "`key`", length = 64, nullable = false)
+    @EqualsAndHashCode.Include
+    private String key;
+
+    @Id
+    @Column(nullable = false)
+    @EqualsAndHashCode.Include
+    private Long slot;
+
+    /**
+     * Transaction hash of the registry-node output this row was indexed from. Part of the primary
+     * key {@code (key, slot, tx_hash)} — tx identity is what makes each update a distinct row, so
+     * the registry keeps full history rather than doing in-place updates. Matches the rest of
+     * yaci-store, where on-chain history tables key on {@code tx_hash} (stake_registration,
+     * governance, etc.).
+     */
+    @Id
+    @Column(name = "tx_hash", length = 64, nullable = false)
+    @EqualsAndHashCode.Include
+    private String txHash;
+
+    /**
+     * Index of the producing transaction within its block. Not part of the primary key; kept as an
+     * ordering column so the latest node state is resolved deterministically by
+     * {@code ORDER BY slot DESC, tx_index DESC} (disambiguating same-slot intra-block updates),
+     * giving the readers a single "latest row per key" without collapsing history.
+     */
+    @Column(name = "tx_index", nullable = false)
+    private Integer txIndex;
+
+    /** Aiken {@code Credential} (28-byte vkey or script hash, 56 hex chars). Protocol-bounded. */
+    @Nullable
+    @Column(name = "transfer_logic_script", length = 56)
+    private String transferLogicScript;
+
+    /**
+     * Aiken {@code Credential} discriminator for {@link #transferLogicScript}. Non-null iff
+     * {@code transferLogicScript} is non-null. Persisted as a string ({@code "VKEY"} or
+     * {@code "SCRIPT"}) so the column is queryable from raw SQL without Java enum awareness.
+     */
+    @Nullable
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transfer_logic_script_type", length = 8)
+    private Cip113CredentialType transferLogicScriptType;
+
+    /** Aiken {@code Credential} (28-byte vkey or script hash, 56 hex chars). Protocol-bounded. */
+    @Nullable
+    @Column(name = "third_party_transfer_logic_script", length = 56)
+    private String thirdPartyTransferLogicScript;
+
+    /** Aiken {@code Credential} discriminator for {@link #thirdPartyTransferLogicScript}. */
+    @Nullable
+    @Enumerated(EnumType.STRING)
+    @Column(name = "third_party_transfer_logic_script_type", length = 8)
+    private Cip113CredentialType thirdPartyTransferLogicScriptType;
+
+    /** Currency symbol of the global-state NFT (28-byte policy_id, 56 hex chars). Protocol-bounded. */
+    @Nullable
+    @Column(name = "global_state_policy_id", length = 56)
+    private String globalStatePolicyId;
+
+    /**
+     * The {@code next} field of the CIP-113 registry node datum — this row's pointer to the
+     * next node in the sorted linked list. Same dual role and length range as {@link #key}:
+     * it is a real 56-hex policy ID when it points at a registered entry, or a sentinel marker
+     * (60 hex on preprod; up to 64 hex allowed for safety) when it points at the tail.
+     * {@code VARCHAR(64)} is the tightest bound — DO NOT shrink to 56.
+     *
+     * <p>Backtick-quoted for the same reason as {@link #key}: {@code NEXT} is reserved in H2
+     * and MySQL.
+     */
+    @Column(name = "`next`", length = 64, nullable = false)
+    private String next;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String datum;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastSyncedAt;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/model/Cip113RegistryNodeId.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/model/Cip113RegistryNodeId.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+public class Cip113RegistryNodeId {
+
+    private String key;
+    private Long slot;
+    private String txHash;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/repository/Cip113RegistryNodeRepository.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/impl/repository/Cip113RegistryNodeRepository.java
@@ -1,0 +1,67 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNode;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNodeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for the CIP-113 programmable-token registry node table.
+ *
+ * <p><b>On the word "key":</b> the {@code key} column of {@link Cip113RegistryNode} is the
+ * registry node's sort key in the on-chain sorted linked list. For real registration rows it
+ * equals the 56-hex policy ID of the registered programmable token; for the two sentinel rows
+ * per registry (head and tail) it is a non-policy-ID linked-list marker. See
+ * {@link Cip113RegistryNode} for the full explanation. Methods on this repository
+ * name their parameter {@code key} to stay honest about that dual role, but in practice
+ * callers always pass a real 56-hex policy ID — there is never a reason to look up a sentinel.
+ *
+ * <p>All queries are JPQL rather than native SQL so that the {@code key} and {@code next}
+ * identifiers — reserved words in H2 and MySQL — do not need dialect-specific quoting.
+ */
+@Repository
+public interface Cip113RegistryNodeRepository extends JpaRepository<Cip113RegistryNode, Cip113RegistryNodeId> {
+
+    /**
+     * Returns the most recent registry node state for a given key — highest slot, and within that
+     * slot the highest tx_index (so intra-block updates resolve deterministically to the last one).
+     * Callers typically pass the 56-hex policy ID of the token they're looking up.
+     */
+    Optional<Cip113RegistryNode> findFirstByKeyOrderBySlotDescTxIndexDesc(String key);
+
+    /**
+     * Returns the latest registry node state for each of the given keys — exactly one row per key.
+     * "Latest" = highest slot, and within that slot the highest tx_index, so the (key, slot, tx_index)
+     * history collapses to a single deterministic current-state row per key. The two correlated
+     * subqueries pin the row to MAX(slot) then MAX(tx_index) within that slot; since
+     * (key, slot, tx_index) is unique this yields one row per key and never a duplicate-key collision
+     * downstream. Written as JPQL so the reserved-word {@code key} identifier needs no dialect quoting.
+     *
+     * <p>Index-backed per-key lookups on PostgreSQL / H2 / MySQL given the
+     * {@code (key, slot, tx_index)} primary key.
+     */
+    @Query("SELECT e FROM Cip113RegistryNode e " +
+            "WHERE e.key IN :keys " +
+            "AND e.slot = (SELECT MAX(e2.slot) FROM Cip113RegistryNode e2 WHERE e2.key = e.key) " +
+            "AND e.txIndex = (SELECT MAX(e3.txIndex) FROM Cip113RegistryNode e3 " +
+            "WHERE e3.key = e.key AND e3.slot = e.slot)")
+    List<Cip113RegistryNode> findLatestByKeys(@Param("keys") Collection<String> keys);
+
+    /**
+     * Bulk delete on rollback. {@code @Modifying @Query} with JPQL issues a single SQL DELETE;
+     * without these annotations Spring Data's derived deleteBy* loads each entity then deletes
+     * per-row (one round-trip per matching row), which is pathological for deep rollbacks.
+     * Caller ({@code Cip113RollbackProcessor.handleRollbackEvent}) is already {@code @Transactional}.
+     */
+    @Modifying
+    @Query("DELETE FROM Cip113RegistryNode e WHERE e.slot > :slot")
+    int deleteBySlotGreaterThan(@Param("slot") Long slot);
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/Cip26NetworkDefaults.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/Cip26NetworkDefaults.java
@@ -1,0 +1,92 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.NetworkType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves CIP-26 GitHub token registry defaults based on the connected network.
+ * <p>
+ * If the user explicitly sets git.organization / git.project-name / git.mappings-folder,
+ * those values take priority. Otherwise, defaults are derived from {@code store.cardano.protocol-magic}.
+ * <p>
+ * CIP-26 offchain registries only exist for mainnet and preprod. On other networks (preview,
+ * sanchonet, devkit) the sync is automatically disabled unless the user explicitly configures
+ * a custom registry.
+ *
+ * <table>
+ *   <caption>CIP-26 registry defaults per network</caption>
+ *   <tr><th>Network</th><th>Organization</th><th>Repository</th><th>Mappings Folder</th></tr>
+ *   <tr><td>Mainnet</td><td>cardano-foundation</td><td>cardano-token-registry</td><td>mappings</td></tr>
+ *   <tr><td>Preprod</td><td>input-output-hk</td><td>metadata-registry-testnet</td><td>registry</td></tr>
+ *   <tr><td>Others</td><td colspan="3">No registry available — CIP-26 sync disabled</td></tr>
+ * </table>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class Cip26NetworkDefaults {
+
+    private final StoreProperties storeProperties;
+    private final AssetsExtStoreProperties assetsStoreProperties;
+
+    @Getter
+    private String organization;
+    @Getter
+    private String projectName;
+    @Getter
+    private String mappingsFolder;
+    @Getter
+    private boolean registryAvailable;
+
+    @PostConstruct
+    void resolve() {
+        NetworkType network = NetworkType.fromProtocolMagic(storeProperties.getProtocolMagic());
+        String userOrganization = assetsStoreProperties.getCip26().getGitOrganization();
+        String userProjectName = assetsStoreProperties.getCip26().getGitProjectName();
+        String userMappingsFolder = assetsStoreProperties.getCip26().getGitMappingsFolder();
+        boolean hasUserOverride = userOrganization != null || userProjectName != null;
+
+        if (network == NetworkType.MAINNET) {
+            organization = defaultIfNull(userOrganization, "cardano-foundation");
+            projectName = defaultIfNull(userProjectName, "cardano-token-registry");
+            mappingsFolder = defaultIfNull(userMappingsFolder, "mappings");
+            registryAvailable = true;
+        } else if (network == NetworkType.PREPROD) {
+            organization = defaultIfNull(userOrganization, "input-output-hk");
+            projectName = defaultIfNull(userProjectName, "metadata-registry-testnet");
+            mappingsFolder = defaultIfNull(userMappingsFolder, "registry");
+            registryAvailable = true;
+        } else if (hasUserOverride) {
+            // User explicitly configured a custom registry for this network
+            organization = userOrganization;
+            projectName = userProjectName;
+            mappingsFolder = defaultIfNull(userMappingsFolder, "mappings");
+            registryAvailable = true;
+        } else {
+            // Preview, Sanchonet, DevKit, etc. — no known CIP-26 registry
+            organization = null;
+            projectName = null;
+            mappingsFolder = null;
+            registryAvailable = false;
+        }
+
+        String networkName = network != null ? network.name() : "UNKNOWN (magic=" + storeProperties.getProtocolMagic() + ")";
+        if (registryAvailable) {
+            log.info("CIP-26 token registry: network={}, org={}, repo={}, folder={}",
+                    networkName, organization, projectName, mappingsFolder);
+        } else {
+            log.info("CIP-26 token registry: no registry available for network={}, sync will be skipped",
+                    networkName);
+        }
+    }
+
+    private static String defaultIfNull(String value, String defaultValue) {
+        return (value != null && !value.isBlank()) ? value : defaultValue;
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Item.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Item.java
@@ -1,0 +1,6 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model;
+
+import java.util.List;
+
+public record Item(Integer sequenceNumber, String value, List<Signature> signatures) {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Mapping.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Mapping.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Parsed representation of a single CIP-26 token metadata mapping file from
+ * <a href="https://github.com/cardano-foundation/cardano-token-registry">cardano-token-registry</a>.
+ * Field names mirror the CIP-26 JSON schema exactly so Jackson can bind 1:1.
+ *
+ * @param subject     The asset identifier, base16-encoded. For phase-1 monetary policies this is
+ *                    {@code policyId (28 bytes) || assetName (up to 32 bytes)}, so at most
+ *                    120 hex chars. Example: LAMP token's subject is
+ *                    {@code 2376e2c5…5b5c} (policyId) + {@code 4c414d50} ("LAMP").
+ * @param policy      The base16-encoded CBOR of the phase-1 monetary script (a native script).
+ *                    <strong>This is the script itself, NOT the 28-byte policyId hash.</strong>
+ *                    Per CIP-26: {@code minLength: 56, maxLength: 120} hex chars. Clients verify
+ *                    an entry by re-hashing this field with blake2b-224 and comparing the result
+ *                    to the first 28 bytes of {@code subject}. A simple single-sig script is
+ *                    ~64 hex chars; time-locked or multisig scripts can reach the 120 cap.
+ * @see <a href="https://github.com/cardano-foundation/CIPs/blob/main/CIP-0026/README.md">CIP-0026</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Mapping(String subject,
+                      Item url,
+                      Item name,
+                      Item ticker,
+                      Item decimals,
+                      Item logo,
+                      String policy,
+                      Item description) {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/MappingUpdateDetails.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/MappingUpdateDetails.java
@@ -1,0 +1,6 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model;
+
+import java.time.LocalDateTime;
+
+public record MappingUpdateDetails(String updatedBy, LocalDateTime updatedAt) {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Signature.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/Signature.java
@@ -1,0 +1,4 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model;
+
+public record Signature(String signature, String publicKey) {
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/enums/SyncStatusEnum.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/enums/SyncStatusEnum.java
@@ -1,0 +1,70 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.Constants;
+
+/**
+ * Lifecycle of the in-process CIP-26 off-chain registry sync.
+ *
+ * <p>The current value is exposed through {@code SyncStatus} on
+ * {@code Cip26MetadataSyncService} and consumed by
+ * {@code OffchainSyncHealthIndicator}, which maps each value to a Spring Boot
+ * {@link org.springframework.boot.actuate.health.Health} status used by
+ * liveness/readiness probes.
+ */
+public enum SyncStatusEnum {
+
+    /**
+     * Initial value when CIP-26 sync is enabled but the cron has not yet executed
+     * its first run (set in {@code Cip26MetadataSyncService#initSyncStatus}). Health
+     * indicator maps this to {@code OUT_OF_SERVICE} so readiness probes don't route
+     * traffic to a process whose registry cache is empty.
+     */
+    SYNC_NOT_STARTED(Constants.SYNC_NOT_STARTED),
+
+    /**
+     * A sync run is currently executing (clone / diff / persist). Set at the top of
+     * {@code synchronizeDatabase()}. Health indicator maps this to
+     * {@code OUT_OF_SERVICE} for the same reason as {@link #SYNC_NOT_STARTED} —
+     * partial data may be visible mid-run.
+     */
+    SYNC_IN_PROGRESS(Constants.SYNC_IN_PROGRESS),
+
+    /**
+     * Most recent sync run finished successfully (either applied a delta or detected
+     * "nothing new since last commit"). Health indicator maps this to {@code UP}.
+     */
+    SYNC_DONE(Constants.SYNC_DONE),
+
+    /**
+     * Most recent sync run threw an exception. Health indicator maps this to
+     * {@code DOWN}, distinct from {@code OUT_OF_SERVICE} so probe groups can treat
+     * it as alertable rather than "wait it out".
+     */
+    SYNC_ERROR(Constants.SYNC_ERROR),
+
+    /**
+     * In-process CIP-26 sync is disabled ({@code store.assets.ext.cip26.enabled=false}).
+     * Set once at startup in {@code initSyncStatus}; never transitions out of this
+     * state.
+     *
+     * <p>The implicit assumption is that the operator is keeping
+     * {@code cip26_metadata} fresh via some external mechanism (separate batch job,
+     * data pipeline, manual import) — yaci itself has no way to verify whether such
+     * a job exists or is working. Health indicator maps this to {@code UP} on that
+     * assumption; returning {@code DOWN} would falsely page on every probe when an
+     * operator deliberately turns the cron off.
+     */
+    SYNC_DISABLED(Constants.SYNC_DISABLED);
+
+    private final String text;
+
+    SyncStatusEnum(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataService.java
@@ -1,0 +1,123 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26MetadataRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.MappingsUtil;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.Cip26MetadataValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.NonTransientDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.MappingsUtil.extractLogo;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class Cip26MetadataService {
+
+    private final Cip26MetadataRepository cip26MetadataRepository;
+    private final Cip26MetadataValidator cip26MetadataValidator;
+
+    /**
+     * Validates and inserts CIP-26 metadata for one mapping.
+     * <p>
+     * Logo is intentionally <em>not</em> set here — see {@link #insertLogo(Mapping)}, which
+     * runs a separate validation pass and updates the same row. The two-step flow predates
+     * the schema merge and is preserved so the validation paths stay independent (a row
+     * with valid metadata but a too-large logo can still be saved with the metadata only).
+     *
+     * @return {@link InsertOutcome#INSERTED} on success;
+     *         {@link InsertOutcome#PERMANENTLY_SKIPPED} when validation fails
+     *         or the database rejects the row with a non-transient error;
+     *         {@link InsertOutcome#TRANSIENTLY_FAILED} when the database error
+     *         looks recoverable (or is an unfamiliar exception we can't
+     *         classify — the conservative default to avoid silent drops).
+     */
+    @Transactional
+    public InsertOutcome insertMapping(Mapping mapping, LocalDateTime updatedAt, String updateBy) {
+        Cip26Metadata cip26Metadata = MappingsUtil.toCip26Metadata(mapping, updateBy, updatedAt);
+
+        if (!cip26MetadataValidator.validate(cip26Metadata)) {
+            // Validator already logged the specific reason at WARN.
+            return InsertOutcome.PERMANENTLY_SKIPPED;
+        }
+
+        try {
+            cip26Metadata.setLastSyncedAt(LocalDateTime.now());
+            cip26MetadataRepository.save(cip26Metadata);
+            return InsertOutcome.INSERTED;
+        } catch (NonTransientDataAccessException e) {
+            // Constraint violation, column too narrow, encoding error — won't
+            // help to retry. Log loudly so operators can either widen the
+            // schema, tighten the validator, or fix upstream data.
+            log.error("Permanent save failure for token subject '{}', skipping: {}",
+                    cip26Metadata.getSubject(), e.getMessage());
+            return InsertOutcome.PERMANENTLY_SKIPPED;
+        } catch (TransientDataAccessException e) {
+            log.warn("Transient save failure for token subject '{}', will retry next sync: {}",
+                    cip26Metadata.getSubject(), e.getMessage());
+            return InsertOutcome.TRANSIENTLY_FAILED;
+        } catch (Exception e) {
+            // Unknown exception type — conservative default is "transient" so
+            // we don't silently drop. Recurring failures will show up in logs
+            // every sync and need investigation.
+            log.error("Unclassified save failure for token subject '{}', will retry next sync: {}",
+                    cip26Metadata.getSubject(), e.getMessage(), e);
+            return InsertOutcome.TRANSIENTLY_FAILED;
+        }
+    }
+
+    /**
+     * Validates the logo and writes it onto the existing {@link Cip26Metadata} row for
+     * this subject. Same outcome semantics as {@link #insertMapping(Mapping, LocalDateTime, String)}.
+     * <p>
+     * If no metadata row exists for the subject (either because {@code insertMapping}
+     * skipped it earlier in this sync, or because of an upstream registry oddity where a
+     * logo file exists without a metadata file), the logo write is skipped — orphan logos
+     * have no way to surface in the API anyway.
+     */
+    @Transactional
+    public InsertOutcome insertLogo(Mapping mapping) {
+        String subject = mapping.subject();
+        String logo = extractLogo(mapping);
+
+        if (!cip26MetadataValidator.validateLogo(subject, logo)) {
+            return InsertOutcome.PERMANENTLY_SKIPPED;
+        }
+
+        try {
+            Optional<Cip26Metadata> existing = cip26MetadataRepository.findById(subject);
+            if (existing.isEmpty()) {
+                // Orphan logo (no metadata row). Skip permanently — the registry has odd
+                // state but retrying won't change it; operator should surface this upstream.
+                log.warn("Skipping logo for subject '{}': no Cip26Metadata row exists", subject);
+                return InsertOutcome.PERMANENTLY_SKIPPED;
+            }
+            Cip26Metadata row = existing.get();
+            row.setLogo(logo);
+            row.setLastSyncedAt(LocalDateTime.now());
+            cip26MetadataRepository.save(row);
+            return InsertOutcome.INSERTED;
+        } catch (NonTransientDataAccessException e) {
+            log.error("Permanent save failure for logo subject '{}', skipping: {}",
+                    subject, e.getMessage());
+            return InsertOutcome.PERMANENTLY_SKIPPED;
+        } catch (TransientDataAccessException e) {
+            log.warn("Transient save failure for logo subject '{}', will retry next sync: {}",
+                    subject, e.getMessage());
+            return InsertOutcome.TRANSIENTLY_FAILED;
+        } catch (Exception e) {
+            log.error("Unclassified save failure for logo subject '{}', will retry next sync: {}",
+                    subject, e.getMessage(), e);
+            return InsertOutcome.TRANSIENTLY_FAILED;
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncCronJob.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncCronJob.java
@@ -1,0 +1,46 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Scheduled cron job that periodically syncs CIP-26 offchain metadata from the GitHub token registry.
+ * <p>
+ * Gated with {@code @ReadOnly(false)} to prevent the {@code @Scheduled} timer from firing in
+ * read-only mode ({@code store.read-only-mode=true}). Unlike on-chain processors that are
+ * implicitly safe (no block events are published in read-only mode), this cron job runs on
+ * a fixed timer and would otherwise attempt git clone/pull and database writes.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "store.assets.ext.cip26.enabled", havingValue = "true", matchIfMissing = true)
+@ReadOnly(false)
+public class Cip26MetadataSyncCronJob implements Runnable {
+
+    private final Cip26MetadataSyncService tokenMetadataSyncService;
+
+    public Cip26MetadataSyncCronJob(Cip26MetadataSyncService tokenMetadataSyncService) {
+        this.tokenMetadataSyncService = tokenMetadataSyncService;
+    }
+
+    @Override
+    @Scheduled(timeUnit = TimeUnit.MINUTES, initialDelay = 1L,
+            fixedDelayString = "${store.assets.ext.cip26.sync-interval-minutes:60}")
+    public void run() {
+        log.info("CIP-26 offchain registry sync — starting.");
+        tokenMetadataSyncService.synchronizeDatabase();
+        log.info("CIP-26 offchain registry sync — finished.");
+    }
+
+    @PostConstruct
+    public void logInitMessage() {
+        log.info("CIP-26 offchain metadata sync cronjob initialised.");
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncService.java
@@ -1,0 +1,283 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26SyncState;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26SyncStateRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class Cip26MetadataSyncService {
+
+    private final GitService gitService;
+    private final Cip26MetadataService tokenMetadataService;
+    private final TokenMappingService tokenMappingService;
+    private final Cip26SyncStateRepository syncStateRepository;
+    private final Cip26NetworkDefaults networkDefaults;
+    private final AssetsExtStoreProperties assetsStoreProperties;
+
+    @Getter
+    private SyncStatus syncStatus;
+
+    @PostConstruct
+    void initSyncStatus() {
+        if (assetsStoreProperties.getCip26().isEnabled()) {
+            syncStatus = new SyncStatus(false, SyncStatusEnum.SYNC_NOT_STARTED);
+        } else {
+            syncStatus = new SyncStatus(true, SyncStatusEnum.SYNC_DISABLED);
+        }
+    }
+
+    public void synchronizeDatabase() {
+        if (!networkDefaults.isRegistryAvailable()) {
+            log.debug("CIP-26 sync skipped — no token registry available for this network");
+            return;
+        }
+
+        syncStatus.setStatus(SyncStatusEnum.SYNC_IN_PROGRESS);
+
+        Optional<Cip26SyncState> lastSyncState = syncStateRepository.findTopByOrderByIdDesc();
+        String lastHash = lastSyncState
+                .map(Cip26SyncState::getLastCommitHash).orElse(null);
+
+        long syncStart = System.currentTimeMillis();
+        log.info("Starting offchain sync. Last known commit: {}", lastHash != null ? lastHash : "(none — full sync)");
+
+        long cloneStart = System.currentTimeMillis();
+        Optional<Path> repoPathOpt = gitService.cloneCardanoTokenRegistryGitRepository();
+
+        if (repoPathOpt.isPresent()) {
+
+            log.info("Repository ready in {} ms", System.currentTimeMillis() - cloneStart);
+
+            Optional<String> newHashOpt = gitService.getHeadCommitHash();
+            if (newHashOpt.isEmpty()) {
+                log.warn("Could not determine HEAD commit hash after cloning. Falling back to full sync without hash tracking.");
+            }
+
+            if (newHashOpt.isPresent() && newHashOpt.get().equals(lastHash)) {
+                log.info("No new commits since last sync. Skipping processing.");
+                syncStatus.setStatus(SyncStatusEnum.SYNC_DONE);
+                syncStatus.setInitialSyncDone(true);
+                return;
+            }
+
+            List<File> filesToProcess = resolveFilesToProcess(lastHash, newHashOpt, repoPathOpt.get());
+            log.info("Resolved {} file(s) to process", filesToProcess.size());
+
+            // Batch-resolve git metadata for all files in a single history walk
+            Set<String> fileNames = filesToProcess.stream()
+                    .map(File::getName)
+                    .collect(Collectors.toCollection(HashSet::new));
+            long gitHistoryStart = System.currentTimeMillis();
+            log.info("Resolving git history for {} file(s) in batch...", fileNames.size());
+            Map<String, MappingUpdateDetails> mappingDetailsMap = gitService.getAllMappingDetails(fileNames);
+            log.info("Git history resolved in {} ms", System.currentTimeMillis() - gitHistoryStart);
+
+            long processStart = System.currentTimeMillis();
+            boolean anyTransientFailure = processMappingFiles(filesToProcess, mappingDetailsMap);
+
+            if (anyTransientFailure) {
+                log.warn("At least one entry hit a transient failure. Commit hash will not be advanced so those entries are retried on next sync.");
+            } else if (newHashOpt.isPresent()) {
+                Cip26SyncState offChainSyncStateToSave = lastSyncState.orElse(new Cip26SyncState());
+                offChainSyncStateToSave.setLastCommitHash(newHashOpt.get());
+                offChainSyncStateToSave.setLastSyncedAt(LocalDateTime.now());
+                syncStateRepository.save(offChainSyncStateToSave);
+                log.info("Commit hash advanced to {}", newHashOpt.get());
+            }
+
+            log.info("Mapping processing took {} ms", System.currentTimeMillis() - processStart);
+
+            syncStatus.setStatus(SyncStatusEnum.SYNC_DONE);
+            syncStatus.setInitialSyncDone(true);
+            log.info("Offchain sync complete in {} ms", System.currentTimeMillis() - syncStart);
+
+        } else {
+            log.warn("cardano-token-registry could not be cloned");
+            syncStatus.setStatus(SyncStatusEnum.SYNC_ERROR);
+        }
+
+    }
+
+    /**
+     * Returns true iff at least one entry hit a transient (recoverable) failure
+     * — those block the cursor advance so the next sync retries them.
+     * Permanently-skipped entries (validation rejected, non-transient DB
+     * errors) do NOT block: they're documented and we move on, otherwise the
+     * sync would loop forever on bad data.
+     */
+    private boolean processMappingFiles(List<File> filesToProcess, Map<String, MappingUpdateDetails> mappingDetailsMap) {
+        Tally tally = new Tally(filesToProcess.size());
+
+        for (File mappingFile : filesToProcess) {
+            FileOutcome outcome = processOneMappingFile(mappingFile, mappingDetailsMap);
+            tally.record(outcome);
+            tally.maybeLogProgress();
+        }
+
+        tally.logSummary();
+        return tally.anyTransient;
+    }
+
+    /**
+     * Process a single mapping file end-to-end and classify the result. Pulls the
+     * skip/insert/error flow out of the main loop so each branch is a {@code return}
+     * rather than a {@code continue}, which keeps the loop's cognitive complexity low.
+     */
+    private FileOutcome processOneMappingFile(File mappingFile,
+                                              Map<String, MappingUpdateDetails> mappingDetailsMap) {
+        Optional<Mapping> mapping = tokenMappingService.parseMappings(mappingFile);
+        if (mapping.isEmpty()) {
+            return FileOutcome.SKIPPED_NO_MAPPING;
+        }
+
+        // Filename-vs-inner-subject filter: in the upstream registries, the
+        // canonical file for a token is named after its subject. ~90% of files
+        // in the testnet registry have a filename that doesn't match the inner
+        // `subject` field (typo / spam / orphaned). Indexing those would mean
+        // last-write-wins on the same DB row by File.listFiles() order, which
+        // is filesystem-dependent and silently picks arbitrary content. By
+        // accepting only filename-matches-subject files we guarantee at most
+        // one file per subject (filenames are unique) and full determinism.
+        String filenameSubject = stripJsonExtension(mappingFile.getName());
+        if (!filenameSubject.equals(mapping.get().subject())) {
+            log.warn("Skipping '{}': filename does not match inner subject '{}'",
+                    mappingFile.getName(), mapping.get().subject());
+            return FileOutcome.SKIPPED_FILENAME_MISMATCH;
+        }
+
+        MappingUpdateDetails updateDetails = mappingDetailsMap.get(mappingFile.getName());
+        if (updateDetails == null) {
+            return FileOutcome.SKIPPED_NO_MAPPING;
+        }
+
+        try {
+            return classifyInsertOutcome(mapping.get(), updateDetails);
+        } catch (Exception e) {
+            // Defensive: should not normally bubble up — the service classifies
+            // its own exceptions. Treat anything that does as transient so it
+            // retries; a real bug will keep showing up in logs.
+            log.warn("Unexpected exception while processing token '{}': {}. Will retry next sync.",
+                    mapping.get().subject(), e.getMessage());
+            return FileOutcome.TRANSIENTLY_FAILED;
+        }
+    }
+
+    private FileOutcome classifyInsertOutcome(Mapping mapping, MappingUpdateDetails updateDetails) {
+        InsertOutcome metadataOutcome = tokenMetadataService.insertMapping(
+                mapping, updateDetails.updatedAt(), updateDetails.updatedBy());
+
+        return switch (metadataOutcome) {
+            case INSERTED -> {
+                // Logo may also be transient — fold its outcome into the same tally.
+                InsertOutcome logoOutcome = tokenMetadataService.insertLogo(mapping);
+                yield logoOutcome == InsertOutcome.TRANSIENTLY_FAILED
+                        ? FileOutcome.INSERTED_LOGO_TRANSIENT
+                        : FileOutcome.INSERTED;
+            }
+            case TRANSIENTLY_FAILED -> FileOutcome.TRANSIENTLY_FAILED;
+            case PERMANENTLY_SKIPPED -> FileOutcome.PERMANENTLY_SKIPPED;
+        };
+    }
+
+    /** Per-file outcome categories the tally tracks. */
+    private enum FileOutcome {
+        INSERTED,
+        INSERTED_LOGO_TRANSIENT,
+        PERMANENTLY_SKIPPED,
+        TRANSIENTLY_FAILED,
+        SKIPPED_NO_MAPPING,
+        SKIPPED_FILENAME_MISMATCH
+    }
+
+    /** Mutable counter bag for the {@link #processMappingFiles} loop. */
+    private final class Tally {
+        private final int total;
+        private int processed;
+        private int inserted;
+        private int permanentlySkipped;
+        private int transientlyFailed;
+        private int skippedNoMapping;
+        private int skippedFilenameMismatch;
+        private boolean anyTransient;
+
+        Tally(int total) {
+            this.total = total;
+        }
+
+        void record(FileOutcome outcome) {
+            processed++;
+            switch (outcome) {
+                case INSERTED -> inserted++;
+                case INSERTED_LOGO_TRANSIENT -> {
+                    inserted++;
+                    transientlyFailed++;
+                    anyTransient = true;
+                }
+                case TRANSIENTLY_FAILED -> {
+                    transientlyFailed++;
+                    anyTransient = true;
+                }
+                case PERMANENTLY_SKIPPED -> permanentlySkipped++;
+                case SKIPPED_NO_MAPPING -> skippedNoMapping++;
+                case SKIPPED_FILENAME_MISMATCH -> skippedFilenameMismatch++;
+            }
+        }
+
+        void maybeLogProgress() {
+            if (processed % 500 == 0) {
+                log.info("Processing mappings: {}/{} done " +
+                                "(inserted={}, perm-skipped={}, transient={}, no-mapping={}, filename-mismatch={})",
+                        processed, total, inserted, permanentlySkipped, transientlyFailed,
+                        skippedNoMapping, skippedFilenameMismatch);
+            }
+        }
+
+        void logSummary() {
+            log.info("Mapping processing complete: {}/{} processed " +
+                            "(inserted={}, perm-skipped={}, transient={}, no-mapping={}, filename-mismatch={}). " +
+                            "Cursor will {} advance.",
+                    processed, total, inserted, permanentlySkipped, transientlyFailed,
+                    skippedNoMapping, skippedFilenameMismatch,
+                    anyTransient ? "NOT" : "");
+        }
+    }
+
+    private static String stripJsonExtension(String fileName) {
+        return fileName.endsWith(".json")
+                ? fileName.substring(0, fileName.length() - ".json".length())
+                : fileName;
+    }
+
+    private List<File> resolveFilesToProcess(String lastHash, Optional<String> newHashOpt, Path repoPath) {
+        if (lastHash != null && newHashOpt.isPresent()) {
+            log.info("Incremental sync from {} to {}", lastHash, newHashOpt.get());
+            List<File> files = gitService.getChangedFiles(lastHash, newHashOpt.get()).stream()
+                    .map(Path::toFile).toList();
+            log.info("Incremental sync: processing {} changed file(s)", files.size());
+            return files;
+        }
+
+        log.info("Full sync: processing all files");
+        File mappings = repoPath.toFile();
+        return Optional.ofNullable(mappings.listFiles())
+                .map(Arrays::asList).orElse(List.of());
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitService.java
@@ -1,0 +1,389 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.BranchConfig;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GitService {
+
+    private static final String GIT_NOT_INITIALIZED = "Git repository not initialized";
+
+    private final Cip26NetworkDefaults networkDefaults;
+    private final AssetsExtStoreProperties assetsStoreProperties;
+
+    String gitTempFolder;
+    boolean forceClone;
+
+    String organization;
+    String projectName;
+    String mappingsFolderName;
+
+    Git git;
+
+    @PostConstruct
+    void init() {
+        organization = networkDefaults.getOrganization();
+        projectName = networkDefaults.getProjectName();
+        mappingsFolderName = networkDefaults.getMappingsFolder();
+
+        gitTempFolder = assetsStoreProperties.getCip26().getGitTmpFolder();
+        forceClone = assetsStoreProperties.getCip26().isForceClone();
+
+        if (gitTempFolder == null || gitTempFolder.isBlank()) {
+            log.warn("store.assets.ext.cip26.git.tmp-folder is blank, defaulting to system temp directory");
+            gitTempFolder = System.getProperty("java.io.tmpdir");
+        }
+    }
+
+    @PreDestroy
+    void cleanup() {
+        if (git != null) {
+            git.close();
+            git = null;
+        }
+    }
+
+    public Optional<Path> cloneCardanoTokenRegistryGitRepository() {
+        File gitFolder = getGitFolder();
+        boolean repoReady;
+
+        if (gitFolder.exists()) {
+            String reasonToFreshClone = reasonToFreshClone();
+            if (reasonToFreshClone != null) {
+                log.info("Wiping clone at {} and re-cloning ({})", gitFolder, reasonToFreshClone);
+                cleanup();
+                FileSystemUtils.deleteRecursively(gitFolder);
+                repoReady = cloneRepo();
+            } else {
+                log.info("Existing clone at {} matches expected remote — opening", gitFolder);
+                repoReady = openExistingRepo() && pullRebaseRepo();
+            }
+        } else {
+            repoReady = cloneRepo();
+        }
+
+        if (repoReady) {
+            return Optional.of(getMappingsFolder());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Determines whether the existing on-disk folder must be wiped before
+     * (re-)cloning. Returns {@code null} if the folder can be reused as-is,
+     * otherwise a short human-readable reason for the log line.
+     *
+     * <p>The remote-URL mismatch branch is the important one: if an operator
+     * switched networks (preprod ⇄ mainnet) the path on disk happens to be
+     * the same temp dir but the existing clone points at a different upstream.
+     * Reusing it would silently index the wrong network's tokens.
+     */
+    String reasonToFreshClone() {
+        if (forceClone) {
+            return "force-clone enabled";
+        }
+        if (!isGitRepo()) {
+            return "folder exists but is not a git repository";
+        }
+        String existingUrl = readExistingRemoteUrl();
+        String expectedUrl = expectedRemoteUrl();
+        if (existingUrl == null || !existingUrl.equals(expectedUrl)) {
+            return "remote URL mismatch (existing='" + existingUrl
+                    + "', expected='" + expectedUrl + "')";
+        }
+        return null;
+    }
+
+    /** URL we'd clone from for the currently-resolved organization/projectName. */
+    String expectedRemoteUrl() {
+        return String.format("https://github.com/%s/%s.git", organization, projectName);
+    }
+
+    /**
+     * Reads {@code remote.origin.url} from the git config inside the existing
+     * clone, without disturbing the {@link #git} field. Returns {@code null}
+     * if the folder isn't a readable git repo or the URL key is absent.
+     */
+    String readExistingRemoteUrl() {
+        File gitDir = getGitFolder().toPath().resolve(".git").toFile();
+        if (!gitDir.exists()) {
+            return null;
+        }
+        try (Repository repo = new FileRepositoryBuilder()
+                .setGitDir(gitDir)
+                .readEnvironment()
+                .build()) {
+            StoredConfig config = repo.getConfig();
+            return config.getString("remote", "origin", "url");
+        } catch (IOException e) {
+            log.warn("Failed to read existing remote URL at {}: {}", gitDir, e.getMessage());
+            return null;
+        }
+    }
+
+    private boolean openExistingRepo() {
+        try {
+            cleanup();
+            git = Git.open(getGitFolder());
+            return true;
+        } catch (IOException e) {
+            log.warn("Failed to open existing git repository", e);
+            return false;
+        }
+    }
+
+    private boolean cloneRepo() {
+        try {
+            String url = String.format("https://github.com/%s/%s.git", organization, projectName);
+            git = Git.cloneRepository()
+                    .setURI(url)
+                    .setDirectory(getGitFolder())
+                    .call();
+            return true;
+        } catch (GitAPIException e) {
+            log.warn("It was not possible to clone the {} project", projectName, e);
+            return false;
+        }
+    }
+
+    private boolean pullRebaseRepo() {
+        try {
+            List<RemoteConfig> remotes = git.remoteList().call();
+            if (remotes.isEmpty()) {
+                log.info("No remote configured, skipping pull");
+                return true;
+            }
+            git.pull()
+                    .setRebase(BranchConfig.BranchRebaseMode.REBASE)
+                    .call();
+            return true;
+        } catch (GitAPIException e) {
+            log.warn("it was not possible to update repo. cloning from scratch", e);
+            return false;
+        }
+    }
+
+    private boolean isGitRepo() {
+        return getGitFolder().toPath().resolve(".git").toFile().exists();
+    }
+
+    private File getGitFolder() {
+        return Path.of(gitTempFolder).resolve(projectName).toFile();
+    }
+
+    private Path getMappingsFolder() {
+        return getGitFolder().toPath().resolve(mappingsFolderName);
+    }
+
+    /**
+     * Batch-resolve mapping update details for all files in a single git log walk.
+     * Instead of running {@code git log --path=<file>} per file (O(files * commits)),
+     * this walks the commit history once and records the most recent non-merge commit
+     * that touched each file under the mappings folder — O(commits * tree-diff).
+     */
+    public Map<String, MappingUpdateDetails> getAllMappingDetails(Set<String> fileNames) {
+        Map<String, MappingUpdateDetails> result = new HashMap<>();
+        if (git == null) {
+            log.warn(GIT_NOT_INITIALIZED);
+            return result;
+        }
+
+        Set<String> remaining = new HashSet<>(fileNames);
+        int commitCount = 0;
+
+        try {
+            Repository repository = git.getRepository();
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                ObjectId head = repository.resolve("HEAD");
+                if (head == null) {
+                    log.warn("Could not resolve HEAD for batch mapping details");
+                    return result;
+                }
+                revWalk.markStart(revWalk.parseCommit(head));
+                revWalk.setRevFilter(RevFilter.NO_MERGES);
+
+                try (ObjectReader reader = repository.newObjectReader()) {
+                    for (RevCommit commit : revWalk) {
+                        if (remaining.isEmpty()) {
+                            break;
+                        }
+                        commitCount++;
+                        recordTouchedMappings(repository, reader, commit, remaining, result);
+
+                        if (commitCount % 1000 == 0) {
+                            log.info("Git history walk: {} commits scanned, {}/{} files resolved",
+                                    commitCount, result.size(), fileNames.size());
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Failed to batch-resolve mapping details after {} commits: {}", commitCount, e.getMessage());
+        }
+
+        log.info("Git history walk complete: {} commits scanned, {}/{} files resolved ({} unresolved)",
+                commitCount, result.size(), fileNames.size(), remaining.size());
+        return result;
+    }
+
+    private void recordTouchedMappings(Repository repository, ObjectReader reader, RevCommit commit,
+                                         Set<String> remaining, Map<String, MappingUpdateDetails> result)
+            throws IOException {
+        List<String> touchedFiles = getFilesTouchedByCommit(repository, reader, commit);
+        String prefix = mappingsFolderName + "/";
+        for (String touchedPath : touchedFiles) {
+            if (!touchedPath.startsWith(prefix)) {
+                continue;
+            }
+            String fileName = touchedPath.substring(prefix.length());
+            if (remaining.remove(fileName)) {
+                PersonIdent author = commit.getAuthorIdent();
+                result.put(fileName, new MappingUpdateDetails(
+                        author.getEmailAddress(),
+                        LocalDateTime.ofInstant(author.getWhenAsInstant(), ZoneOffset.UTC)));
+            }
+        }
+    }
+
+    private List<String> getFilesTouchedByCommit(Repository repository, ObjectReader reader, RevCommit commit)
+            throws IOException {
+        if (commit.getParentCount() == 0) {
+            // Root commit — use recursive TreeWalk to find all files under mappings folder
+            try (TreeWalk treeWalk = new TreeWalk(repository)) {
+                treeWalk.addTree(commit.getTree());
+                treeWalk.setRecursive(true);
+                treeWalk.setFilter(PathFilter.create(mappingsFolderName));
+                List<String> files = new ArrayList<>();
+                while (treeWalk.next()) {
+                    files.add(treeWalk.getPathString());
+                }
+                return files;
+            }
+        }
+
+        try (RevWalk parentWalk = new RevWalk(repository)) {
+            RevCommit parent = parentWalk.parseCommit(commit.getParent(0).getId());
+            CanonicalTreeParser oldTree = new CanonicalTreeParser();
+            oldTree.reset(reader, parent.getTree().getId());
+            CanonicalTreeParser newTree = new CanonicalTreeParser();
+            newTree.reset(reader, commit.getTree().getId());
+
+            List<DiffEntry> diffs = git.diff()
+                    .setOldTree(oldTree)
+                    .setNewTree(newTree)
+                    .setPathFilter(PathFilter.create(mappingsFolderName))
+                    .call();
+
+            return diffs.stream()
+                    .map(d -> d.getChangeType() == DiffEntry.ChangeType.DELETE
+                            ? d.getOldPath() : d.getNewPath())
+                    .toList();
+        } catch (GitAPIException e) {
+            log.warn("Failed to diff commit {}: {}", commit.getName(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    public Optional<String> getHeadCommitHash() {
+        if (git == null) {
+            log.warn(GIT_NOT_INITIALIZED);
+            return Optional.empty();
+        }
+        try {
+            Repository repository = git.getRepository();
+            ObjectId head = repository.resolve("HEAD");
+            if (head != null) {
+                return Optional.of(head.name());
+            }
+        } catch (IOException e) {
+            log.warn("Failed to get HEAD commit hash", e);
+        }
+        return Optional.empty();
+    }
+
+    public List<Path> getChangedFiles(String fromHash, String toHash) {
+        if (git == null) {
+            log.warn(GIT_NOT_INITIALIZED);
+            return List.of();
+        }
+        try {
+            Repository repository = git.getRepository();
+
+            ObjectId oldId = repository.resolve(fromHash);
+            ObjectId newId = repository.resolve(toHash);
+
+            if (oldId == null || newId == null) {
+                log.warn("Could not resolve commit hashes: {} -> {}", fromHash, toHash);
+                return List.of();
+            }
+
+            AbstractTreeIterator oldTree = prepareTreeParser(repository, oldId);
+            AbstractTreeIterator newTree = prepareTreeParser(repository, newId);
+
+            List<DiffEntry> diffs = git.diff()
+                    .setOldTree(oldTree)
+                    .setNewTree(newTree)
+                    .setPathFilter(PathFilter.create(mappingsFolderName))
+                    .call();
+
+            Path repoRoot = getGitFolder().toPath();
+            return diffs.stream()
+                    .filter(d -> d.getChangeType() == DiffEntry.ChangeType.ADD
+                            || d.getChangeType() == DiffEntry.ChangeType.MODIFY)
+                    .map(DiffEntry::getNewPath)
+                    .filter(path -> path.endsWith(".json"))
+                    .map(repoRoot::resolve)
+                    .toList();
+        } catch (Exception e) {
+            log.warn("Failed to get changed files between {} and {}", fromHash, toHash, e);
+        }
+        return List.of();
+    }
+
+    private AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId) throws IOException {
+        try (RevWalk walk = new RevWalk(repository)) {
+            RevCommit commit = walk.parseCommit(objectId);
+            CanonicalTreeParser treeParser = new CanonicalTreeParser();
+            try (ObjectReader reader = repository.newObjectReader()) {
+                treeParser.reset(reader, commit.getTree().getId());
+            }
+            return treeParser;
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/InsertOutcome.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/InsertOutcome.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+/**
+ * Result of attempting to persist a single CIP-26 entry.
+ *
+ * <p>The sync service uses these to decide whether to advance the
+ * {@code last_commit_hash} cursor: any {@link #TRANSIENTLY_FAILED} in a batch
+ * blocks the advance so the next sync retries; otherwise the hash advances
+ * and {@link #PERMANENTLY_SKIPPED} entries are documented as dropped.
+ */
+public enum InsertOutcome {
+
+    /** Entry was successfully persisted. */
+    INSERTED,
+
+    /**
+     * Entry will never persist as-is — either it failed CIP-26 validation
+     * (yaci-side pre-check or upstream library) or the database rejected it
+     * with a non-transient error (constraint violation, value too long,
+     * encoding issue). Retrying the same entry won't help; advance past it.
+     */
+    PERMANENTLY_SKIPPED,
+
+    /**
+     * Save failed with what looks like a recoverable database condition
+     * (lock timeout, lost connection, deadlock) or an exception we don't
+     * recognise. The cursor must NOT advance — the next sync should retry
+     * this entry. Genuine recurring failures will surface as repeating log
+     * lines and need investigation.
+     */
+    TRANSIENTLY_FAILED
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/SyncStatus.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/SyncStatus.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class SyncStatus {
+
+    private boolean isInitialSyncDone;
+    private SyncStatusEnum status;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/TokenMappingService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/TokenMappingService.java
@@ -1,0 +1,48 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenMappingService {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Parses a single registry mapping file. Returns {@link Optional#empty()} on any failure
+     * so the sync loop can keep going.
+     *
+     * <p>Exceptions are split by category so operators can distinguish:
+     * <ul>
+     *   <li>{@link JsonProcessingException} — malformed minter data; expected occurrence on
+     *       public registries, logged at WARN with filename only (no stack trace);</li>
+     *   <li>{@link IOException} — file/disk read failure; infrastructure-shaped, logged at
+     *       ERROR with full stack trace so it surfaces in alerting.</li>
+     * </ul>
+     * Both buckets currently translate to the same downstream outcome
+     * ({@code Cip26MetadataSyncService.FileOutcome.SKIPPED_NO_MAPPING}), so the cursor
+     * behaviour is unchanged — this is a logging-hygiene fix, not a control-flow change.
+     */
+    public Optional<Mapping> parseMappings(File mappingFile) {
+        try {
+            return Optional.of(objectMapper.readValue(mappingFile, Mapping.class));
+        } catch (JsonProcessingException e) {
+            log.warn("Malformed JSON in registry file '{}': {}", mappingFile.getName(), e.getOriginalMessage());
+            return Optional.empty();
+        } catch (IOException e) {
+            log.error("I/O failure reading registry file '{}'", mappingFile.getName(), e);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/Cip26StorageReader.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/Cip26StorageReader.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Read-only access to CIP-26 offchain fungible token metadata.
+ */
+public interface Cip26StorageReader {
+
+    /**
+     * Find metadata for a single subject.
+     */
+    Optional<Cip26Metadata> findBySubject(String subject);
+
+    /**
+     * Batch lookup metadata for multiple subjects.
+     */
+    List<Cip26Metadata> findBySubjects(List<String> subjects);
+
+    /**
+     * Find the logo (base64-encoded PNG) for a subject.
+     */
+    Optional<String> findLogoBySubject(String subject);
+
+    /**
+     * Batch lookup logos for multiple subjects. Returns a map of subject → logo (base64).
+     * Subjects without logos are omitted from the map.
+     */
+    Map<String, String> findLogosBySubjects(List<String> subjects);
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/Cip26StorageReaderImpl.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/Cip26StorageReaderImpl.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26MetadataRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class Cip26StorageReaderImpl implements Cip26StorageReader {
+
+    private final Cip26MetadataRepository cip26MetadataRepository;
+
+    @Override
+    public Optional<Cip26Metadata> findBySubject(String subject) {
+        return cip26MetadataRepository.findById(subject);
+    }
+
+    @Override
+    public List<Cip26Metadata> findBySubjects(List<String> subjects) {
+        return cip26MetadataRepository.findAllById(subjects);
+    }
+
+    @Override
+    public Optional<String> findLogoBySubject(String subject) {
+        return cip26MetadataRepository.findById(subject)
+                .map(Cip26Metadata::getLogo);
+    }
+
+    @Override
+    public Map<String, String> findLogosBySubjects(List<String> subjects) {
+        return cip26MetadataRepository.findAllById(subjects).stream()
+                .filter(row -> row.getLogo() != null)
+                .collect(Collectors.toMap(Cip26Metadata::getSubject, Cip26Metadata::getLogo));
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/model/Cip26Metadata.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/model/Cip26Metadata.java
@@ -1,0 +1,98 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cip26_metadata")
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Cip26Metadata {
+
+    /**
+     * Subject = policyId (28 bytes) + optional assetName (0-32 bytes), hex-encoded.
+     * CIP-26 spec: {@code minLength: 56, maxLength: 120}.
+     */
+    @Id
+    @EqualsAndHashCode.Include
+    @Column(length = 120)
+    private String subject;
+
+    /**
+     * CIP-26 {@code policy} field: base16 CBOR-encoded phase-1 monetary script (a native script),
+     * <strong>not</strong> the 28-byte policyId hash (that lives in the first 56 hex chars of
+     * {@link #subject}). Clients verify an entry by re-hashing this field through blake2b-224
+     * and comparing to the first 28 bytes of {@code subject}.
+     * <p>
+     * The CIP-26 spec places <strong>no upper bound</strong> on this field — the
+     * {@code cf-tokens-cip26} validator only checks it is valid hex of even length and that
+     * its hash matches the subject's policy prefix. Real registry entries with time-locked
+     * or k-of-n multisig scripts routinely exceed 200 hex characters, and some go much
+     * further:
+     * <ul>
+     *   <li>MCOS (policy {@code 6f46e1304b16d884c85c62fb0eef35028facdc41aaa0fd319a152ed6})
+     *       encodes a time-lock plus 3-of-4 multisig and lands at 216 hex chars.</li>
+     *   <li>Incy sits at 586 hex chars — roughly 5× the old {@code VARCHAR(120)} cap.</li>
+     * </ul>
+     * Under the old {@code VARCHAR(120)} PostgreSQL rejected the {@code INSERT} outright
+     * with {@code "value too long for type character varying(120)"};
+     * {@code Cip26MetadataService#insertMapping} catches that, logs an {@code ERROR} line
+     * naming the subject, and returns {@code false}. The overall sync still reports success,
+     * so operators who don't tail logs or alert on {@code ERROR} counts would not notice the
+     * dropped entries — but the failure is not swallowed silently at the JPA layer. The
+     * column is therefore mapped to {@code TEXT} / unbounded {@code VARCHAR} — do not add a
+     * {@code length} attribute here.
+     *
+     * @see <a href="https://github.com/cardano-foundation/CIPs/blob/main/CIP-0026/README.md">CIP-0026</a>
+     */
+    @Column(columnDefinition = "TEXT")
+    private String policy;
+
+    /** CIP-26 name: max 50 chars (enforced by cf-tokens-cip26 validator). */
+    @Column(length = 50)
+    private String name;
+
+    /** CIP-26 ticker: 2-9 chars (enforced by cf-tokens-cip26 validator). */
+    @Column(length = 9)
+    private String ticker;
+
+    /** CIP-26 url: max 250 chars (enforced by cf-tokens-cip26 validator). */
+    @Column(length = 250)
+    private String url;
+
+    /** CIP-26 description: max 500 chars per spec. */
+    @Column(length = 500)
+    private String description;
+
+    /** CIP-26 decimals: spec range [0, 19] inclusive (well-known property 'decimals'). */
+    private Long decimals;
+
+    /**
+     * CIP-26 logo: base64-encoded image, up to ~87,400 chars per spec. Was a separate
+     * {@code ft_offchain_logo} table previously; merged into this entity in the schema
+     * rename. PostgreSQL TOAST keeps the column off main heap pages so non-logo queries
+     * pay no scan-time cost.
+     */
+    @Column(columnDefinition = "TEXT")
+    private String logo;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updated;
+
+    private String updatedBy;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Mapping properties;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastSyncedAt;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/model/Cip26SyncState.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/model/Cip26SyncState.java
@@ -1,0 +1,53 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cip26_sync_state")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Cip26SyncState {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "last_commit_hash", length = 40, nullable = false)
+    private String lastCommitHash;
+
+    @Column(name = "last_synced_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastSyncedAt;
+
+    /**
+     * ID-based equality with a null-safe check — the id is {@code null} for transient
+     * instances (before the first flush) under {@code GenerationType.IDENTITY}.
+     * {@code instanceof} rather than {@code getClass()} keeps the comparison proxy-safe
+     * for any future lazy-loaded associations.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Cip26SyncState that)) return false;
+        return id != null && id.equals(that.id);
+    }
+
+    /**
+     * Constant hashCode. Required because the id is {@code null} for transient instances
+     * and becomes non-null after flush — a hashCode derived from the id would change
+     * across that transition and break {@code Set}/{@code Map} semantics if the entity is
+     * added to a collection before persistence. See Vlad Mihalcea's "How to implement
+     * equals and hashCode using the JPA entity identifier" for the full rationale.
+     */
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26MetadataRepository.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26MetadataRepository.java
@@ -1,0 +1,10 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface Cip26MetadataRepository extends JpaRepository<Cip26Metadata, String> {
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26SyncStateRepository.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26SyncStateRepository.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26SyncState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Cip26SyncStateRepository extends JpaRepository<Cip26SyncState, Long> {
+    Optional<Cip26SyncState> findTopByOrderByIdDesc();
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Cip26MetadataValidator.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Cip26MetadataValidator.java
@@ -1,0 +1,123 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.metadatatools.core.cip26.MetadataCreator;
+import org.cardanofoundation.metadatatools.core.cip26.ValidationField;
+import org.cardanofoundation.metadatatools.core.cip26.ValidationResult;
+import org.cardanofoundation.metadatatools.core.cip26.model.Metadata;
+import org.cardanofoundation.metadatatools.core.cip26.model.MetadataProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.stream.Collectors;
+
+/**
+ * Validates token metadata fields against the CIP-26 specification using the
+ * <a href="https://github.com/cardano-foundation/cf-token-metadata-registry">cf-tokens-cip26</a> library.
+ */
+@Component
+@Slf4j
+public class Cip26MetadataValidator {
+
+    /**
+     * Validates that all fields in the Cip26Metadata entity comply with CIP-26 specification.
+     *
+     * @param tokenMetadata the token metadata to validate
+     * @return true if valid according to CIP-26, false otherwise
+     */
+    public boolean validate(Cip26Metadata tokenMetadata) {
+        try {
+            Metadata cip26Metadata = convertToMetadata(tokenMetadata);
+            ValidationResult validationResult = MetadataCreator.validateMetadata(cip26Metadata);
+
+            if (!validationResult.isValid()) {
+                String errorMessages = validationResult.getValidationErrors().stream()
+                        .map(error -> error.getField() + ": " + error.getMessage())
+                        .collect(Collectors.joining(", "));
+                log.warn("CIP-26 validation failed for subject '{}': {}",
+                        tokenMetadata.getSubject(), errorMessages);
+                return false;
+            }
+
+            return true;
+
+        } catch (Exception e) {
+            log.error("Error during CIP-26 validation for subject '{}': {}",
+                    tokenMetadata.getSubject(), e.getMessage(), e);
+            return false;
+        }
+    }
+
+    // CIP-26 logo size cap: ~87,400 base64 chars → 65,536 decoded bytes (64 KiB).
+    // The decoded size is what matters; base64 is a 4:3 expansion, so we check the
+    // decoded byte length directly rather than the encoded length.
+    private static final int LOGO_MAX_DECODED_BYTES = 65_536;
+
+    /**
+     * Validates a logo string according to CIP-26 specification.
+     *
+     * <p>Two checks: must be valid base64, and the decoded payload must not exceed
+     * {@value #LOGO_MAX_DECODED_BYTES} bytes. Image format (PNG/SVG/etc.) is
+     * intentionally NOT checked — CIP-26 currently recommends PNG but the spec may
+     * broaden, and our validator should not be stricter than upstream
+     * cf-tokens-cip26 on a format dimension.
+     *
+     * <p>The earlier implementation built a fake {@code Metadata} with {@code "dummy"}
+     * placeholder name/description fields just to bypass the upstream full-record
+     * validator's required-field checks, then post-filtered errors back to LOGO/SUBJECT.
+     * That coupled this method to internal validator quirks (e.g., dummy-name acceptance)
+     * and produced misleading log lines (a SUBJECT error reported under "logo failed").
+     *
+     * @param subject the token subject (for logging)
+     * @param logo    the logo string to validate (can be null)
+     * @return true if valid according to CIP-26, false otherwise
+     */
+    public boolean validateLogo(String subject, String logo) {
+        if (logo == null || logo.isEmpty()) {
+            return true;
+        }
+
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(logo);
+        } catch (IllegalArgumentException e) {
+            log.warn("CIP-26 logo validation failed for subject '{}': not valid base64",
+                    subject);
+            return false;
+        }
+
+        if (decoded.length > LOGO_MAX_DECODED_BYTES) {
+            log.warn("CIP-26 logo validation failed for subject '{}': decoded size {} > {} bytes",
+                    subject, decoded.length, LOGO_MAX_DECODED_BYTES);
+            return false;
+        }
+
+        return true;
+    }
+
+    private Metadata convertToMetadata(Cip26Metadata tokenMetadata) {
+        Metadata metadata = new Metadata();
+
+        if (tokenMetadata.getSubject() != null) {
+            metadata.setSubject(tokenMetadata.getSubject());
+        }
+        if (tokenMetadata.getName() != null) {
+            metadata.addProperty(ValidationField.NAME, new MetadataProperty<>(tokenMetadata.getName()));
+        }
+        if (tokenMetadata.getDescription() != null) {
+            metadata.addProperty(ValidationField.DESCRIPTION, new MetadataProperty<>(tokenMetadata.getDescription()));
+        }
+        if (tokenMetadata.getTicker() != null) {
+            metadata.addProperty(ValidationField.TICKER, new MetadataProperty<>(tokenMetadata.getTicker()));
+        }
+        if (tokenMetadata.getDecimals() != null) {
+            metadata.addProperty(ValidationField.DECIMALS, new MetadataProperty<>(tokenMetadata.getDecimals().intValue()));
+        }
+        if (tokenMetadata.getUrl() != null) {
+            metadata.addProperty(ValidationField.URL, new MetadataProperty<>(tokenMetadata.getUrl()));
+        }
+
+        return metadata;
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Constants.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Constants.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util;
+
+public final class Constants {
+
+    private Constants() {}
+
+    public static final String SYNC_NOT_STARTED = "Sync not started";
+    public static final String SYNC_IN_PROGRESS = "Sync in progress";
+    public static final String SYNC_DONE = "Sync done";
+    public static final String SYNC_ERROR = "Error while syncing";
+    public static final String SYNC_DISABLED = "Sync disabled";
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/MappingsUtil.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/MappingsUtil.java
@@ -1,0 +1,53 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Slf4j
+public final class MappingsUtil {
+
+    private MappingsUtil() {
+    }
+
+    public static Cip26Metadata toCip26Metadata(Mapping mapping, String updateBy, LocalDateTime updatedAt) {
+        Cip26Metadata cip26Metadata = new Cip26Metadata();
+        cip26Metadata.setSubject(mapping.subject());
+        cip26Metadata.setPolicy(mapping.policy());
+        cip26Metadata.setName(getValue(mapping.name()));
+        cip26Metadata.setTicker(getValue(mapping.ticker()));
+        cip26Metadata.setUrl(getValue(mapping.url()));
+        cip26Metadata.setDescription(getValue(mapping.description()));
+        cip26Metadata.setDecimals(getValue(mapping.decimals(), s -> {
+            try {
+                return Long.valueOf(s);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid decimals value '{}' for subject '{}'", s, mapping.subject());
+                return null;
+            }
+        }));
+        cip26Metadata.setUpdated(updatedAt);
+        cip26Metadata.setUpdatedBy(updateBy);
+        cip26Metadata.setProperties(mapping);
+        return cip26Metadata;
+    }
+
+    /** Extract the logo's base64 string from a Mapping, or null if absent. */
+    public static String extractLogo(Mapping mapping) {
+        return getValue(mapping.logo());
+    }
+
+    private static String getValue(Item item) {
+        return getValue(item, Function.identity());
+    }
+
+    private static <T> T getValue(Item item, Function<String, T> f) {
+        return Optional.ofNullable(item).map(Item::value).map(f).orElse(null);
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/AssetType.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/AssetType.java
@@ -1,0 +1,38 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Record/Utility class to group in one place Asset unit, policy and name manipulation and comparison
+ *
+ * @param policyId  the 56-character hex policy ID
+ * @param assetName the hex-encoded asset name (may be empty for policy-only assets)
+ */
+@Slf4j
+public record AssetType(String policyId, String assetName) {
+
+    private static final int POLICY_ID_LENGTH = 56;
+    private static final String LOVELACE = "lovelace";
+    private static final AssetType ADA_ASSET = new AssetType("", LOVELACE);
+
+    public String toUnit() {
+        return policyId + assetName;
+    }
+
+    public static AssetType fromUnit(String unit) {
+        if (unit.equalsIgnoreCase(LOVELACE) || unit.isBlank()) {
+            return ADA_ASSET;
+        }
+
+        String sanitized = unit.replace(".", "");
+        return switch (Integer.compare(sanitized.length(), POLICY_ID_LENGTH)) {
+            case 1  -> new AssetType(sanitized.substring(0, POLICY_ID_LENGTH), sanitized.substring(POLICY_ID_LENGTH));
+            case 0  -> new AssetType(sanitized, "");
+            default -> {
+                log.warn("Invalid unit '{}': must be at least {} hex characters (28-byte policy id)", unit, POLICY_ID_LENGTH);
+                yield new AssetType(sanitized, "");
+            }
+        };
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/Cip68Constants.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/Cip68Constants.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model;
+
+public final class Cip68Constants {
+
+    // Asset name prefixes (hex-encoded CIP-68 labels). The reference NFT (label 100)
+    // is the metadata-holding token; user-facing tokens use one of the other prefixes
+    // depending on type. See https://cips.cardano.org/cip/CIP-68/.
+    public static final String REFERENCE_TOKEN_PREFIX     = "000643b0";  // label 100 — reference NFT (metadata holder)
+    public static final String NFT_TOKEN_PREFIX           = "000de140";  // label 222 — non-fungible
+    public static final String FUNGIBLE_TOKEN_PREFIX      = "0014df10";  // label 333 — fungible
+    public static final String RICH_FUNGIBLE_TOKEN_PREFIX = "001bc280";  // label 444 — rich fungible (RFT)
+
+    // CIP-68 label values written to cip68_metadata.label by Cip68Processor based on
+    // cross-output detection of the co-minted user-token prefix.
+    public static final int LABEL_NFT = 222;
+    public static final int LABEL_FT  = 333;
+    public static final int LABEL_RFT = 444;
+
+    private Cip68Constants() {
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/FungibleTokenMetadata.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/FungibleTokenMetadata.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+
+@Schema(description = "CIP-68 fungible token metadata parsed from a reference NFT inline datum (label 333).")
+public record FungibleTokenMetadata(
+        @Nullable @Schema(description = "Number of decimal places.") Long decimals,
+        @Nullable @Schema(description = "Token description.") String description,
+        @Nullable @Schema(description = "Base64-encoded PNG logo.") String logo,
+        @Nullable @Schema(description = "Human-readable token name.") String name,
+        @Nullable @Schema(description = "Token ticker symbol.") String ticker,
+        @Nullable @Schema(description = "Project URL.") String url,
+        @Nullable @Schema(description = "CIP-68 metadata version.") Long version
+) {}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/ParsedCip68Datum.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/ParsedCip68Datum.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Map;
+
+/**
+ * Internal representation of a parsed CIP-68 inline datum.
+ * <p>
+ * Richer than {@link FungibleTokenMetadata} (the public DTO the API surfaces for FTs) —
+ * carries the additional fields that NFT and RFT datums populate (image, mediaType, files,
+ * arbitrary collection-specific properties). The parser produces this; the processor uses
+ * it to populate the {@code cip68_metadata} row, including {@code image}, {@code media_type},
+ * and the {@code properties} JSONB column.
+ * <p>
+ * The {@link #properties} map's documented shape is:
+ * <pre>{@code
+ * {
+ *   "files": [{"name": "...", "mediaType": "...", "src": "..."}, ...],
+ *   "additional_properties": { ...arbitrary collection-specific keys... }
+ * }
+ * }</pre>
+ * Either key may be absent. The {@link #properties} field as a whole may be {@code null}
+ * if the datum has no files and no additional properties beyond the well-known scalars.
+ */
+public record ParsedCip68Datum(
+        @Nullable Long decimals,
+        @Nullable String description,
+        @Nullable String logo,
+        @Nullable String name,
+        @Nullable String ticker,
+        @Nullable String url,
+        Long version,
+        @Nullable String image,
+        @Nullable String mediaType,
+        @Nullable Map<String, Object> properties
+) {
+    /**
+     * Project to the FT-shape DTO for read-path consumers (the API today only surfaces
+     * FT data; NFT-specific fields are stored but not yet exposed).
+     */
+    public FungibleTokenMetadata toFungibleTokenMetadata() {
+        return new FungibleTokenMetadata(decimals, description, logo, name, ticker, url, version);
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/parser/Cip68DatumParser.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/parser/Cip68DatumParser.java
@@ -1,0 +1,248 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.parser;
+
+import com.bloxbean.cardano.client.plutus.spec.*;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class Cip68DatumParser {
+
+    // Well-known CIP-68 keys that map to typed columns on cip68_metadata.
+    public static final String DECIMALS    = "decimals";
+    public static final String DESCRIPTION = "description";
+    public static final String LOGO        = "logo";
+    public static final String NAME        = "name";
+    public static final String TICKER      = "ticker";
+    public static final String URL         = "url";
+    public static final String IMAGE       = "image";
+    public static final String MEDIA_TYPE  = "mediaType";
+    public static final String FILES       = "files";
+
+    /** Set of keys we promote to typed columns; everything else goes into the JSONB additional_properties. */
+    private static final Set<String> TYPED_KEYS = Set.of(
+            DECIMALS, DESCRIPTION, LOGO, NAME, TICKER, URL, IMAGE, MEDIA_TYPE, FILES);
+
+    /**
+     * Parse a CIP-68 reference NFT inline datum into the richer {@link ParsedCip68Datum}.
+     * <p>
+     * Extracts the FT-shape scalars (name, description, ticker, decimals, url, logo, version)
+     * AND the NFT-shape scalars (image, mediaType), AND the variable-shape parts (files[],
+     * arbitrary additional properties) into the JSONB-bound {@code properties} map.
+     */
+    public Optional<ParsedCip68Datum> parse(String inlineDatum) {
+        if (inlineDatum == null || inlineDatum.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            return extractDatumProperties(inlineDatum)
+                    .map(parts -> buildParsedDatum(parts.properties(), parts.version()));
+        } catch (Exception e) {
+            log.warn("Unexpected error while parsing CIP-68 datum: {}", inlineDatum, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Strip the CIP-68 datum envelope: a Constr containing a {@code (Map, BigInt)} pair
+     * (the metadata properties map and the version integer). Returns empty for any datum
+     * that doesn't fit this shape.
+     */
+    private Optional<DatumParts> extractDatumProperties(String inlineDatum) throws com.bloxbean.cardano.client.exception.CborDeserializationException {
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString(inlineDatum));
+
+        if (!(plutusData instanceof ConstrPlutusData cip68Data)) {
+            return Optional.empty();
+        }
+
+        List<PlutusData> dataList = cip68Data.getData().getPlutusDataList();
+        if (dataList.size() < 2 || !(dataList.getFirst() instanceof MapPlutusData properties)) {
+            return Optional.empty();
+        }
+
+        if (!(dataList.get(1) instanceof BigIntPlutusData version)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new DatumParts(properties, version));
+    }
+
+    /** Build the typed {@link ParsedCip68Datum} from the unwrapped (Map, version) pair. */
+    private ParsedCip68Datum buildParsedDatum(MapPlutusData properties, BigIntPlutusData version) {
+        return new ParsedCip68Datum(
+                getNumericProperty(DECIMALS, properties).orElse(null),
+                getStringProperty(DESCRIPTION, properties).orElse(null),
+                getStringProperty(LOGO, properties).orElse(null),
+                getStringProperty(NAME, properties).orElse(null),
+                getStringProperty(TICKER, properties).orElse(null),
+                getStringProperty(URL, properties).orElse(null),
+                version.getValue().longValue(),
+                getStringOrChunkedProperty(IMAGE, properties).orElse(null),
+                getStringProperty(MEDIA_TYPE, properties).orElse(null),
+                buildPropertiesJson(properties));
+    }
+
+    /**
+     * Combine {@code files[]} and any non-well-known keys into the single JSONB-backed
+     * {@code properties} column. Returns {@code null} if neither part is populated, so
+     * pure FT rows don't materialise an empty wrapper.
+     */
+    private Map<String, Object> buildPropertiesJson(MapPlutusData properties) {
+        List<Map<String, Object>> files = parseFiles(properties);
+        Map<String, Object> additional = parseAdditionalProperties(properties);
+
+        boolean hasFiles = files != null && !files.isEmpty();
+        boolean hasAdditional = additional != null && !additional.isEmpty();
+        if (!hasFiles && !hasAdditional) {
+            return null;
+        }
+
+        Map<String, Object> json = new LinkedHashMap<>();
+        if (hasFiles) {
+            json.put(FILES, files);
+        }
+        if (hasAdditional) {
+            json.put("additional_properties", additional);
+        }
+        return json;
+    }
+
+    /** Internal record for the unwrapped CIP-68 envelope ((properties Map, version BigInt)). */
+    private record DatumParts(MapPlutusData properties, BigIntPlutusData version) {}
+
+    private Optional<String> getStringProperty(String propertyName, MapPlutusData mapPlutusData) {
+        PlutusData property = mapPlutusData.getMap().get(BytesPlutusData.of(propertyName));
+        return switch (property) {
+            case BytesPlutusData bytes -> Optional.of(bytesToString(bytes.getValue()));
+            case null, default -> Optional.empty();
+        };
+    }
+
+    /**
+     * CIP-25 convention (inherited by CIP-68 NFTs): if a string value exceeds 64 bytes
+     * the issuer may split it into a list of byte-string chunks. This helper joins them
+     * back together. Falls back to {@link #getStringProperty} for the simple-string case.
+     */
+    private Optional<String> getStringOrChunkedProperty(String propertyName, MapPlutusData mapPlutusData) {
+        PlutusData property = mapPlutusData.getMap().get(BytesPlutusData.of(propertyName));
+        return switch (property) {
+            case BytesPlutusData bytes -> Optional.of(bytesToString(bytes.getValue()));
+            case ListPlutusData list -> {
+                StringBuilder sb = new StringBuilder();
+                for (PlutusData chunk : list.getPlutusDataList()) {
+                    if (chunk instanceof BytesPlutusData b) {
+                        sb.append(bytesToString(b.getValue()));
+                    }
+                }
+                yield sb.isEmpty() ? Optional.empty() : Optional.of(sb.toString());
+            }
+            case null, default -> Optional.empty();
+        };
+    }
+
+    private Optional<Long> getNumericProperty(String propertyName, MapPlutusData mapPlutusData) {
+        PlutusData property = mapPlutusData.getMap().get(BytesPlutusData.of(propertyName));
+        return switch (property) {
+            case BigIntPlutusData bigInt -> Optional.of(bigInt.getValue().longValue());
+            case null, default -> Optional.empty();
+        };
+    }
+
+    /**
+     * Walk the {@code files} key (if present) and return a list of file descriptors.
+     * Each element is a {@code Map<String, Object>} with keys {@code name}, {@code mediaType},
+     * {@code src} where present. Unknown keys inside a file entry are preserved verbatim.
+     */
+    private List<Map<String, Object>> parseFiles(MapPlutusData properties) {
+        PlutusData filesProp = properties.getMap().get(BytesPlutusData.of(FILES));
+        if (!(filesProp instanceof ListPlutusData filesList)) {
+            return null;
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (PlutusData item : filesList.getPlutusDataList()) {
+            if (!(item instanceof MapPlutusData fileMap)) {
+                continue;
+            }
+            Map<String, Object> file = new LinkedHashMap<>();
+            for (Map.Entry<PlutusData, PlutusData> e : fileMap.getMap().entrySet()) {
+                if (!(e.getKey() instanceof BytesPlutusData keyBytes)) {
+                    continue;
+                }
+                String key = bytesToString(keyBytes.getValue());
+                Object value = unwrapPlutusValue(e.getValue());
+                if (value != null) {
+                    file.put(key, value);
+                }
+            }
+            if (!file.isEmpty()) {
+                result.add(file);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Collect every key in the metadata map that isn't one of the well-known typed scalars
+     * or {@code files}. These project-specific properties (attributes, traits, royalties...)
+     * go into {@code properties.additional_properties} for downstream consumers.
+     */
+    private Map<String, Object> parseAdditionalProperties(MapPlutusData properties) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        properties.getMap().entrySet().stream()
+                .filter(e -> e.getKey() instanceof BytesPlutusData)
+                .map(e -> Map.entry(
+                        bytesToString(((BytesPlutusData) e.getKey()).getValue()),
+                        unwrapPlutusValue(e.getValue())))
+                .filter(e -> !TYPED_KEYS.contains(e.getKey()) && e.getValue() != null)
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+        return result;
+    }
+
+    /**
+     * Unwrap a Plutus value into a Java type suitable for JSONB serialization. Recurses
+     * into maps and lists. Bytes become strings (UTF-8 with null bytes stripped); ints
+     * become Long; constructors are flattened to their field list with the alt index.
+     */
+    private Object unwrapPlutusValue(PlutusData data) {
+        return switch (data) {
+            case BytesPlutusData b   -> bytesToString(b.getValue());
+            case BigIntPlutusData i  -> i.getValue();
+            case ListPlutusData list -> {
+                List<Object> items = new ArrayList<>();
+                for (PlutusData inner : list.getPlutusDataList()) {
+                    Object u = unwrapPlutusValue(inner);
+                    if (u != null) items.add(u);
+                }
+                yield items;
+            }
+            case MapPlutusData map -> {
+                Map<String, Object> out = new LinkedHashMap<>();
+                for (Map.Entry<PlutusData, PlutusData> entry : map.getMap().entrySet()) {
+                    if (!(entry.getKey() instanceof BytesPlutusData kb)) continue;
+                    Object u = unwrapPlutusValue(entry.getValue());
+                    if (u != null) out.put(bytesToString(kb.getValue()), u);
+                }
+                yield out;
+            }
+            case null -> null;
+            default -> null;
+        };
+    }
+
+    private static String bytesToString(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8).replace("\0", "");
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68Processor.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68Processor.java
@@ -1,0 +1,159 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.processor;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.Cip68Constants;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.parser.Cip68DatumParser;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service.Cip68TokenService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository.Cip68MetadataRepository;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressUtxoEvent;
+import com.bloxbean.cardano.yaci.store.utxo.domain.TxInputOutput;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "store.assets.ext.cip68.enabled", havingValue = "true", matchIfMissing = true)
+public class Cip68Processor {
+
+    private final Cip68TokenService cip68TokenService;
+    private final Cip68DatumParser cip68DatumParser;
+    private final Cip68MetadataRepository cip68MetadataRepository;
+
+    @EventListener
+    @Transactional
+    public void processTransaction(AddressUtxoEvent addressUtxoEvent) {
+        Long slot = addressUtxoEvent.getMetadata().getSlot();
+
+        // Iterate per-transaction so we keep the transaction's full output set in context.
+        // Label classification needs to look at the OTHER outputs in the same tx to find
+        // the co-minted user token (000de140 / 0014df10 / 001bc280); a flat-map across
+        // all txs would lose that boundary.
+        List<Cip68Metadata> entities = new ArrayList<>();
+        for (TxInputOutput txIo : addressUtxoEvent.getTxInputOutputs()) {
+            Set<String> coMintedPrefixesInTx = collectCoMintedPrefixes(txIo);
+
+            for (AddressUtxo output : txIo.getOutputs()) {
+                cip68TokenService.extractReferenceNft(output).ifPresent(refNftAmt -> {
+                    cip68DatumParser.parse(output.getInlineDatum()).ifPresent(parsed -> {
+                        if (!cip68TokenService.isValidMetadata(parsed)) {
+                            return;
+                        }
+                        AssetType refNftAssetType = AssetType.fromUnit(refNftAmt.getUnit());
+                        int label = deriveLabel(refNftAssetType, coMintedPrefixesInTx);
+                        entities.add(buildCip68Metadata(
+                                parsed, refNftAssetType, output.getInlineDatum(), slot,
+                                output.getTxHash(), output.getTxIndex(), label));
+                    });
+                });
+            }
+        }
+
+        if (!entities.isEmpty()) {
+            cip68MetadataRepository.saveAll(entities);
+        }
+    }
+
+    /**
+     * Determine the CIP-68 user-token label by looking at the co-minted user token
+     * present in the same transaction. CIP-68 always co-mints the reference NFT (label 100)
+     * with one of the user-token prefixes — this method picks which one.
+     * <p>
+     * If no co-minted user token is found at the same policy ID with a recognised CIP-68
+     * prefix, falls back to {@link Cip68Constants#LABEL_FT}. This matches the prior
+     * default-to-FT behaviour for orphan reference NFTs and odd one-off mints that don't
+     * follow the standard pattern.
+     */
+    private int deriveLabel(AssetType refNftAssetType, Set<String> coMintedPrefixes) {
+        if (coMintedPrefixes.contains(Cip68Constants.NFT_TOKEN_PREFIX)) {
+            return Cip68Constants.LABEL_NFT;
+        }
+        if (coMintedPrefixes.contains(Cip68Constants.FUNGIBLE_TOKEN_PREFIX)) {
+            return Cip68Constants.LABEL_FT;
+        }
+        if (coMintedPrefixes.contains(Cip68Constants.RICH_FUNGIBLE_TOKEN_PREFIX)) {
+            return Cip68Constants.LABEL_RFT;
+        }
+        // Orphan reference NFT (no co-minted user token in this tx) or non-standard mint.
+        // Default to FT — the historical behaviour and the most common case in practice.
+        log.debug("No CIP-68 user-token prefix co-minted with reference NFT {}/{}; defaulting label to FT (333)",
+                refNftAssetType.policyId(), refNftAssetType.assetName());
+        return Cip68Constants.LABEL_FT;
+    }
+
+    /**
+     * Walk the transaction's full output set and collect every CIP-68 user-token prefix
+     * (000de140 / 0014df10 / 001bc280) appearing at any policy ID. We only need the
+     * SET of prefixes, not which policy they belong to, because in practice CIP-68
+     * mints are 1:1 — one reference NFT + one user token at the same base name. The
+     * presence of an NFT-prefix token anywhere in the tx is a reliable signal that
+     * the ref NFT was minted alongside an NFT, not a FT.
+     */
+    private Set<String> collectCoMintedPrefixes(TxInputOutput txIo) {
+        return txIo.getOutputs().stream()
+                .flatMap(o -> o.getAmounts().stream())
+                .map(this::extractCip68UserTokenPrefix)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    /** Returns the 4-byte CIP-68 user-token prefix if the asset matches one, else null. */
+    private String extractCip68UserTokenPrefix(Amt amt) {
+        AssetType at = AssetType.fromUnit(amt.getUnit());
+        String assetName = at.assetName();
+        if (assetName == null || assetName.length() < 8) {
+            return null;
+        }
+        String prefix = assetName.substring(0, 8);
+        if (Cip68Constants.NFT_TOKEN_PREFIX.equals(prefix)
+                || Cip68Constants.FUNGIBLE_TOKEN_PREFIX.equals(prefix)
+                || Cip68Constants.RICH_FUNGIBLE_TOKEN_PREFIX.equals(prefix)) {
+            return prefix;
+        }
+        return null;
+    }
+
+    private Cip68Metadata buildCip68Metadata(ParsedCip68Datum parsed,
+                                             AssetType assetType,
+                                             String datum,
+                                             Long slot,
+                                             String txHash,
+                                             Integer txIndex,
+                                             int label) {
+        return Cip68Metadata.builder()
+                .policyId(assetType.policyId())
+                .assetName(assetType.assetName())
+                .slot(slot)
+                .txHash(txHash)
+                .txIndex(txIndex)
+                .label(label)
+                .name(parsed.name())
+                .description(parsed.description())
+                .ticker(parsed.ticker())
+                .url(parsed.url())
+                .decimals(parsed.decimals())
+                .logo(parsed.logo())
+                .image(parsed.image())
+                .mediaType(parsed.mediaType())
+                .version(parsed.version())
+                .datum(datum)
+                .properties(parsed.properties())
+                .lastSyncedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68RollbackProcessor.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68RollbackProcessor.java
@@ -1,0 +1,28 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.processor;
+
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository.Cip68MetadataRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "store.assets.ext.cip68.enabled", havingValue = "true", matchIfMissing = true)
+public class Cip68RollbackProcessor {
+
+    private final Cip68MetadataRepository metadataReferenceNftRepository;
+
+    @EventListener
+    @Transactional
+    public void handleRollback(RollbackEvent rollbackEvent) {
+        long rollbackSlot = rollbackEvent.getRollbackTo().getSlot();
+        int count = metadataReferenceNftRepository.deleteBySlotGreaterThan(rollbackSlot);
+        log.info("CIP-68 rollback to slot {}: deleted {} reference NFT records", rollbackSlot, count);
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/service/Cip68TokenService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/service/Cip68TokenService.java
@@ -1,0 +1,171 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.parser.Cip68DatumParser;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository.Cip68MetadataRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import jakarta.annotation.Nullable;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.Cip68Constants.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Cip68TokenService {
+
+    private static final String VERSION = "version";
+
+    private final Cip68MetadataRepository metadataReferenceNftRepository;
+
+    /**
+     * Validate a CIP-68 datum. Per spec, name and description are the required fields
+     * for any of the user-token labels (222 NFT / 333 FT / 444 RFT).
+     *
+     * @return true if the metadata satisfies CIP-68's required-field constraint
+     */
+    public boolean isValidMetadata(ParsedCip68Datum parsed) {
+        return parsed.name() != null && parsed.description() != null;
+    }
+
+    /**
+     * Checks whether the utxo contains an NFT which matches Cip68 Reference NFT requirements
+     *
+     * @param utxo the utxo to check
+     * @return true if any of the utxo's contains a Cip68 Reference NFT
+     */
+    public boolean containsReferenceNft(AddressUtxo utxo) {
+        return utxo.getAmounts().stream().anyMatch(this::isReferenceNft);
+    }
+
+    /**
+     * Checks and returns an NFT which matches Cip68 Reference NFT requirements if present
+     *
+     * @param utxo the utxo to check
+     * @return the amt matching the Reference NFT if found
+     */
+    public Optional<Amt> extractReferenceNft(AddressUtxo utxo) {
+        return utxo.getAmounts().stream().filter(this::isReferenceNft).findFirst();
+    }
+
+    /**
+     * Check if the amount matches Cip68 Reference NFT Requirements
+     *
+     * @param amount the amount to check
+     * @return true if the amount is a Cip68 Reference NFT
+     */
+    public boolean isReferenceNft(Amt amount) {
+        return amount.getQuantity().equals(BigInteger.ONE)
+                && AssetType.fromUnit(amount.getUnit()).assetName().startsWith(REFERENCE_TOKEN_PREFIX);
+    }
+
+    /**
+     * Find the latest reference-NFT metadata for the given {@code (policyId, assetName)} pair
+     * and project it into a {@link FungibleTokenMetadata}.
+     * <p>
+     * No label filter is applied: a single reference NFT may have rows tagged with different
+     * labels across its history (the per-row label reflects whichever user-token prefix was
+     * co-minted in that transaction), so the truthful latest metadata is "max slot for this
+     * reference NFT, regardless of label" — see
+     * {@link Cip68MetadataRepository#findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc}.
+     */
+    public Optional<FungibleTokenMetadata> findSubject(String policyId, String assetName, List<String> properties) {
+        return metadataReferenceNftRepository.findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc(
+                        policyId, assetName)
+                .map(referenceNft -> toFungibleTokenMetadata(referenceNft, properties));
+    }
+
+    /**
+     * Batch variant of {@link #findSubject(String, String, List)}: fetches the latest FT metadata
+     * for every given {@code (policyId, assetName)} pair in a single DB round-trip.
+     * <p>
+     * The input {@code assetName} values are <b>reference NFT</b> asset names (prefix {@code 000643b0}),
+     * not fungible token asset names. Callers should use
+     * {@link #getReferenceNftSubject(String)} first to map fungible-token subjects to reference-NFT keys.
+     * <p>
+     * The returned map is keyed by reference-NFT subject ({@code policyId + assetName}) — mirroring the
+     * input key shape — so callers can do O(1) lookups without rebuilding keys.
+     *
+     * @param refNftKeys reference-NFT asset-type pairs (policyId + ref-NFT asset name)
+     * @param properties property filter (empty list = include all)
+     * @return map keyed by reference-NFT subject; pairs with no data are omitted
+     */
+    public Map<String, FungibleTokenMetadata> findSubjects(List<AssetType> refNftKeys, List<String> properties) {
+        if (refNftKeys.isEmpty()) {
+            return Map.of();
+        }
+
+        List<String> concatenatedKeys = refNftKeys.stream()
+                .map(AssetType::toUnit)
+                .toList();
+
+        return metadataReferenceNftRepository.findLatestByConcatenatedKeys(concatenatedKeys).stream()
+                .collect(Collectors.toMap(
+                        row -> row.getPolicyId() + row.getAssetName(),
+                        row -> toFungibleTokenMetadata(row, properties)));
+    }
+
+    private FungibleTokenMetadata toFungibleTokenMetadata(Cip68Metadata referenceNft, List<String> properties) {
+        return new FungibleTokenMetadata(
+                getPropertyIfRequired(Cip68DatumParser.DECIMALS, referenceNft.getDecimals(), properties),
+                getPropertyIfRequired(Cip68DatumParser.DESCRIPTION, referenceNft.getDescription(), properties),
+                getPropertyIfRequired(Cip68DatumParser.LOGO, referenceNft.getLogo(), properties),
+                getPropertyIfRequired(Cip68DatumParser.NAME, referenceNft.getName(), properties),
+                getPropertyIfRequired(Cip68DatumParser.TICKER, referenceNft.getTicker(), properties),
+                getPropertyIfRequired(Cip68DatumParser.URL, referenceNft.getUrl(), properties),
+                getPropertyIfRequired(VERSION, referenceNft.getVersion(), properties));
+    }
+
+    @Nullable
+    private <T> T getPropertyIfRequired(String propertyName, T propertyValue, List<String> properties) {
+        if (properties.isEmpty() || properties.contains(propertyName)) {
+            return propertyValue;
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts a fungible token subject to its corresponding reference NFT subject.
+     * <p>
+     * CIP-68 stores metadata in a <b>reference NFT</b> (label 100, prefix {@code 000643b0}),
+     * not in the fungible token itself (label 333, prefix {@code 0014df10}). Both tokens are
+     * minted together under the same policy with the same base name — only the 8-char label
+     * prefix differs.
+     * <p>
+     * When a user queries by the fungible token subject they see in their wallet
+     * (e.g. {@code <policyId>0014df10<name>}), this method swaps the prefix to produce the
+     * reference NFT subject ({@code <policyId>000643b0<name>}) that the database stores.
+     * <p>
+     * Returns empty if the subject does not have a fungible token prefix ({@code 0014df10}),
+     * indicating the subject is not a CIP-68 fungible token.
+     *
+     * @param subject the fungible token unit (policyId + 0014df10 + hex name)
+     * @return the reference NFT AssetType if the subject has a fungible token prefix, empty otherwise
+     */
+    public Optional<AssetType> getReferenceNftSubject(String subject) {
+        AssetType assetType = AssetType.fromUnit(subject);
+        String assetName = assetType.assetName();
+        int tokenPrefixLength = REFERENCE_TOKEN_PREFIX.length();
+
+        if (assetName.length() > tokenPrefixLength && assetName.startsWith(FUNGIBLE_TOKEN_PREFIX)) {
+            String refNftAssetName = String.format("%s%s", REFERENCE_TOKEN_PREFIX, assetType.assetName().substring(tokenPrefixLength));
+            return Optional.of(new AssetType(assetType.policyId(), refNftAssetName));
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/Cip68StorageReader.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/Cip68StorageReader.java
@@ -1,0 +1,46 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Read-only access to CIP-68 on-chain fungible token metadata.
+ * All queries are scoped to fungible tokens (label 333).
+ */
+public interface Cip68StorageReader {
+
+    /**
+     * Find the latest CIP-68 fungible token metadata by policy ID and asset name.
+     */
+    Optional<FungibleTokenMetadata> findByPolicyIdAndAssetName(String policyId, String assetName);
+
+    /**
+     * Find the latest CIP-68 fungible token metadata for a subject.
+     * Automatically converts the fungible token prefix to reference NFT prefix.
+     */
+    Optional<FungibleTokenMetadata> findBySubject(String subject);
+
+    /**
+     * Find the latest CIP-68 fungible token metadata for a subject with property filtering.
+     */
+    Optional<FungibleTokenMetadata> findBySubject(String subject, List<String> properties);
+
+    /**
+     * Batch lookup of CIP-68 fungible token metadata for multiple subjects.
+     * Performs the fungible-to-reference-NFT prefix conversion internally
+     * ({@code 0014df10} → {@code 000643b0}) and issues a single DB query.
+     * <p>
+     * The returned map is keyed by the <b>original fungible token subject</b>
+     * (the string passed in by the caller), not the reference NFT subject —
+     * the prefix conversion is an internal detail. Subjects that do not match
+     * a CIP-68 fungible token prefix are silently skipped.
+     *
+     * @param subjects   fungible-token subjects (policyId + {@code 0014df10} + hex name)
+     * @param properties property filter (empty list = include all properties)
+     * @return map keyed by the original fungible subject; subjects with no metadata are omitted
+     */
+    Map<String, FungibleTokenMetadata> findBySubjects(List<String> subjects, List<String> properties);
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/Cip68StorageReaderImpl.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/Cip68StorageReaderImpl.java
@@ -1,0 +1,75 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service.Cip68TokenService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fungible-token-facing implementation of {@link Cip68StorageReader}.
+ * <p>
+ * The {@code cip68_metadata} table stores rows for label 222 / 333 / 444; this reader
+ * filters to label 333 (FT) only — the public API surface today is FT-focused. NFT/RFT
+ * rows in the same table are dormant data, future-proofed for a later release that
+ * adds NFT/RFT-specific service methods and DTOs.
+ */
+@RequiredArgsConstructor
+public class Cip68StorageReaderImpl implements Cip68StorageReader {
+
+    private final Cip68TokenService cip68TokenService;
+
+    @Override
+    public Optional<FungibleTokenMetadata> findByPolicyIdAndAssetName(String policyId, String assetName) {
+        return cip68TokenService.findSubject(policyId, assetName, List.of());
+    }
+
+    @Override
+    public Optional<FungibleTokenMetadata> findBySubject(String subject) {
+        return findBySubject(subject, List.of());
+    }
+
+    @Override
+    public Optional<FungibleTokenMetadata> findBySubject(String subject, List<String> properties) {
+        return cip68TokenService.getReferenceNftSubject(subject)
+                .flatMap(assetType -> cip68TokenService.findSubject(
+                        assetType.policyId(), assetType.assetName(), properties));
+    }
+
+    @Override
+    public Map<String, FungibleTokenMetadata> findBySubjects(List<String> subjects, List<String> properties) {
+        if (subjects.isEmpty()) {
+            return Map.of();
+        }
+
+        // Convert each fungible subject to its reference NFT key and remember the mapping back,
+        // so the result can be keyed by the original fungible subject.
+        List<AssetType> refNftKeys = new ArrayList<>(subjects.size());
+        Map<String, String> fungibleSubjectByRefNftSubject = new HashMap<>(subjects.size());
+        for (String subject : subjects) {
+            cip68TokenService.getReferenceNftSubject(subject).ifPresent(refNftKey -> {
+                refNftKeys.add(refNftKey);
+                fungibleSubjectByRefNftSubject.put(refNftKey.toUnit(), subject);
+            });
+        }
+
+        if (refNftKeys.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, FungibleTokenMetadata> byRefNftSubject = cip68TokenService.findSubjects(refNftKeys, properties);
+
+        // Re-key the result by the original fungible subject so the caller doesn't need to
+        // know about the prefix conversion.
+        Map<String, FungibleTokenMetadata> result = new HashMap<>(byRefNftSubject.size());
+        byRefNftSubject.forEach((refNftSubject, metadata) ->
+                Optional.ofNullable(fungibleSubjectByRefNftSubject.get(refNftSubject))
+                        .ifPresent(fungibleSubject -> result.put(fungibleSubject, metadata)));
+        return result;
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/model/Cip68Metadata.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/model/Cip68Metadata.java
@@ -1,0 +1,133 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "cip68_metadata")
+@IdClass(Cip68MetadataId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+// Business-key equals/hashCode: all four PK components are app-assigned and non-null at
+// construction, so they're stable across the transient → managed → detached lifecycle.
+// Lombok's generated equals uses `instanceof` (proxy-safe for lazy-loaded associations).
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Cip68Metadata {
+
+    /** Policy id: exactly 28 bytes = 56 hex chars (Blake2b-224). Protocol-bounded. */
+    @Id
+    @Column(name = "policy_id", length = 56, nullable = false)
+    @EqualsAndHashCode.Include
+    private String policyId;
+
+    /**
+     * Asset name: 0–32 bytes = 0–64 hex chars (Cardano ledger max). Protocol-bounded.
+     * Includes the CIP-68 user-token label prefix (000de140 NFT / 0014df10 FT / 001bc280 RFT)
+     * so the table's primary key matches the user-facing on-chain subject.
+     */
+    @Id
+    @Column(name = "asset_name", length = 64, nullable = false)
+    @EqualsAndHashCode.Include
+    private String assetName;
+
+    @Id
+    @Column(nullable = false)
+    @EqualsAndHashCode.Include
+    private Long slot;
+
+    /**
+     * Transaction hash of the reference-NFT output this row was indexed from. Part of the
+     * primary key — tx identity is what makes each update a distinct row, so the table keeps
+     * full history rather than overwriting in place. Matches the rest of yaci-store, where
+     * on-chain history tables key on {@code tx_hash} (stake_registration, governance, etc.).
+     */
+    @Id
+    @Column(name = "tx_hash", length = 64, nullable = false)
+    @EqualsAndHashCode.Include
+    private String txHash;
+
+    /**
+     * Index of the producing transaction within its block. Not part of the primary key; kept as
+     * an ordering column so the latest row is resolved deterministically by
+     * {@code ORDER BY slot DESC, tx_index DESC} (disambiguating same-slot intra-block updates).
+     */
+    @Column(name = "tx_index", nullable = false)
+    private Integer txIndex;
+
+    /**
+     * CIP-68 label: 222 (NFT), 333 (FT), 444 (RFT). Set by Cip68Processor based on the
+     * co-minted user-token prefix observed in the same transaction's outputs.
+     */
+    @Column(nullable = false)
+    private Integer label;
+
+    /** CIP-68 metadata 'name': variable UTF-8 string from the datum. */
+    @Column(length = 255)
+    private String name;
+
+    /** CIP-68 'description': arbitrary multi-sentence text; stored as TEXT. */
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    /** CIP-68 'ticker': short symbol (typically only label 333/444). */
+    @Column(length = 32)
+    private String ticker;
+
+    /** CIP-68 'url': aligns with CIP-26 url cap of 250 chars. */
+    @Column(length = 250)
+    private String url;
+
+    /** CIP-68 'decimals': unsigned integer from the datum. In practice 0–19 per CIP-26 convention.
+     *  Long to match the {@code BIGINT} column and the rest of the pipeline (ParsedCip68Datum,
+     *  FungibleTokenMetadata, LongProperty) — uniform type avoids boundary conversions. */
+    private Long decimals;
+
+    /** CIP-68 logo: base64-encoded image (mostly label 333 FTs). Loaded eagerly: lazy
+     *  basic-field fetch requires Hibernate bytecode enhancement, which this build does
+     *  not configure. Add the {@code org.hibernate.orm} gradle plugin if eager loading
+     *  of this column ever becomes a hotspot. */
+    @Column(columnDefinition = "TEXT")
+    private String logo;
+
+    /**
+     * CIP-68 NFT 'image': IPFS URI / data: URL / https URL (mostly label 222/444).
+     * Distinct from {@link #logo}, which is base64-inline. NFTs typically use {@code image}
+     * (a reference) while FTs typically use {@code logo} (inlined base64).
+     */
+    @Column(columnDefinition = "TEXT")
+    private String image;
+
+    /** CIP-68 NFT 'mediaType': MIME type of the image (e.g. image/png). */
+    @Column(name = "media_type", length = 255)
+    private String mediaType;
+
+    @Column(nullable = false)
+    private Long version;
+
+    /** Full CBOR hex of the inline datum. Variable length; kept for re-parsing/auditing.
+     *  Loaded eagerly — see {@link #logo} for the rationale (no bytecode enhancement
+     *  configured). This column is the largest per-row payload (typically 1–10 KB);
+     *  enabling lazy fetch project-wide would be the highest-impact perf change. */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String datum;
+
+    /**
+     * Catch-all JSONB. Holds the parsed datum's non-scalar bits — array of files
+     * ({@code [{name, mediaType, src}, ...]}) and arbitrary collection-specific properties
+     * (attributes, royalties, custom traits) that don't map to a typed column.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> properties;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastSyncedAt;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/model/Cip68MetadataId.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/model/Cip68MetadataId.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+public class Cip68MetadataId {
+
+    private String policyId;
+    private String assetName;
+    private Long slot;
+    private String txHash;
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/repository/Cip68MetadataRepository.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/storage/impl/repository/Cip68MetadataRepository.java
@@ -1,0 +1,64 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68MetadataId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface Cip68MetadataRepository extends JpaRepository<Cip68Metadata, Cip68MetadataId> {
+
+    /**
+     * Returns the latest row for a given {@code (policy_id, asset_name)} reference NFT,
+     * regardless of label.
+     * <p>
+     * The cross-output classifier in {@code Cip68Processor} tags each reference-NFT update row
+     * with the co-minted user-token label observed in that transaction. A single reference NFT
+     * therefore accumulates rows under multiple labels over its lifetime (e.g. an FT whose
+     * later updates happened to be co-minted alongside a 222-prefixed NFT will have its newest
+     * row stored under label 222). Filtering by label here would silently return stale metadata.
+     */
+    Optional<Cip68Metadata> findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc(
+            String policyId, String assetName);
+
+    /**
+     * Returns the latest reference NFT row per {@code (policy_id, asset_name)} pair, regardless of label.
+     * Replaces the N+1 per-subject query pattern with a single round-trip.
+     * <p>
+     * Callers pass a list of {@code policy_id || asset_name} concatenated keys. Since policy IDs are
+     * always exactly 56 hex characters, the concatenation is unambiguous — the DB can split the key
+     * back if needed, though this method matches directly against the concatenated form.
+     * <p>
+     * Uses {@code ROW_NUMBER() OVER} window function for per-pair dedup. Portable across
+     * PostgreSQL, H2, and MySQL 8+.
+     * <p>
+     * No label filter — see {@link #findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc} for why.
+     *
+     * @param concatenatedKeys list of {@code policy_id || asset_name} keys (reference-NFT asset names)
+     * @return one entity per matching concatenated key; pairs with no data are omitted
+     */
+    @Query(value = "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY policy_id, asset_name " +
+            "ORDER BY slot DESC, tx_index DESC) AS rn FROM cip68_metadata " +
+            "WHERE CONCAT(policy_id, asset_name) IN (:concatenatedKeys)) ranked WHERE rn = 1",
+            nativeQuery = true)
+    List<Cip68Metadata> findLatestByConcatenatedKeys(
+            @Param("concatenatedKeys") Collection<String> concatenatedKeys);
+
+    /**
+     * Bulk delete on rollback. {@code @Modifying @Query} with JPQL issues a single SQL DELETE;
+     * without these annotations Spring Data's derived deleteBy* loads each entity then deletes
+     * per-row (one round-trip per matching row), which is pathological for deep rollbacks.
+     * Caller ({@code Cip68RollbackProcessor.handleRollback}) is already {@code @Transactional}.
+     */
+    @Modifying
+    @Query("DELETE FROM Cip68Metadata e WHERE e.slot > :slot")
+    int deleteBySlotGreaterThan(@Param("slot") Long slot);
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/health/OffchainSyncHealthIndicator.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/health/OffchainSyncHealthIndicator.java
@@ -1,0 +1,64 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.health;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service.SyncStatus;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service.Cip26MetadataSyncCronJob;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service.Cip26MetadataSyncService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator for CIP-26 offchain metadata sync.
+ * <p>
+ * Reports the status of the background GitHub token registry sync job.
+ * Ported from cf-token-metadata-registry's {@code OffchainSyncHealthIndicator}.
+ * <p>
+ * The consuming application decides which probe group (startup, liveness, readiness)
+ * this indicator belongs to via {@code management.endpoint.health.group.*} configuration.
+ *
+ * <ul>
+ *   <li>{@code UP} — sync completed successfully or running as an external job</li>
+ *   <li>{@code OUT_OF_SERVICE} — sync in progress or not yet started</li>
+ *   <li>{@code DOWN} — sync encountered an error</li>
+ * </ul>
+ *
+ * <p>Conditional on {@link Cip26MetadataSyncCronJob} — this indicator is only registered when
+ * the CIP-26 sync cron job is active. In read-only mode or when CIP-26 is disabled, the cron
+ * job bean is absent and this indicator is silently skipped (reporting sync status without an
+ * active sync job would be misleading).
+ */
+@Component("assetStoreOffchainSync")
+@ConditionalOnBean(Cip26MetadataSyncCronJob.class)
+@RequiredArgsConstructor
+public class OffchainSyncHealthIndicator implements HealthIndicator {
+
+    private static final String DETAIL_SYNC_STATUS = "syncStatus";
+
+    private final Cip26MetadataSyncService tokenMetadataSyncService;
+
+    @Override
+    public Health health() {
+        SyncStatus syncStatus = tokenMetadataSyncService.getSyncStatus();
+        if (syncStatus == null) {
+            return Health.unknown()
+                    .withDetail(DETAIL_SYNC_STATUS, "Not initialized")
+                    .build();
+        }
+
+        String statusText = syncStatus.getStatus().toString();
+
+        return switch (syncStatus.getStatus()) {
+            case SYNC_DONE, SYNC_DISABLED -> Health.up()
+                    .withDetail(DETAIL_SYNC_STATUS, statusText)
+                    .build();
+            case SYNC_IN_PROGRESS, SYNC_NOT_STARTED -> Health.outOfService()
+                    .withDetail(DETAIL_SYNC_STATUS, statusText)
+                    .build();
+            case SYNC_ERROR -> Health.down()
+                    .withDetail(DETAIL_SYNC_STATUS, statusText)
+                    .build();
+        };
+    }
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/service/AssetsReader.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/service/AssetsReader.java
@@ -1,0 +1,144 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.QueryPriority;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Subject;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService.BatchPrefetchData;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.Cip113StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Top-level service for querying token metadata across CIP standards.
+ * <p>
+ * This is the primary API for consumers using the assets extension
+ * as a library dependency (via the starter) without REST controllers.
+ *
+ * <ul>
+ *   <li>{@link #getSubject} — merged metadata with configurable CIP priority</li>
+ *   <li>{@link #getCip26Metadata} — CIP-26 offchain metadata only</li>
+ *   <li>{@link #getCip68Metadata} — CIP-68 on-chain reference NFT metadata only</li>
+ *   <li>{@link #getCip113RegistryNode} — CIP-113 programmable token info only (when enabled)</li>
+ * </ul>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AssetsReader {
+
+    private final TokenQueryService tokenQueryService;
+    private final Cip26StorageReader cip26StorageReader;
+    private final Cip68StorageReader cip68StorageReader;
+    private final Cip113StorageReader cip113StorageReader;
+
+    // ========== Merged queries ==========
+
+    /**
+     * Query merged metadata for a subject using default priority (CIP_68, CIP_26).
+     *
+     * @param subject the subject (policyId + hex assetName)
+     * @return the merged subject with metadata and extensions, or empty if not found
+     */
+    public Optional<Subject> getSubject(String subject) {
+        return getSubject(subject, List.of(QueryPriority.CIP_68, QueryPriority.CIP_26));
+    }
+
+    /**
+     * Query merged metadata for a subject with explicit priority.
+     *
+     * @param subject       the subject (policyId + hex assetName)
+     * @param queryPriority ordered list of CIP standards to query
+     * @return the merged subject with metadata and extensions, or empty if not found
+     */
+    public Optional<Subject> getSubject(String subject, List<QueryPriority> queryPriority) {
+        return getSubject(subject, queryPriority, List.of());
+    }
+
+    /**
+     * Query merged metadata for a subject with priority and property filtering.
+     *
+     * @param subject       the subject (policyId + hex assetName)
+     * @param queryPriority ordered list of CIP standards to query
+     * @param properties    list of property names to include (empty = all)
+     * @return the merged subject with metadata and extensions, or empty if not found
+     */
+    public Optional<Subject> getSubject(String subject, List<QueryPriority> queryPriority, List<String> properties) {
+        return tokenQueryService.querySubject(subject, queryPriority, properties, false);
+    }
+
+    /**
+     * Batch query merged metadata for multiple subjects.
+     *
+     * @param subjects      list of subject identifiers
+     * @param queryPriority ordered list of CIP standards
+     * @return list of subjects with valid metadata (invalid/not-found subjects are excluded)
+     */
+    public List<Subject> getSubjects(List<String> subjects, List<QueryPriority> queryPriority) {
+        BatchPrefetchData prefetchData = tokenQueryService.prefetchBatch(subjects, List.of());
+        return subjects.stream()
+                .map(subject -> tokenQueryService.querySubjectBatch(
+                        subject, queryPriority, List.of(), prefetchData, false))
+                .filter(subject -> subject.metadata() != null && subject.metadata().isValid())
+                .toList();
+    }
+
+    // ========== Per-CIP queries (via StorageReader interfaces) ==========
+
+    /**
+     * Look up CIP-26 offchain metadata for a subject.
+     */
+    public Optional<Cip26Metadata> getCip26Metadata(String subject) {
+        return cip26StorageReader.findBySubject(subject);
+    }
+
+    /**
+     * Look up CIP-26 logo for a subject.
+     */
+    public Optional<String> getCip26Logo(String subject) {
+        return cip26StorageReader.findLogoBySubject(subject);
+    }
+
+    /**
+     * Look up CIP-68 on-chain reference NFT metadata for a subject.
+     * Handles the fungible token prefix to reference NFT prefix conversion.
+     */
+    public Optional<FungibleTokenMetadata> getCip68Metadata(String subject) {
+        return cip68StorageReader.findBySubject(subject);
+    }
+
+    /**
+     * Look up CIP-113 programmable token registry node for a policy ID.
+     * Returns empty if CIP-113 is not enabled (no-op reader returns empty).
+     */
+    public Optional<ProgrammableTokenCip113> getCip113RegistryNode(String policyId) {
+        return cip113StorageReader.findByPolicyId(policyId);
+    }
+
+    /**
+     * Batch look up CIP-113 registry nodes for multiple policy IDs.
+     * Returns empty map if CIP-113 is not enabled (no-op reader returns empty map).
+     */
+    public Map<String, ProgrammableTokenCip113> getCip113RegistryNodes(Collection<String> policyIds) {
+        return cip113StorageReader.findByPolicyIds(policyIds);
+    }
+
+    /**
+     * Check whether a policy ID is registered as a CIP-113 programmable token.
+     * Returns false if CIP-113 is not enabled.
+     */
+    public boolean isProgrammableToken(String policyId) {
+        return cip113StorageReader.isProgrammableToken(policyId);
+    }
+
+}

--- a/extensions/assets-ext/src/main/resources/META-INF/native-image/yaci-store-assets-ext/README.md
+++ b/extensions/assets-ext/src/main/resources/META-INF/native-image/yaci-store-assets-ext/README.md
@@ -1,0 +1,54 @@
+# GraalVM native-image reflection hints for assets-ext
+
+This module embeds **JGit** to sync the CIP-26 cardano-token-registry from
+GitHub (`TokenMetadataSyncService` → `GitService` → `CloneCommand` /
+`DiffCommand` / `LogCommand`). No other yaci-store module uses JGit, so the
+reflection hints live here and nowhere else.
+
+## Why hints are needed
+
+`org.eclipse.jgit.lib.Config#getEnum` reads enum-typed git config values
+(`core.autocrlf`, `core.trustlooserefstat`, `diff.algorithm`,
+`diff.renames`, …) by reflectively calling `enumClass.getMethod("values")`.
+GraalVM static reachability analysis cannot see those calls — the enum
+class arrives as a `Class<?>` parameter through generic plumbing — so the
+auto-generated `public static values()` method is stripped from the native
+image. At runtime JGit throws:
+
+```
+java.lang.IllegalArgumentException: Enumerated values of type
+  org.eclipse.jgit.<pkg>$<EnumName> not available
+Caused by: java.lang.NoSuchMethodException:
+  org.eclipse.jgit.<pkg>$<EnumName>.values()
+```
+
+The effect on the CIP-26 sync is total: the cron fires, JGit aborts on the
+first config read, the sync job logs the error and waits for the next
+tick (which fails the same way). Zero entries reach `ft_offchain_metadata`.
+
+## Enums registered
+
+Three families, each on a distinct part of the sync's hot path:
+
+- **`org.eclipse.jgit.lib.CoreConfig.*`** — read during repo init and
+  working-tree setup (`CloneCommand` → `InitCommand` → `FileRepository` →
+  `RefDirectory`). Exercised by the initial full-sync clone.
+- **`org.eclipse.jgit.diff.{DiffAlgorithm.SupportedAlgorithm, DiffConfig.RenameDetectionType}`**
+  — read by `DiffFormatter.setReader` during commit-history traversal
+  (`GitService.getAllMappingDetails` uses `LogCommand` + diffs to resolve
+  per-file `updatedAt` / `updatedBy`).
+- **`org.eclipse.jgit.lib.CommitConfig.CleanupMode`** — read by
+  `CommitConfig.<init>` when `Config.get(COMMIT_KEY)` materialises the
+  section. Exercised by incremental sync: `PullCommand` → `RebaseCommand`
+  → reads `commit.cleanup`. Only surfaces on cron ticks after the first
+  (which did a clone, not a pull).
+
+`allDeclaredMethods: true` keeps `values()` / `valueOf(String)` reachable;
+`allDeclaredFields: true` keeps the enum constants introspectable.
+
+## Extending
+
+This is a class-of-bug — any enum-typed git config option on a code path
+the sync exercises can surface the same symptom on a different enum class.
+On a new `IllegalArgumentException: Enumerated values of type … not
+available` from JGit, add the enum here.

--- a/extensions/assets-ext/src/main/resources/META-INF/native-image/yaci-store-assets-ext/reflect-config.json
+++ b/extensions/assets-ext/src/main/resources/META-INF/native-image/yaci-store-assets-ext/reflect-config.json
@@ -1,0 +1,25 @@
+[
+  { "name": "org.eclipse.jgit.lib.CoreConfig$AutoCRLF",               "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$CheckStat",              "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$EOL",                    "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$EolStreamType",          "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",           "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",          "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$SymLinks",               "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat",    "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat",      "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm", "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.diff.DiffConfig$RenameDetectionType",   "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "org.eclipse.jgit.lib.CommitConfig$CleanupMode",          "allDeclaredMethods": true, "allDeclaredFields": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType", "allDeclaredMethods": true, "allDeclaredFields": true },
+
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.AnnotatedSignature",    "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.TokenMetadataProperty", "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.Cip26TokenMetadata",    "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.NameProperty",        "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.DescriptionProperty", "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.TickerProperty",      "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.UrlProperty",         "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.DecimalsProperty",    "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true },
+  { "name": "com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26.wellknownproperties.LogoProperty",        "allDeclaredMethods": true, "allDeclaredFields": true, "allDeclaredConstructors": true }
+]

--- a/extensions/assets-ext/src/main/resources/cip113/cip113-mainnet.properties
+++ b/extensions/assets-ext/src/main/resources/cip113/cip113-mainnet.properties
@@ -1,0 +1,6 @@
+# CIP-113 registry NFT policy IDs for mainnet
+#
+# DISCLAIMER: CIP-113 is not yet officially live on mainnet. Once it is
+# released, the registry NFT policy ID(s) will be added here and a new
+# yaci-store version will follow.
+#registry-nft-policy-ids=

--- a/extensions/assets-ext/src/main/resources/cip113/cip113-preprod.properties
+++ b/extensions/assets-ext/src/main/resources/cip113/cip113-preprod.properties
@@ -1,0 +1,10 @@
+# CIP-113 registry NFT policy IDs for preprod
+#
+# DISCLAIMER: CIP-113 is not yet officially live on mainnet. The policy ID(s)
+# listed below correspond to the current preprod deployment of the
+# programmable-tokens registry and WILL change once CIP-113 is officially
+# released. A new yaci-store version will follow that release with the
+# updated values.
+#
+# Comma-separated — append additional policy IDs here as new registries are deployed.
+registry-nft-policy-ids=b9b19dc682ed108590277bb5301132b8b2c357cfbdb9138c01af5d1d

--- a/extensions/assets-ext/src/main/resources/cip113/cip113-preview.properties
+++ b/extensions/assets-ext/src/main/resources/cip113/cip113-preview.properties
@@ -1,0 +1,8 @@
+# CIP-113 registry NFT policy IDs for preview
+#
+# DISCLAIMER: CIP-113 is not yet officially live on mainnet. The policy ID(s)
+# listed below correspond to the current preview deployment of the
+# programmable-tokens registry and WILL change once CIP-113 is officially
+# released. A new yaci-store version will follow that release with the
+# updated values.
+registry-nft-policy-ids=dc8a7d1fc883bcb3bfa4e4eb2e06e9b1104ea01292789325c7726e37

--- a/extensions/assets-ext/src/main/resources/db/store/README.md
+++ b/extensions/assets-ext/src/main/resources/db/store/README.md
@@ -1,0 +1,151 @@
+# assets-ext schema
+
+Flyway migrations for the `assets-ext` extension, one file per supported SQL dialect:
+[`h2`](h2), [`mysql`](mysql), [`postgresql`](postgresql). The three dialects describe
+the same schema — the differences are type names (`TEXT` ↔ `LONGTEXT`, `JSONB` ↔ `JSON`),
+identifier quoting, and a `TIMESTAMP` nullability quirk on MySQL.
+
+`optional-indexes.sql` (in this folder) lists indexes that are NOT applied automatically.
+Apply them after the initial sync reaches chain tip — e.g. via the yaci-store admin CLI.
+
+Column type bounds across the SQL files follow the CIP-26 / CIP-68 / CIP-113 specs and
+their canonical implementations. Tightening beyond these bounds is likely unsafe;
+loosening is acceptable but wasteful.
+
+---
+
+## `cip26_metadata` — CIP-26 off-chain GitHub registry
+
+One row per `subject` (a single CIP-26 entry). Bundles metadata, logo, and a catch-all
+JSON column. Historically this was three tables (`ft_offchain_metadata`,
+`ft_offchain_logo`, `off_chain_sync_state`); the logo was folded in and the sync_state
+renamed to `cip26_sync_state` below.
+
+All text-field bounds match the CIP-26 validator in
+[`cf-tokens-cip26`](https://github.com/cardano-foundation/cf-token-metadata-registry).
+Anything exceeding the limits is rejected by `Cip26MetadataValidator` before insert.
+
+| Column | Type | Bound / Rationale |
+|---|---|---|
+| `subject` | `VARCHAR(120)` PK | policyId (28 B) + optional assetName (0–32 B), hex-encoded. CIP-26 spec: 56–120 chars. |
+| `policy` | `TEXT` | CIP-26 `policy` is a base16 CBOR-encoded phase-1 monetary script (a native script), **not** the 28-byte policyId hash (that lives in the first 56 hex chars of `subject`). The spec places no upper bound; real entries with time-locked or k-of-n multisig scripts routinely exceed 200 hex chars (MCOS 216, Incy 586). An earlier `VARCHAR(120)` caused PostgreSQL to reject such entries; `Cip26MetadataService` caught the exception, logged ERROR, and skipped the row — entries were silently dropped with a log line. **Do not cap.** |
+| `name` | `VARCHAR(50)` | CIP-26 cap. |
+| `ticker` | `VARCHAR(9)` | CIP-26 cap, 2–9 chars. |
+| `url` | `VARCHAR(250)` | CIP-26 cap. |
+| `description` | `VARCHAR(500)` | CIP-26 cap (see `MetadataValidationRules.MAX_DESCRIPTION_LENGTH`). |
+| `decimals` | `BIGINT` | Spec range [0, 19]. Stored as `BIGINT` to match the rest of the pipeline (Java `Long` in parser, entity, DTO) and avoid type-conversion noise at every boundary. The 4-byte overhead vs `INTEGER` is negligible. |
+| `logo` | `TEXT` (PG/H2) / `LONGTEXT` (MySQL) | Base64-encoded image, up to ~87 KB per CIP-26. MySQL `TEXT` caps at 64 KB so `LONGTEXT` is required. PostgreSQL TOAST keeps the bulky column out of the row when not selected. |
+| `updated`, `updated_by` | `TIMESTAMP`, `VARCHAR(255)` | Audit fields from the registry entry. |
+| `properties` | `JSONB` (PG) / `JSON` (MySQL) / `TEXT` (H2) | Catch-all: full original `Mapping` JSON with per-property signed envelopes (`{value, signatures, sequenceNumber}`) and any non-well-known properties. |
+| `last_synced_at` | `TIMESTAMP` | |
+
+## `cip26_sync_state` — sync housekeeping
+
+One row tracks the last commit synced from the CF GitHub registry.
+
+| Column | Type | Note |
+|---|---|---|
+| `id` | `BIGSERIAL` (PG) / `BIGINT AUTO_INCREMENT` (H2, MySQL) PK | |
+| `last_commit_hash` | `VARCHAR(40)` NOT NULL | Git SHA-1 = exactly 40 hex chars. |
+| `last_synced_at` | `TIMESTAMP` | |
+
+---
+
+## `cip68_metadata` — on-chain reference NFT metadata (FT/NFT/RFT unified)
+
+One row per *reference-NFT update*. Holds rows for all three CIP-68 label types
+(222 NFT / 333 FT / 444 RFT) — different columns are populated depending on label.
+`Cip68Processor` classifies each row at index time using cross-output detection
+(observing the co-minted user-token prefix in the same transaction's outputs).
+
+Primary key is `(policy_id, asset_name, slot, tx_hash)` — keying on `tx_hash` (like the rest of
+yaci-store: stake_registration, governance, etc.) means the table preserves the full history of
+reference-NFT updates, including multiple updates within the same slot (intra-block tx chaining),
+without in-place overwrites. `tx_index` is a non-key ordering column: the latest row is resolved by
+`ORDER BY slot DESC, tx_index DESC`. **`label` is per-row, not per-asset**: a single reference
+NFT accumulates rows under multiple labels over its lifetime (an FT whose later
+updates happened to be co-minted alongside a 222-prefixed NFT will have its newest
+row stored under label=222). Read-path queries must **not** filter by label — see
+`Cip68MetadataRepository.findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc`.
+
+| Column | Type | Bound / Rationale |
+|---|---|---|
+| `policy_id` | `VARCHAR(56)` NOT NULL | 28 B Blake2b-224. Protocol-bounded. |
+| `asset_name` | `VARCHAR(64)` NOT NULL | 0–32 B ledger max. |
+| `slot` | `BIGINT` NOT NULL | |
+| `tx_hash` | `VARCHAR(64)` NOT NULL | Cardano transaction hash. PK component — tx identity preserves per-update history. |
+| `tx_index` | `INTEGER` NOT NULL | Producing tx's index within its block. Non-key ordering column — disambiguates same-slot updates. |
+| `label` | `INTEGER` NOT NULL | 222 / 333 / 444. See note above. |
+| `name` | `VARCHAR(255)` | CIP-68 datum field. |
+| `description` | `TEXT` | Can be arbitrarily long. |
+| `ticker` | `VARCHAR(32)` | Typically only label 333/444. |
+| `url` | `VARCHAR(250)` | Aligned with CIP-26 cap. |
+| `decimals` | `BIGINT` | See `cip26_metadata.decimals` rationale. |
+| `logo` | `TEXT` (PG/H2) / `LONGTEXT` (MySQL) | Base64-inline (mostly FTs). |
+| `image` | `TEXT` | IPFS / `data:` / `https:` URL (mostly NFTs/RFTs). |
+| `media_type` | `VARCHAR(255)` | MIME type of the image. |
+| `version` | `BIGINT` NOT NULL | CIP-68 schema version, typically 1. |
+| `datum` | `TEXT` (PG/H2) / `LONGTEXT` (MySQL) NOT NULL | Full CBOR hex of the inline datum, kept for re-parse / audit. |
+| `properties` | `JSONB` (PG) / `JSON` (MySQL) / `TEXT` (H2) | Catch-all: `files[]` (array of `{name, mediaType, src}`) + collection-specific traits. |
+| `last_synced_at` | `TIMESTAMP` | |
+
+Indexes: `idx_cip68_metadata_slot`, `idx_cip68_metadata_label`. See
+`optional-indexes.sql` for additional indexes that pay off at chain-tip scale.
+
+---
+
+## `cip113_registry_node` — CIP-113 programmable token registry (Aiken linked list)
+
+The datum is an Aiken `RegistryNode` sorted-linked-list entry. Column names mirror the
+on-chain datum field names — see
+[CIP-143](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0143/README.md)
+(parent spec) and
+[`cip113-programmable-tokens`](https://github.com/cardano-foundation/cip113-programmable-tokens).
+
+**Why `key` and not `policy_id`** — the registry is a sorted linked list. For real
+registered tokens the `key` column equals the programmable token's policy ID (56 hex).
+But two rows per registry are *sentinel* nodes — the head (empty string) and the tail
+(conventionally 32 bytes of `0xFF` in the aiken-linked-list library) — that are
+linked-list machinery, not registrations, and do NOT hold policy IDs. Naming the
+column `policy_id` would overclaim what is stored. See the Javadoc on
+`Cip113RegistryNode.key` for the full rationale. `key` and `next` are reserved words
+in H2 and MySQL (but not in PostgreSQL) so those two dialects quote them.
+
+| Column | Type | Note |
+|---|---|---|
+| `key` | `VARCHAR(64)` NOT NULL | Three possible values: empty string (head sentinel), 56 hex chars (real policy ID), or 58–64 hex chars (tail sentinel). **Do not shrink to 56.** Quoted as `"key"` (H2) / `` `key` `` (MySQL). |
+| `slot` | `BIGINT` NOT NULL | |
+| `tx_hash` | `VARCHAR(64)` NOT NULL | Cardano transaction hash: 32 B = 64 hex. PK component — tx identity preserves per-update history. |
+| `tx_index` | `INTEGER` NOT NULL | Producing tx's index within its block. Non-key ordering column — disambiguates same-slot updates. |
+| `transfer_logic_script` | `VARCHAR(56)` | Aiken Credential inner hash (28 B = 56 hex). Both NULL together when the on-chain Credential field encodes "absent"; both non-NULL otherwise. |
+| `transfer_logic_script_type` | `VARCHAR(8)` | Companion to above: `"VKEY"` or `"SCRIPT"`. |
+| `third_party_transfer_logic_script` | `VARCHAR(56)` | Same pattern. |
+| `third_party_transfer_logic_script_type` | `VARCHAR(8)` | |
+| `global_state_policy_id` | `VARCHAR(56)` | Currency symbol of the global-state NFT (28-byte policy_id). |
+| `next` | `VARCHAR(64)` NOT NULL | Sorted-linked-list pointer. Same range as `key`. Quoted as `"next"` / `` `next` ``. |
+| `datum` | `TEXT` (PG/H2) / `LONGTEXT` (MySQL) NOT NULL | Full CBOR hex of the inline datum. |
+| `last_synced_at` | `TIMESTAMP` | |
+
+PK: `(key, slot, tx_hash)`. Index: `idx_cip113_slot`
+(used by `Cip113RegistryNodeRepository.deleteBySlotGreaterThan`).
+
+Keying on `tx_hash` keeps full per-transaction history rather than doing in-place updates —
+consistent with the rest of yaci-store (stake registration, governance, etc., all key on
+`tx_hash`). Two updates to the same registry node within a single slot (possible via intra-block
+transaction chaining) are preserved as distinct `(key, slot, tx_hash)` rows. `tx_index` is a
+non-key ordering column: the readers resolve a single current-state row per key by
+`ORDER BY slot DESC, tx_index DESC` — `findLatestByKeys` pins each key to its MAX(slot) then
+MAX(tx_index), so `Cip113StorageReaderImpl.findByPolicyIds` returns exactly one row per key and
+cannot hit a duplicate-key collision.
+
+---
+
+## Dialect differences
+
+| Concept | PostgreSQL | H2 | MySQL |
+|---|---|---|---|
+| Big text columns | `TEXT` | `TEXT` | `LONGTEXT` (`TEXT` caps at 64 KB) |
+| JSON column | `JSONB` | `TEXT` | `JSON` |
+| `key` / `next` identifier | unquoted (non-reserved) | `"key"` / `"next"` (reserved) | `` `key` `` / `` `next` `` (reserved) |
+| Auto-increment PK | `BIGSERIAL` | `BIGINT AUTO_INCREMENT` | `BIGINT AUTO_INCREMENT` |
+| `TIMESTAMP` nullability | implicit nullable | implicit nullable | requires explicit `NULL` |

--- a/extensions/assets-ext/src/main/resources/db/store/h2/V0_1700_1__init.sql
+++ b/extensions/assets-ext/src/main/resources/db/store/h2/V0_1700_1__init.sql
@@ -1,0 +1,68 @@
+-- assets-ext schema. See ../README.md for column rationale, CIP references, and dialect notes.
+
+-- CIP-26 — off-chain GitHub registry
+CREATE TABLE cip26_metadata (
+    subject        VARCHAR(120) PRIMARY KEY,
+    policy         TEXT,
+    name           VARCHAR(50),
+    ticker         VARCHAR(9),
+    url            VARCHAR(250),
+    description    VARCHAR(500),
+    decimals       BIGINT,
+    logo           TEXT,
+    updated        TIMESTAMP,
+    updated_by     VARCHAR(255),
+    properties     TEXT,
+    last_synced_at TIMESTAMP
+);
+
+CREATE TABLE cip26_sync_state (
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    last_commit_hash VARCHAR(40) NOT NULL,
+    last_synced_at   TIMESTAMP
+);
+
+-- CIP-68 — on-chain reference NFT metadata (label 222/333/444 unified)
+CREATE TABLE cip68_metadata (
+    policy_id      VARCHAR(56)  NOT NULL,
+    asset_name     VARCHAR(64)  NOT NULL,
+    slot           BIGINT       NOT NULL,
+    tx_hash        VARCHAR(64)  NOT NULL,
+    tx_index       INTEGER      NOT NULL,
+    label          INTEGER      NOT NULL,
+    name           VARCHAR(255),
+    description    TEXT,
+    ticker         VARCHAR(32),
+    url            VARCHAR(250),
+    decimals       BIGINT,
+    logo           TEXT,
+    image          TEXT,
+    media_type     VARCHAR(255),
+    version        BIGINT       NOT NULL,
+    datum          TEXT         NOT NULL,
+    properties     TEXT,
+    last_synced_at TIMESTAMP,
+    PRIMARY KEY (policy_id, asset_name, slot, tx_hash)
+);
+
+CREATE INDEX idx_cip68_metadata_slot  ON cip68_metadata(slot);
+CREATE INDEX idx_cip68_metadata_label ON cip68_metadata(label);
+
+-- CIP-113 — programmable token registry nodes ("key" / "next" quoted: H2 reserved words)
+CREATE TABLE cip113_registry_node (
+    "key"                                  VARCHAR(64)  NOT NULL,
+    slot                                   BIGINT       NOT NULL,
+    tx_hash                                VARCHAR(64)  NOT NULL,
+    tx_index                               INTEGER      NOT NULL,
+    transfer_logic_script                  VARCHAR(56),
+    transfer_logic_script_type             VARCHAR(8),
+    third_party_transfer_logic_script      VARCHAR(56),
+    third_party_transfer_logic_script_type VARCHAR(8),
+    global_state_policy_id                 VARCHAR(56),
+    "next"                                 VARCHAR(64)  NOT NULL,
+    datum                                  TEXT         NOT NULL,
+    last_synced_at                         TIMESTAMP,
+    PRIMARY KEY ("key", slot, tx_hash)
+);
+
+CREATE INDEX idx_cip113_slot ON cip113_registry_node(slot);

--- a/extensions/assets-ext/src/main/resources/db/store/mysql/V0_1700_1__init.sql
+++ b/extensions/assets-ext/src/main/resources/db/store/mysql/V0_1700_1__init.sql
@@ -1,0 +1,68 @@
+-- assets-ext schema. See ../README.md for column rationale, CIP references, and dialect notes.
+
+-- CIP-26 — off-chain GitHub registry
+CREATE TABLE cip26_metadata (
+    subject        VARCHAR(120) PRIMARY KEY,
+    policy         TEXT,
+    name           VARCHAR(50),
+    ticker         VARCHAR(9),
+    url            VARCHAR(250),
+    description    VARCHAR(500),
+    decimals       BIGINT,
+    logo           LONGTEXT,
+    updated        TIMESTAMP NULL,
+    updated_by     VARCHAR(255),
+    properties     JSON,
+    last_synced_at TIMESTAMP NULL
+);
+
+CREATE TABLE cip26_sync_state (
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    last_commit_hash VARCHAR(40) NOT NULL,
+    last_synced_at   TIMESTAMP NULL
+);
+
+-- CIP-68 — on-chain reference NFT metadata (label 222/333/444 unified)
+CREATE TABLE cip68_metadata (
+    policy_id      VARCHAR(56)  NOT NULL,
+    asset_name     VARCHAR(64)  NOT NULL,
+    slot           BIGINT       NOT NULL,
+    tx_hash        VARCHAR(64)  NOT NULL,
+    tx_index       INTEGER      NOT NULL,
+    label          INTEGER      NOT NULL,
+    name           VARCHAR(255),
+    description    TEXT,
+    ticker         VARCHAR(32),
+    url            VARCHAR(250),
+    decimals       BIGINT,
+    logo           LONGTEXT,
+    image          TEXT,
+    media_type     VARCHAR(255),
+    version        BIGINT       NOT NULL,
+    datum          LONGTEXT     NOT NULL,
+    properties     JSON,
+    last_synced_at TIMESTAMP NULL,
+    PRIMARY KEY (policy_id, asset_name, slot, tx_hash)
+);
+
+CREATE INDEX idx_cip68_metadata_slot  ON cip68_metadata(slot);
+CREATE INDEX idx_cip68_metadata_label ON cip68_metadata(label);
+
+-- CIP-113 — programmable token registry nodes (`key` / `next` backtick-quoted: MySQL reserved words)
+CREATE TABLE cip113_registry_node (
+    `key`                                  VARCHAR(64)  NOT NULL,
+    slot                                   BIGINT       NOT NULL,
+    tx_hash                                VARCHAR(64)  NOT NULL,
+    tx_index                               INTEGER      NOT NULL,
+    transfer_logic_script                  VARCHAR(56),
+    transfer_logic_script_type             VARCHAR(8),
+    third_party_transfer_logic_script      VARCHAR(56),
+    third_party_transfer_logic_script_type VARCHAR(8),
+    global_state_policy_id                 VARCHAR(56),
+    `next`                                 VARCHAR(64)  NOT NULL,
+    datum                                  LONGTEXT     NOT NULL,
+    last_synced_at                         TIMESTAMP NULL,
+    PRIMARY KEY (`key`, slot, tx_hash)
+);
+
+CREATE INDEX idx_cip113_slot ON cip113_registry_node(slot);

--- a/extensions/assets-ext/src/main/resources/db/store/optional-indexes.sql
+++ b/extensions/assets-ext/src/main/resources/db/store/optional-indexes.sql
@@ -1,0 +1,24 @@
+-- Optional indexes for the assets-ext extension.
+-- These are NOT applied automatically during sync. Apply after initial sync reaches chain tip,
+-- or use the yaci-store admin CLI tool.
+
+-- CIP-26: lookup by ticker (for findByTicker via StorageReader)
+CREATE INDEX IF NOT EXISTS idx_cip26_metadata_ticker ON cip26_metadata(ticker);
+
+-- CIP-26: case-insensitive name search (for searchByName with ILIKE)
+-- pg_trgm extension + GIN index is best for LIKE queries on PostgreSQL:
+-- CREATE INDEX IF NOT EXISTS idx_cip26_metadata_name_trgm ON cip26_metadata USING GIN(name gin_trgm_ops);
+
+-- CIP-26: GIN index on JSONB properties (PostgreSQL only)
+-- CREATE INDEX IF NOT EXISTS idx_cip26_metadata_properties ON cip26_metadata USING GIN(properties);
+
+-- CIP-68: label-filtered lookups by policy (for findLatestByConcatenatedKeys; supports
+-- index-only scans of the (policy_id, label, slot DESC) prefix used by findFirst*OrderBySlotDesc
+-- and the ROW_NUMBER() OVER (PARTITION BY policy_id, asset_name ORDER BY slot DESC) windowing).
+CREATE INDEX IF NOT EXISTS idx_cip68_metadata_policy_label ON cip68_metadata(policy_id, label, slot DESC);
+
+-- CIP-68 NFT image / collection-attribute lookups via the JSONB column (PostgreSQL only):
+-- CREATE INDEX IF NOT EXISTS idx_cip68_metadata_properties ON cip68_metadata USING GIN(properties);
+
+-- CIP-113: no additional index needed — PK (key, slot, tx_hash) supports backward scan
+-- for findFirstByKeyOrderBySlotDesc and findLatestByKeys queries.

--- a/extensions/assets-ext/src/main/resources/db/store/postgresql/V0_1700_1__init.sql
+++ b/extensions/assets-ext/src/main/resources/db/store/postgresql/V0_1700_1__init.sql
@@ -1,0 +1,68 @@
+-- assets-ext schema. See ../README.md for column rationale, CIP references, and dialect notes.
+
+-- CIP-26 — off-chain GitHub registry
+CREATE TABLE cip26_metadata (
+    subject        VARCHAR(120) PRIMARY KEY,
+    policy         TEXT,
+    name           VARCHAR(50),
+    ticker         VARCHAR(9),
+    url            VARCHAR(250),
+    description    VARCHAR(500),
+    decimals       BIGINT,
+    logo           TEXT,
+    updated        TIMESTAMP,
+    updated_by     VARCHAR(255),
+    properties     JSONB,
+    last_synced_at TIMESTAMP
+);
+
+CREATE TABLE cip26_sync_state (
+    id               BIGSERIAL PRIMARY KEY,
+    last_commit_hash VARCHAR(40) NOT NULL,
+    last_synced_at   TIMESTAMP
+);
+
+-- CIP-68 — on-chain reference NFT metadata (label 222/333/444 unified)
+CREATE TABLE cip68_metadata (
+    policy_id      VARCHAR(56)  NOT NULL,
+    asset_name     VARCHAR(64)  NOT NULL,
+    slot           BIGINT       NOT NULL,
+    tx_hash        VARCHAR(64)  NOT NULL,
+    tx_index       INTEGER      NOT NULL,
+    label          INTEGER      NOT NULL,
+    name           VARCHAR(255),
+    description    TEXT,
+    ticker         VARCHAR(32),
+    url            VARCHAR(250),
+    decimals       BIGINT,
+    logo           TEXT,
+    image          TEXT,
+    media_type     VARCHAR(255),
+    version        BIGINT       NOT NULL,
+    datum          TEXT         NOT NULL,
+    properties     JSONB,
+    last_synced_at TIMESTAMP,
+    PRIMARY KEY (policy_id, asset_name, slot, tx_hash)
+);
+
+CREATE INDEX idx_cip68_metadata_slot  ON cip68_metadata(slot);
+CREATE INDEX idx_cip68_metadata_label ON cip68_metadata(label);
+
+-- CIP-113 — programmable token registry nodes
+CREATE TABLE cip113_registry_node (
+    key                                    VARCHAR(64)  NOT NULL,
+    slot                                   BIGINT       NOT NULL,
+    tx_hash                                VARCHAR(64)  NOT NULL,
+    tx_index                               INTEGER      NOT NULL,
+    transfer_logic_script                  VARCHAR(56),
+    transfer_logic_script_type             VARCHAR(8),
+    third_party_transfer_logic_script      VARCHAR(56),
+    third_party_transfer_logic_script_type VARCHAR(8),
+    global_state_policy_id                 VARCHAR(56),
+    next                                   VARCHAR(64)  NOT NULL,
+    datum                                  TEXT         NOT NULL,
+    last_synced_at                         TIMESTAMP,
+    PRIMARY KEY (key, slot, tx_hash)
+);
+
+CREATE INDEX idx_cip113_slot ON cip113_registry_node(slot);

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip26MetadataControllerTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip26MetadataControllerTest.java
@@ -1,0 +1,158 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip26MetadataController")
+class Cip26MetadataControllerTest {
+
+    private static final String VALID_POLICY_ID = "025146866af908340247fe4e9672d5ac7059f1e8534696b5f920c9e6";
+    private static final String VALID_ASSET_NAME = "6362544848";
+    private static final String VALID_SUBJECT = VALID_POLICY_ID + VALID_ASSET_NAME;
+
+    @Mock
+    private Cip26StorageReader cip26StorageReader;
+
+    @InjectMocks
+    private Cip26MetadataController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setValidator(validator)
+                .addPlaceholderValue("apiPrefix", "/api/v1")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("GET /tokens/cip26/{subject}")
+    class GetBySubject {
+
+        @Test
+        void returns200WithMetadataWhenFound() throws Exception {
+            Cip26Metadata metadata = new Cip26Metadata();
+            metadata.setSubject(VALID_SUBJECT);
+            metadata.setName("Nutcoin");
+            metadata.setDescription("A test token");
+            when(cip26StorageReader.findBySubject(VALID_SUBJECT)).thenReturn(Optional.of(metadata));
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.subject").value(VALID_SUBJECT))
+                    .andExpect(jsonPath("$.name").value("Nutcoin"));
+        }
+
+        @Test
+        void returns404WhenNotFound() throws Exception {
+            when(cip26StorageReader.findBySubject(any())).thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void returns400WhenSubjectTooShort() throws Exception {
+            String tooShort = "ab";
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{subject}", tooShort))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenSubjectTooLong() throws Exception {
+            String tooLong = VALID_POLICY_ID + "a".repeat(65); // 56 + 65 = 121 > max 120
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{subject}", tooLong))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenSubjectNotHex() throws Exception {
+            String nonHex = "zz" + VALID_POLICY_ID.substring(2);
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{subject}", nonHex))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /tokens/cip26/{policyId}/{assetName}")
+    class GetByPolicyAndAssetName {
+
+        @Test
+        void returns200WithMetadataWhenFound() throws Exception {
+            Cip26Metadata metadata = new Cip26Metadata();
+            metadata.setSubject(VALID_SUBJECT);
+            metadata.setName("Nutcoin");
+            metadata.setDescription("A test token");
+            when(cip26StorageReader.findBySubject(VALID_SUBJECT)).thenReturn(Optional.of(metadata));
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", VALID_POLICY_ID, VALID_ASSET_NAME))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.name").value("Nutcoin"));
+        }
+
+        @Test
+        void returns404WhenNotFound() throws Exception {
+            when(cip26StorageReader.findBySubject(any())).thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", VALID_POLICY_ID, VALID_ASSET_NAME))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void returns400WhenPolicyIdWrongLength() throws Exception {
+            String shortPolicyId = VALID_POLICY_ID.substring(0, 55);
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", shortPolicyId, VALID_ASSET_NAME))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenPolicyIdNotHex() throws Exception {
+            String nonHexPolicyId = "zz" + VALID_POLICY_ID.substring(2);
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", nonHexPolicyId, VALID_ASSET_NAME))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenAssetNameTooLong() throws Exception {
+            String tooLong = "a".repeat(65);
+
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", VALID_POLICY_ID, tooLong))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenAssetNameNotHex() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/cip26/{policyId}/{assetName}", VALID_POLICY_ID, "xyz"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip68MetadataControllerTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/Cip68MetadataControllerTest.java
@@ -1,0 +1,155 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.Cip68Constants;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip68MetadataController")
+class Cip68MetadataControllerTest {
+
+    private static final String VALID_POLICY_ID = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e";
+    private static final String RAW_ASSET_NAME = "464c4454"; // "FLDT" in hex
+    private static final String REF_NFT_ASSET_NAME = Cip68Constants.REFERENCE_TOKEN_PREFIX + RAW_ASSET_NAME;
+    private static final String VALID_SUBJECT = VALID_POLICY_ID + "0014df10" + RAW_ASSET_NAME;
+
+    @Mock
+    private Cip68StorageReader cip68StorageReader;
+
+    @InjectMocks
+    private Cip68MetadataController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setValidator(validator)
+                .addPlaceholderValue("apiPrefix", "/api/v1")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("GET /tokens/cip68/ft/{subject}")
+    class GetBySubject {
+
+        @Test
+        void returns200WithMetadataWhenFound() throws Exception {
+            FungibleTokenMetadata metadata = new FungibleTokenMetadata(
+                    6L, "FLDT fungible token", "logo", "FLDT", "FLDT", "https://fluidtokens.com", 1L);
+            when(cip68StorageReader.findBySubject(VALID_SUBJECT)).thenReturn(Optional.of(metadata));
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.name").value("FLDT"))
+                    .andExpect(jsonPath("$.decimals").value(6));
+        }
+
+        @Test
+        void returns404WhenNotFound() throws Exception {
+            when(cip68StorageReader.findBySubject(any())).thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void returns400WhenSubjectTooShort() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{subject}", "ab"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenSubjectNotHex() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{subject}", "zz" + VALID_POLICY_ID.substring(2)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /tokens/cip68/ft/{policyId}/{rawAssetName}")
+    class GetByPolicyAndRawAssetName {
+
+        @Test
+        void returns200WithMetadataWhenFound() throws Exception {
+            FungibleTokenMetadata metadata = new FungibleTokenMetadata(
+                    6L, "FLDT fungible token", "logo", "FLDT", "FLDT", "https://fluidtokens.com", 1L);
+            when(cip68StorageReader.findByPolicyIdAndAssetName(eq(VALID_POLICY_ID), eq(REF_NFT_ASSET_NAME)))
+                    .thenReturn(Optional.of(metadata));
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            VALID_POLICY_ID, RAW_ASSET_NAME))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.ticker").value("FLDT"));
+        }
+
+        @Test
+        void returns404WhenNotFound() throws Exception {
+            when(cip68StorageReader.findByPolicyIdAndAssetName(any(), any())).thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            VALID_POLICY_ID, RAW_ASSET_NAME))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void returns400WhenPolicyIdWrongLength() throws Exception {
+            String shortPolicyId = VALID_POLICY_ID.substring(0, 55);
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            shortPolicyId, RAW_ASSET_NAME))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenRawAssetNameExceeds56Chars() throws Exception {
+            // CIP-68 specific: raw asset name is capped at 56 hex chars because the controller
+            // prepends the 8-char label automatically (total must stay within 64 hex chars).
+            String tooLong = "a".repeat(57);
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            VALID_POLICY_ID, tooLong))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void acceptsRawAssetNameUpTo56Chars() throws Exception {
+            String max = "a".repeat(56);
+            when(cip68StorageReader.findByPolicyIdAndAssetName(any(), any())).thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            VALID_POLICY_ID, max))
+                    .andExpect(status().isNotFound()); // passes validation; storage returns empty
+        }
+
+        @Test
+        void returns400WhenRawAssetNameNotHex() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/cip68/ft/{policyId}/{rawAssetName}",
+                            VALID_POLICY_ID, "xyz"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenMetadataSubjectControllerTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/controller/TokenMetadataSubjectControllerTest.java
@@ -1,0 +1,233 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.controller;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.StringProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Subject;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.TokenType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService.BatchPrefetchData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenMetadataSubjectController")
+class TokenMetadataSubjectControllerTest {
+
+    private static final String VALID_SUBJECT = "025146866af908340247fe4e9672d5ac7059f1e8534696b5f920c9e66362544848";
+    private static final String VALID_SUBJECT_2 = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private TokenQueryService tokenQueryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AssetsExtStoreProperties properties = new AssetsExtStoreProperties();
+        TokenMetadataSubjectController controller = new TokenMetadataSubjectController(tokenQueryService, properties);
+        controller.init(); // @PostConstruct needs to be called manually outside Spring context
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setValidator(validator)
+                .addPlaceholderValue("apiPrefix", "/api/v1")
+                .build();
+    }
+
+    private static Subject subjectWithName(String subject, String name) {
+        Metadata metadata = Metadata.builder()
+                .name(new StringProperty(name, "CIP_26"))
+                .description(new StringProperty("a token", "CIP_26"))
+                .build();
+        return new Subject(subject, TokenType.NATIVE, metadata, null, null);
+    }
+
+    @Nested
+    @DisplayName("GET /tokens/subject/{subject}")
+    class GetSubject {
+
+        @Test
+        void returns200WithMergedMetadataWhenFound() throws Exception {
+            when(tokenQueryService.querySubject(eq(VALID_SUBJECT), anyList(), anyList(), anyBoolean()))
+                    .thenReturn(Optional.of(subjectWithName(VALID_SUBJECT, "Nutcoin")));
+
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.subject.subject").value(VALID_SUBJECT))
+                    .andExpect(jsonPath("$.subject.metadata.name.value").value("Nutcoin"))
+                    .andExpect(jsonPath("$.queryPriority[0]").value("CIP_68"))
+                    .andExpect(jsonPath("$.queryPriority[1]").value("CIP_26"));
+        }
+
+        @Test
+        void returns404WhenSubjectHasNoValidMetadata() throws Exception {
+            when(tokenQueryService.querySubject(anyString(), anyList(), anyList(), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", VALID_SUBJECT))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void returns400WhenSubjectTooShort() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", "ab"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenSubjectNotHex() throws Exception {
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", "zz" + VALID_SUBJECT.substring(2)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenPropertyFilterMissesRequiredFields() throws Exception {
+            // When filtering properties, 'name' and 'description' are required.
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", VALID_SUBJECT)
+                            .param("property", "ticker"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void acceptsPropertyFilterWithRequiredFields() throws Exception {
+            when(tokenQueryService.querySubject(anyString(), anyList(), anyList(), anyBoolean()))
+                    .thenReturn(Optional.of(subjectWithName(VALID_SUBJECT, "Nutcoin")));
+
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", VALID_SUBJECT)
+                            .param("property", "name")
+                            .param("property", "description"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void usesRequestedQueryPriority() throws Exception {
+            when(tokenQueryService.querySubject(anyString(), anyList(), anyList(), anyBoolean()))
+                    .thenReturn(Optional.of(subjectWithName(VALID_SUBJECT, "Nutcoin")));
+
+            mockMvc.perform(get("/api/v1/tokens/subject/{subject}", VALID_SUBJECT)
+                            .param("query_priority", "CIP_26", "CIP_68"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.queryPriority[0]").value("CIP_26"))
+                    .andExpect(jsonPath("$.queryPriority[1]").value("CIP_68"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /tokens/subject/query")
+    class BatchQuery {
+
+        @Test
+        void returns200WithBatchResultsWhenValid() throws Exception {
+            when(tokenQueryService.prefetchBatch(anyList(), anyList()))
+                    .thenReturn(new BatchPrefetchData(Map.of(), Map.of(), Map.of(), Map.of()));
+            when(tokenQueryService.querySubjectBatch(eq(VALID_SUBJECT), anyList(), anyList(), any(), anyBoolean()))
+                    .thenReturn(subjectWithName(VALID_SUBJECT, "Nutcoin"));
+            when(tokenQueryService.querySubjectBatch(eq(VALID_SUBJECT_2), anyList(), anyList(), any(), anyBoolean()))
+                    .thenReturn(subjectWithName(VALID_SUBJECT_2, "FLDT"));
+
+            String body = objectMapper.writeValueAsString(Map.of(
+                    "subjects", List.of(VALID_SUBJECT, VALID_SUBJECT_2)));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.subjects.length()").value(2))
+                    .andExpect(jsonPath("$.subjects[0].metadata.name.value").value("Nutcoin"))
+                    .andExpect(jsonPath("$.subjects[1].metadata.name.value").value("FLDT"));
+        }
+
+        @Test
+        void filtersOutSubjectsWithEmptyMetadata() throws Exception {
+            when(tokenQueryService.prefetchBatch(anyList(), anyList()))
+                    .thenReturn(new BatchPrefetchData(Map.of(), Map.of(), Map.of(), Map.of()));
+            when(tokenQueryService.querySubjectBatch(eq(VALID_SUBJECT), anyList(), anyList(), any(), anyBoolean()))
+                    .thenReturn(new Subject(VALID_SUBJECT, TokenType.NATIVE, Metadata.empty(), null, null));
+
+            String body = objectMapper.writeValueAsString(Map.of("subjects", List.of(VALID_SUBJECT)));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.subjects.length()").value(0));
+        }
+
+        @Test
+        void returns400WhenSubjectsListEmpty() throws Exception {
+            String body = objectMapper.writeValueAsString(Map.of("subjects", List.of()));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenSubjectsListExceedsMaxSize() throws Exception {
+            List<String> tooMany = new java.util.ArrayList<>();
+            for (int i = 0; i < 101; i++) {
+                tooMany.add(VALID_SUBJECT);
+            }
+            String body = objectMapper.writeValueAsString(Map.of("subjects", tooMany));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenAnySubjectInBatchIsInvalid() throws Exception {
+            String body = objectMapper.writeValueAsString(Map.of(
+                    "subjects", List.of(VALID_SUBJECT, "invalid-not-hex")));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void returns400WhenPropertyFilterMissesRequiredFields() throws Exception {
+            String body = objectMapper.writeValueAsString(Map.of(
+                    "subjects", List.of(VALID_SUBJECT),
+                    "properties", List.of("ticker")));
+
+            mockMvc.perform(post("/api/v1/tokens/subject/query")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/Cip26TokenMetadataTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/dto/cip26/Cip26TokenMetadataTest.java
@@ -1,0 +1,274 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.cip26;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Signature;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Locks the CIP-26 V2 wire shape produced by {@link Cip26TokenMetadata#from(Cip26Metadata, String)}.
+ *
+ * <p>This is the factory that builds the {@code subject.standards.cip26} block returned to V2
+ * clients. The shape was validated against 7,871 mainnet subjects (May 2026 sweep, 0 yaci-side
+ * defects); these tests pin the per-property paths so a future refactor cannot regress that
+ * parity silently.
+ *
+ * <p>The most fragile area is the {@code null} vs {@code []} distinction on {@code signatures}
+ * and {@code null} vs explicit-zero on {@code sequenceNumber} — CF preprod is inconsistent
+ * (some subjects emit {@code null}, others {@code []}) so the only spec-correct answer is
+ * byte-faithful pass-through of whatever the registry source supplied.
+ */
+@SuppressWarnings("java:S2187") // tests are in @Nested inner classes
+@DisplayName("Cip26TokenMetadata.from")
+class Cip26TokenMetadataTest {
+
+    private static final String SUBJECT =
+            "0011fbab202151eca9e9ef7680569d9419d12e51e693cb05a2edd2ed4341524b";
+    private static final String POLICY = "82018201828200581c0c0c6dc5f6b02995465ae5de8bdf07d5466932288bea414614ca7d2a";
+    private static final String SIG_HEX = "7880260a00c8a7e7a426f4e971ef938f6dc67a67404dfd4aae3d0a963cf101c3";
+    private static final String PUBKEY_HEX = "0c0c6dc5f6b02995465ae5de8bdf07d5466932288bea414614ca7d2a96c63002";
+    private static final String LOGO_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAUAAeIVWUMAAAAASUVORK5CYII=";
+
+    private static Cip26Metadata entityWith(Mapping mapping) {
+        Cip26Metadata e = new Cip26Metadata();
+        e.setSubject(SUBJECT);
+        e.setPolicy(POLICY);
+        e.setProperties(mapping);
+        return e;
+    }
+
+    private static Item itemNoSig(String value) {
+        return new Item(null, value, null);
+    }
+
+    private static Item itemEmptySig(String value, int sequenceNumber) {
+        return new Item(sequenceNumber, value, List.of());
+    }
+
+    private static Item itemWithSig(String value, int sequenceNumber, Signature... sigs) {
+        return new Item(sequenceNumber, value, List.of(sigs));
+    }
+
+    @Nested
+    @DisplayName("entity-level branches")
+    class EntityLevel {
+
+        @Test
+        void nullEntityReturnsNull() {
+            // Defensive contract: callers can pass a missing entity through without a null check.
+            assertThat(Cip26TokenMetadata.from(null, null)).isNull();
+        }
+
+        @Test
+        void entityWithoutMappingExposesSubjectAndPolicyOnly() {
+            // Real-world case: a row exists in cip26_metadata but the original mapping JSON wasn't
+            // stored (legacy entries). We still want a usable response carrying the on-chain bits.
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(null), null);
+
+            assertThat(dto).isNotNull();
+            assertThat(dto.getSubject()).isEqualTo(SUBJECT);
+            assertThat(dto.getPolicy()).isEqualTo(POLICY);
+            assertThat(dto.getName()).isNull();
+            assertThat(dto.getDescription()).isNull();
+            assertThat(dto.getUrl()).isNull();
+            assertThat(dto.getTicker()).isNull();
+            assertThat(dto.getDecimals()).isNull();
+            assertThat(dto.getLogo()).isNull();
+        }
+
+        @Test
+        void allWellKnownPropertiesAreLifted() {
+            Mapping mapping = new Mapping(
+                    SUBJECT,
+                    itemNoSig("https://example.com"),
+                    itemNoSig("Example Token"),
+                    itemNoSig("EXMPL"),
+                    itemNoSig("6"),
+                    null,
+                    POLICY,
+                    itemNoSig("Example description"));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getValue()).isEqualTo("Example Token");
+            assertThat(dto.getDescription().getValue()).isEqualTo("Example description");
+            assertThat(dto.getUrl().getValue()).isEqualTo("https://example.com");
+            assertThat(dto.getTicker().getValue()).isEqualTo("EXMPL");
+            assertThat(dto.getDecimals().getValue()).isEqualByComparingTo(BigDecimal.valueOf(6));
+        }
+
+        @Test
+        void logoIsSuppressedWhenLogoB64IsNullEvenIfMappingHasLogoItem() {
+            // Yaci stores logos in a separate column; if the table copy is absent we don't fabricate
+            // one from the mapping JSON alone — that would diverge from CF's wire shape (which gates
+            // logo emission on the table-side payload, not the mapping envelope).
+            Mapping mapping = new Mapping(SUBJECT, null, null, null, null,
+                    itemWithSig("ignored-base64", 0, new Signature(SIG_HEX, PUBKEY_HEX)),
+                    POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getLogo()).isNull();
+        }
+
+        @Test
+        void logoUsesTableValueButPreservesMappingSignaturesAndSequence() {
+            // Logo is unique: the canonical bytes come from the table column (logoB64) but the
+            // signatures/sequenceNumber must come from the mapping's logo Item so off-chain
+            // signatures aren't lost when the table is rebuilt.
+            Mapping mapping = new Mapping(SUBJECT, null, null, null, null,
+                    itemWithSig("ignored-base64", 7, new Signature(SIG_HEX, PUBKEY_HEX)),
+                    POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), LOGO_B64);
+
+            assertThat(dto.getLogo().getValue()).isEqualTo(LOGO_B64);
+            assertThat(dto.getLogo().getSignatures())
+                    .singleElement()
+                    .satisfies(sig -> {
+                        assertThat(sig.getSignature()).isEqualTo(SIG_HEX);
+                        assertThat(sig.getPublicKey()).isEqualTo(PUBKEY_HEX);
+                    });
+            assertThat(dto.getLogo().getSequenceNumber()).isEqualByComparingTo(BigDecimal.valueOf(7));
+        }
+
+        @Test
+        void logoFromTableButNoMappingItemHasNullSignaturesAndSequence() {
+            // Defensive: if the mapping JSON has no logo Item at all but the table column does,
+            // we still produce a logo property — just without sig metadata.
+            Mapping mapping = new Mapping(SUBJECT, null, null, null, null,
+                    null, POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), LOGO_B64);
+
+            assertThat(dto.getLogo().getValue()).isEqualTo(LOGO_B64);
+            assertThat(dto.getLogo().getSignatures()).isNull();
+            assertThat(dto.getLogo().getSequenceNumber()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("V2 wire-shape — signatures & sequenceNumber")
+    class WireShape {
+
+        @Test
+        void nullSignaturesPassThroughAsNull() {
+            // CF preprod emits "signatures": null when the registry JSON omits the field.
+            // yaci's Item.signatures is a null List<Signature> in that case → must remain null.
+            Mapping mapping = mappingWithName(itemNoSig("Example"));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSignatures()).isNull();
+        }
+
+        @Test
+        void emptySignaturesPassThroughAsEmptyList() {
+            // CF preprod emits "signatures": [] when the registry JSON has the empty array literal.
+            // yaci's Item.signatures is a List.of() in that case → must remain empty list (NOT null).
+            // Conflating null and [] reintroduced ~37 mainnet divergences in an earlier fix; this
+            // test pins the distinction.
+            Mapping mapping = mappingWithName(itemEmptySig("Example", 0));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSignatures()).isEmpty();
+        }
+
+        @Test
+        void realSignaturesAreMappedToAnnotatedSignaturesVerbatim() {
+            Signature sig = new Signature(SIG_HEX, PUBKEY_HEX);
+            Mapping mapping = mappingWithName(itemWithSig("Example", 0, sig));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSignatures())
+                    .singleElement()
+                    .satisfies(annotated -> {
+                        assertThat(annotated.getSignature()).isEqualTo(SIG_HEX);
+                        assertThat(annotated.getPublicKey()).isEqualTo(PUBKEY_HEX);
+                    });
+        }
+
+        @Test
+        void nullSequenceNumberStaysNull() {
+            // CF emits "sequenceNumber": null for entries missing the field. Returning
+            // BigDecimal.ZERO instead would falsely advertise "version 0" — a valid sequenceNumber
+            // value — so unknown-vs-explicit-zero must be distinguishable on the wire.
+            Mapping mapping = mappingWithName(itemNoSig("Example"));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSequenceNumber()).isNull();
+        }
+
+        @Test
+        void explicitZeroSequenceNumberPropagatesAsBigDecimalZero() {
+            // 0 is a valid CIP-26 sequenceNumber (initial registration). Must not be confused
+            // with null.
+            Mapping mapping = mappingWithName(itemEmptySig("Example", 0));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSequenceNumber()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+
+        @Test
+        void nonZeroSequenceNumberPropagatesAsBigDecimal() {
+            Mapping mapping = mappingWithName(itemEmptySig("Example", 42));
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getName().getSequenceNumber()).isEqualByComparingTo(BigDecimal.valueOf(42));
+        }
+
+        private Mapping mappingWithName(Item nameItem) {
+            return new Mapping(SUBJECT, null, nameItem, null, null, null, POLICY, null);
+        }
+    }
+
+    @Nested
+    @DisplayName("decimals — string-to-BigDecimal conversion")
+    class Decimals {
+
+        @Test
+        void invalidNumericStringResolvesToNullProperty() {
+            // Defensive: CIP-26 schema permits only integer-shaped decimals, but a malformed
+            // registry entry shouldn't crash the response. Logged at WARN by the factory.
+            Mapping mapping = new Mapping(SUBJECT, null, null, null,
+                    itemNoSig("not-a-number"), null, POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getDecimals()).isNull();
+        }
+
+        @Test
+        void validIntegerProducesBigDecimalValue() {
+            Mapping mapping = new Mapping(SUBJECT, null, null, null,
+                    itemNoSig("8"), null, POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getDecimals().getValue()).isEqualByComparingTo(BigDecimal.valueOf(8));
+        }
+
+        @Test
+        void nullValueItemResolvesToNullProperty() {
+            Mapping mapping = new Mapping(SUBJECT, null, null, null,
+                    new Item(null, null, null), null, POLICY, null);
+
+            Cip26TokenMetadata dto = Cip26TokenMetadata.from(entityWith(mapping), null);
+
+            assertThat(dto.getDecimals()).isNull();
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/service/TokenQueryServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/api/service/TokenQueryServiceTest.java
@@ -1,0 +1,296 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.QueryPriority;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Subject;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.Cip113StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TokenQueryService")
+class TokenQueryServiceTest {
+
+    private static final String KNOWN_SUBJECT = "025146866af908340247fe4e9672d5ac7059f1e8534696b5f920c9e66362544848";
+    private static final String UNKNOWN_SUBJECT = "025146866af908340247fe4e9672d5ac7059f1e8534696b5f920c9e66362544843";
+    private static final String FLDT_SUBJECT = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e0014df10464c4454";
+    private static final String FLDT_POLICY_ID = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e";
+
+    private static final List<QueryPriority> DEFAULT_PRIORITY = List.of(QueryPriority.CIP_68, QueryPriority.CIP_26);
+
+    @Mock
+    private Cip26StorageReader cip26StorageReader;
+
+    @Mock
+    private Cip68StorageReader cip68StorageReader;
+
+    @Mock
+    private Cip113StorageReader cip113StorageReader;
+
+    private TokenQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TokenQueryService(cip26StorageReader, cip68StorageReader, cip113StorageReader);
+
+        // Unknown subject: no CIP-26, no CIP-68
+        AssetType unknownAssetType = AssetType.fromUnit(UNKNOWN_SUBJECT);
+        when(cip26StorageReader.findBySubject(UNKNOWN_SUBJECT)).thenReturn(Optional.empty());
+        when(cip68StorageReader.findBySubject(eq(UNKNOWN_SUBJECT), any())).thenReturn(Optional.empty());
+
+        // Known subject: CIP-26 + CIP-68
+        Cip26Metadata knownCip26 = new Cip26Metadata();
+        knownCip26.setSubject(KNOWN_SUBJECT);
+        knownCip26.setName("nutcoin");
+        knownCip26.setDescription("The legendary Nutcoin, the first native asset minted on Cardano.");
+        knownCip26.setUrl("https://fivebinaries.com/nutcoin");
+        when(cip26StorageReader.findBySubject(KNOWN_SUBJECT)).thenReturn(Optional.of(knownCip26));
+        when(cip26StorageReader.findLogoBySubject(KNOWN_SUBJECT)).thenReturn(Optional.empty());
+
+        // CIP-68 for known subject (name and url overridden)
+        when(cip68StorageReader.findBySubject(eq(KNOWN_SUBJECT), any()))
+                .thenReturn(Optional.of(new FungibleTokenMetadata(null, null, null, "NUTCOIN", null, "https://cip68-url.com/nutcoin", null)));
+
+        // FLDT: CIP-26 data. The Mapping JSON is what populates the show_cips_details=true
+        // standards.cip26 envelope (signatures + sequenceNumber + value), so set it here
+        // alongside the entity's flat columns.
+        Cip26Metadata fldtCip26 = new Cip26Metadata();
+        fldtCip26.setSubject(FLDT_SUBJECT);
+        fldtCip26.setName("FLDT");
+        fldtCip26.setTicker("FLDT");
+        fldtCip26.setUrl("https://fluidtokens.com");
+        fldtCip26.setProperties(new Mapping(
+                FLDT_SUBJECT,
+                new Item(0, "https://fluidtokens.com", List.of()),
+                new Item(0, "FLDT", List.of()),
+                new Item(0, "FLDT", List.of()),
+                null,
+                null,
+                null,
+                null));
+        when(cip26StorageReader.findBySubject(FLDT_SUBJECT)).thenReturn(Optional.of(fldtCip26));
+        when(cip26StorageReader.findLogoBySubject(FLDT_SUBJECT)).thenReturn(Optional.empty());
+
+        // FLDT: CIP-68 data
+        when(cip68StorageReader.findBySubject(eq(FLDT_SUBJECT), any()))
+                .thenReturn(Optional.of(new FungibleTokenMetadata(null,
+                        "The official token of FluidTokens, a leading DeFi ecosystem fueled by innovation and community backing.",
+                        null, "FLDT", "FLDT", null, null)));
+
+        // CIP-113: FLDT is programmable
+        when(cip113StorageReader.findByPolicyId(FLDT_POLICY_ID))
+                .thenReturn(Optional.of(new ProgrammableTokenCip113(
+                        "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd",
+                        Cip113CredentialType.SCRIPT,
+                        "11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344",
+                        Cip113CredentialType.SCRIPT,
+                        "eeff0011eeff0011eeff0011eeff0011eeff0011eeff0011eeff0011")));
+
+        // CIP-113: non-programmable tokens return empty
+        AssetType knownAssetType = AssetType.fromUnit(KNOWN_SUBJECT);
+        when(cip113StorageReader.findByPolicyId(knownAssetType.policyId())).thenReturn(Optional.empty());
+        when(cip113StorageReader.findByPolicyId(unknownAssetType.policyId())).thenReturn(Optional.empty());
+
+        // CIP-113 batch
+        when(cip113StorageReader.findByPolicyIds(anyCollection()))
+                .thenReturn(Map.of(FLDT_POLICY_ID, new ProgrammableTokenCip113(
+                        "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd",
+                        Cip113CredentialType.SCRIPT,
+                        "11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344",
+                        Cip113CredentialType.SCRIPT,
+                        "eeff0011eeff0011eeff0011eeff0011eeff0011eeff0011eeff0011")));
+
+        // CIP-26 batch: findBySubjects returns all known metadata
+        when(cip26StorageReader.findBySubjects(any())).thenAnswer(invocation -> {
+            List<String> subjects = invocation.getArgument(0);
+            return subjects.stream()
+                    .map(s -> cip26StorageReader.findBySubject(s).orElse(null))
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+        });
+
+        // CIP-26 batch: findLogosBySubjects returns empty (no logos mocked)
+        when(cip26StorageReader.findLogosBySubjects(any())).thenReturn(Map.of());
+
+        // CIP-68 batch: findBySubjects falls back to the per-subject mocks above
+        when(cip68StorageReader.findBySubjects(any(), any())).thenAnswer(invocation -> {
+            List<String> subjects = invocation.getArgument(0);
+            List<String> props = invocation.getArgument(1);
+            java.util.Map<String, FungibleTokenMetadata> result = new java.util.HashMap<>();
+            for (String s : subjects) {
+                cip68StorageReader.findBySubject(s, props).ifPresent(md -> result.put(s, md));
+            }
+            return result;
+        });
+    }
+
+    @Nested
+    @DisplayName("querySubject - unknown subject")
+    class UnknownSubject {
+
+        @Test
+        void returnsEmptyForNonExistingSubject() {
+            assertThat(service.querySubject(UNKNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), false)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("querySubject - CIP-26 + CIP-68 token")
+    class Cip26AndCip68Token {
+
+        @Test
+        void returnsMetadataWithCorrectSubject() {
+            Subject result = service.querySubject(KNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+            assertThat(result.subject()).isEqualTo(KNOWN_SUBJECT);
+        }
+
+        @Test
+        void cip68TakesPriorityForNameAndUrl() {
+            Subject result = service.querySubject(KNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+
+            assertThat(result.metadata().name().value()).isEqualTo("NUTCOIN");
+            assertThat(result.metadata().name().source()).isEqualTo("CIP_68");
+            assertThat(result.metadata().url().value()).isEqualTo("https://cip68-url.com/nutcoin");
+            assertThat(result.metadata().url().source()).isEqualTo("CIP_68");
+            assertThat(result.metadata().description().value()).isEqualTo("The legendary Nutcoin, the first native asset minted on Cardano.");
+            assertThat(result.metadata().description().source()).isEqualTo("CIP_26");
+        }
+
+        @Test
+        void nonProgrammableTokenShouldNotHaveExtensions() {
+            Subject result = service.querySubject(KNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+            assertThat(result.type()).isEqualTo(com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.TokenType.NATIVE);
+            assertThat(result.extensions()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("querySubject - FLDT (CIP-26 + CIP-68)")
+    class FldtToken {
+
+        @Test
+        void mergesMetadataWithCip68Priority() {
+            Subject result = service.querySubject(FLDT_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+            assertThat(result.metadata().name().value()).isEqualTo("FLDT");
+            assertThat(result.metadata().name().source()).isEqualTo("CIP_68");
+            assertThat(result.metadata().url().value()).isEqualTo("https://fluidtokens.com");
+            assertThat(result.metadata().url().source()).isEqualTo("CIP_26");
+        }
+
+        @Test
+        void showCipsDetailsReturnsStandards() {
+            Subject result = service.querySubject(FLDT_SUBJECT, DEFAULT_PRIORITY, List.of(), true).orElseThrow();
+            assertThat(result.standards()).isNotNull();
+            assertThat(result.standards().cip26()).isNotNull();
+            // standards.cip26 now uses CF-compatible envelopes — value lives under .getName().getValue()
+            assertThat(result.standards().cip26().getName()).isNotNull();
+            assertThat(result.standards().cip26().getName().getValue()).isEqualTo("FLDT");
+            // Mock signatures = List.of() — empty list passes through as []. CF preprod
+            // is inconsistent (some subjects emit null for missing JSON field, others emit
+            // [] for "signatures": []), so yaci must preserve the source distinction
+            // verbatim rather than normalising. The null-source path is not exercised here.
+            assertThat(result.standards().cip26().getName().getSignatures()).isEmpty();
+            // Mock sequenceNumber = 0 — a real value passes through unchanged. The null-
+            // source path (sequenceNumber absent in registry) is covered by sequenceNumberOf
+            // returning null; not exercised here because every FLDT mock Item sets it.
+            assertThat(result.standards().cip26().getName().getSequenceNumber())
+                    .isEqualByComparingTo(java.math.BigDecimal.ZERO);
+            assertThat(result.standards().cip26().getTicker().getValue()).isEqualTo("FLDT");
+            assertThat(result.standards().cip26().getUrl().getValue()).isEqualTo("https://fluidtokens.com");
+            // additionalProperties is always {} on CF for tokens with no extra fields — match that.
+            assertThat(result.standards().cip26().getAdditionalProperties()).isEmpty();
+            assertThat(result.standards().cip68()).isNotNull();
+            assertThat(result.standards().cip68().name()).isEqualTo("FLDT");
+        }
+
+        @Test
+        void cip26PriorityOverrideChangesMergeOrder() {
+            List<QueryPriority> cip26First = List.of(QueryPriority.CIP_26, QueryPriority.CIP_68);
+            Subject result = service.querySubject(FLDT_SUBJECT, cip26First, List.of(), false).orElseThrow();
+            assertThat(result.metadata().name().value()).isEqualTo("FLDT");
+            assertThat(result.metadata().name().source()).isEqualTo("CIP_26");
+            assertThat(result.metadata().url().value()).isEqualTo("https://fluidtokens.com");
+            assertThat(result.metadata().url().source()).isEqualTo("CIP_26");
+        }
+    }
+
+    @Nested
+    @DisplayName("querySubject - CIP-113 extensions")
+    class Cip113Extensions {
+
+        @Test
+        void cip113ExtensionShouldAppearForProgrammableToken() {
+            Subject result = service.querySubject(FLDT_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+            assertThat(result.type()).isEqualTo(com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.TokenType.PROGRAMMABLE);
+            assertThat(result.extensions()).isNotNull();
+            assertThat(result.extensions()).containsKey("cip113");
+
+            ProgrammableTokenCip113 cip113 = (ProgrammableTokenCip113) result.extensions().get("cip113");
+            assertThat(cip113.transferLogicScript())
+                    .isEqualTo("aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd");
+        }
+
+        @Test
+        void nonProgrammableTokenShouldNotHaveExtensions() {
+            Subject result = service.querySubject(KNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), false).orElseThrow();
+            assertThat(result.type()).isEqualTo(com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.TokenType.NATIVE);
+            assertThat(result.extensions()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("querySubjectBatch")
+    class BatchQuery {
+
+        @Test
+        void returnsMergedMetadataForMultipleSubjects() {
+            TokenQueryService.BatchPrefetchData prefetchData = service.prefetchBatch(
+                    List.of(KNOWN_SUBJECT, FLDT_SUBJECT), List.of());
+
+            Subject known = service.querySubjectBatch(KNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), prefetchData, false);
+            Subject fldt = service.querySubjectBatch(FLDT_SUBJECT, DEFAULT_PRIORITY, List.of(), prefetchData, false);
+
+            assertThat(known.subject()).isEqualTo(KNOWN_SUBJECT);
+            assertThat(known.metadata().url().value()).isEqualTo("https://cip68-url.com/nutcoin");
+
+            assertThat(fldt.subject()).isEqualTo(FLDT_SUBJECT);
+            assertThat(fldt.metadata().name().source()).isEqualTo("CIP_68");
+        }
+
+        @Test
+        void unknownSubjectReturnsEmptyMetadata() {
+            TokenQueryService.BatchPrefetchData prefetchData = service.prefetchBatch(
+                    List.of(UNKNOWN_SUBJECT), List.of());
+
+            Subject unknown = service.querySubjectBatch(UNKNOWN_SUBJECT, DEFAULT_PRIORITY, List.of(), prefetchData, false);
+            assertThat(unknown.metadata().isEmpty() || !unknown.metadata().isValid()).isTrue();
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/parser/Cip113RegistryNodeParserTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/parser/Cip113RegistryNodeParserTest.java
@@ -1,0 +1,667 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.parser;
+
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ListPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("java:S2187") // tests are in @Nested inner classes
+@DisplayName("Cip113RegistryNodeParser")
+class Cip113RegistryNodeParserTest {
+
+    // All hash-shaped values are 56 hex chars = 28 bytes (Blake2b-224 / policy id).
+    private static final String POLICY_A_HEX = "0befd1269cf3b5b41cce136c92c64b45dde93e4bfe11875839b713d1";
+    private static final String POLICY_B_HEX = "1befd1269cf3b5b41cce136c92c64b45dde93e4bfe11875839b713d2";
+    private static final String CRED_TRANSFER_HEX = "aaa513b0fcc01d635f8535d49f38acc33d4d6b62ee8732ca6e126102";
+    private static final String CRED_THIRD_PARTY_HEX = "def513b0fcc01d635f8535d49f38acc33d4d6b62ee8732ca6e126103";
+    private static final String GLOBAL_STATE_POLICY_HEX = "1234567890abcdef1234567890abcdef1234567890abcdef12345678";
+
+    /** Tail sentinel conventionally ~32 bytes of 0xFF in the aiken-linked-list library. */
+    private static final byte[] TAIL_SENTINEL_32B = new byte[32];
+
+    static {
+        java.util.Arrays.fill(TAIL_SENTINEL_32B, (byte) 0xFF);
+    }
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    private final Cip113RegistryNodeParser parser = new Cip113RegistryNodeParser();
+
+    // ----- Happy path -----------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Valid datums")
+    class ValidDatums {
+
+        @Test
+        void parsesFullRegistryNodeWithVKeyCredentials() throws Exception {
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    hex(GLOBAL_STATE_POLICY_HEX));
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().key()).isEqualTo(POLICY_A_HEX);
+            assertThat(result.get().next()).isEqualTo(POLICY_B_HEX);
+            assertThat(result.get().transferLogicScript()).isEqualTo(CRED_TRANSFER_HEX);
+            assertThat(result.get().transferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(result.get().thirdPartyTransferLogicScript()).isEqualTo(CRED_THIRD_PARTY_HEX);
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(result.get().globalStatePolicyId()).isEqualTo(GLOBAL_STATE_POLICY_HEX);
+        }
+
+        @Test
+        void parsesNodeWithScriptCredential() throws Exception {
+            // Credential alternative 1 = Script (vs 0 = VerificationKey). Both are valid; the
+            // discriminator is preserved so downstream verifiers know which check to apply.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    scriptCred(hex(CRED_TRANSFER_HEX)),
+                    scriptCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isEqualTo(CRED_TRANSFER_HEX);
+            assertThat(result.get().transferLogicScriptType()).isEqualTo(Cip113CredentialType.SCRIPT);
+            assertThat(result.get().thirdPartyTransferLogicScript()).isEqualTo(CRED_THIRD_PARTY_HEX);
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.SCRIPT);
+        }
+
+        @Test
+        void parsesNodeWithMixedCredentialTypes() throws Exception {
+            // Real registries can have a vkey-credential transfer logic and a script-credential
+            // third-party logic (or vice versa). Each discriminator is independent.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    scriptCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.SCRIPT);
+        }
+
+        @Test
+        void parsesHeadSentinelNode() throws Exception {
+            // key = empty (head sentinel), next points to first real node.
+            String datum = buildDatum(
+                    EMPTY_BYTES,
+                    hex(POLICY_A_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().key()).isEmpty();
+            assertThat(result.get().next()).isEqualTo(POLICY_A_HEX);
+            assertThat(result.get().globalStatePolicyId()).isNull();
+        }
+
+        @Test
+        void parsesNodeWithAbsentGlobalState() throws Exception {
+            // global_state_cs = empty bytes → semantically absent → null in the parsed output.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().globalStatePolicyId()).isNull();
+        }
+
+        @Test
+        void parsesNodeWithMaxLengthNextSentinel() throws Exception {
+            // A materialized tail sentinel node: next points to the 32-byte 0xFF sentinel.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    TAIL_SENTINEL_32B,
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().next()).isEqualTo("ff".repeat(32));
+        }
+
+        @Test
+        void parsesNodeWithAbsentTransferLogicScriptAsPlainEmptyBytes() throws Exception {
+            // Real-world tolerance: plain BytesPlutusData(h'') in place of a Credential Constr
+            // means "no transfer_logic_script".
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            // Absent credential: hash AND type are both null — they're populated together.
+            assertThat(result.get().transferLogicScript()).isNull();
+            assertThat(result.get().transferLogicScriptType()).isNull();
+            assertThat(result.get().thirdPartyTransferLogicScript()).isEqualTo(CRED_THIRD_PARTY_HEX);
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+        }
+
+        @Test
+        void parsesNodeWithAbsentTransferLogicScriptAsWrappedEmptyBytes() throws Exception {
+            // Also tolerate a Credential Constr whose inner ByteString is empty.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(EMPTY_BYTES),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isNull();
+        }
+
+        @Test
+        void parsesNodeWithAbsentThirdPartyTransferLogicScript() throws Exception {
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isEqualTo(CRED_TRANSFER_HEX);
+            assertThat(result.get().thirdPartyTransferLogicScript()).isNull();
+        }
+
+        @Test
+        void parsesNodeWithAllThreeOptionalFieldsAbsent() throws Exception {
+            // Demonstrates that all three optional fields (both credentials + global_state_cs)
+            // can be simultaneously null — only 'key' and 'next' are strictly required.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES),
+                    BytesPlutusData.of(EMPTY_BYTES),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().key()).isEqualTo(POLICY_A_HEX);
+            assertThat(result.get().next()).isEqualTo(POLICY_B_HEX);
+            assertThat(result.get().transferLogicScript()).isNull();
+            assertThat(result.get().thirdPartyTransferLogicScript()).isNull();
+            assertThat(result.get().globalStatePolicyId()).isNull();
+        }
+    }
+
+    // ----- Root-structure invariants --------------------------------------------------
+
+    @Nested
+    @DisplayName("Root structure invariants")
+    class RootStructureInvariants {
+
+        @Test
+        void rejectsNonConstrRoot() throws Exception {
+            // A bare BytesPlutusData as the whole datum.
+            String datum = serialize(BytesPlutusData.of(hex(POLICY_A_HEX)));
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsListPlutusDataRoot() throws Exception {
+            ListPlutusData list = ListPlutusData.of(
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)));
+            String datum = serialize(list);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsWrongConstructorAlternative() throws Exception {
+            // Alternative 1 with otherwise valid fields — must be rejected (RegistryNode is alternative 0).
+            ConstrPlutusData node = ConstrPlutusData.of(1,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsFewerThanFiveFields() throws Exception {
+            // 4 fields — missing global_state_cs. Spec requires all 5.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsMoreThanFiveFields() throws Exception {
+            // 6 fields — an extra unknown trailing field.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES),
+                    BytesPlutusData.of(hex("cafe")));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+    }
+
+    // ----- key / next field invariants ------------------------------------------------
+
+    @Nested
+    @DisplayName("key / next field invariants")
+    class KeyNextInvariants {
+
+        @Test
+        void rejectsKeyAsNonByteString() throws Exception {
+            // key is a Constr — wrong type.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    vkeyCred(hex(POLICY_A_HEX)),  // wrong type for field 0
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsKeyExceedingMaxLength() throws Exception {
+            // 33-byte key — exceeds the 32-byte cap (max sentinel convention).
+            byte[] tooLong = new byte[33];
+            java.util.Arrays.fill(tooLong, (byte) 0xFF);
+
+            String datum = buildDatum(
+                    tooLong,
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsEmptyNext() throws Exception {
+            // next must be non-empty — an empty next would violate key < next for any key.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    EMPTY_BYTES,
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsNextAsNonByteString() throws Exception {
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    vkeyCred(hex(POLICY_B_HEX)),  // wrong type for field 1
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsNextExceedingMaxLength() throws Exception {
+            byte[] tooLong = new byte[33];
+            java.util.Arrays.fill(tooLong, (byte) 0xFF);
+
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    tooLong,
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+    }
+
+    // ----- Credential field invariants ------------------------------------------------
+
+    @Nested
+    @DisplayName("Credential field invariants")
+    class CredentialInvariants {
+
+        @Test
+        void rejectsTransferLogicScriptAsPlainBytes() throws Exception {
+            // Field 2 is a plain BytesPlutusData instead of Constr — the old parser's
+            // off-spec tolerance incorrectly returned null here; the new parser rejects.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    BytesPlutusData.of(hex(CRED_TRANSFER_HEX)),  // not wrapped in Credential Constr
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsTransferLogicScriptWithWrongByteLength() throws Exception {
+            // Credential wraps 10 bytes instead of 28.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex("aabbccddeeff00112233")),  // 10 bytes
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsTransferLogicScriptWithInvalidAlternative() throws Exception {
+            // Aiken Credential alternatives are {0=VerificationKey, 1=Script}. Anything else is invalid.
+            ConstrPlutusData badCred = ConstrPlutusData.of(2, BytesPlutusData.of(hex(CRED_TRANSFER_HEX)));
+
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    badCred,
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsTransferLogicScriptWithMultipleInnerFields() throws Exception {
+            // Credential Constr should have exactly 1 inner field.
+            ConstrPlutusData badCred = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(CRED_TRANSFER_HEX)),
+                    BytesPlutusData.of(hex("cafe")));
+
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    badCred,
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsThirdPartyTransferLogicScriptAsPlainBytes() throws Exception {
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    BytesPlutusData.of(hex(CRED_THIRD_PARTY_HEX)),  // not wrapped
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsThirdPartyTransferLogicScriptWithWrongByteLength() throws Exception {
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex("aabbccddeeff00112233")),  // 10 bytes
+                    BytesPlutusData.of(EMPTY_BYTES));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+    }
+
+    // ----- global_state_cs field invariants --------------------------------------------
+
+    @Nested
+    @DisplayName("global_state_cs field invariants")
+    class GlobalStateInvariants {
+
+        @Test
+        void acceptsEmptyGlobalState() throws Exception {
+            // Already covered by parsesNodeWithAbsentGlobalState — duplicated here for
+            // symmetry with the rejection cases in this class.
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+            assertThat(result).isPresent();
+            assertThat(result.get().globalStatePolicyId()).isNull();
+        }
+
+        @Test
+        void acceptsFullLengthGlobalState() throws Exception {
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    hex(GLOBAL_STATE_POLICY_HEX));
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+            assertThat(result).isPresent();
+            assertThat(result.get().globalStatePolicyId()).isEqualTo(GLOBAL_STATE_POLICY_HEX);
+        }
+
+        @Test
+        void rejectsGlobalStateWithWrongLength() throws Exception {
+            // 10 bytes — neither 0 (absent) nor 28 (real currency symbol).
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    hex("aabbccddeeff00112233"));
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsGlobalStateAsConstr() throws Exception {
+            // Field 4 must be a ByteString, not a Constr.
+            ConstrPlutusData node = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(hex(POLICY_A_HEX)),
+                    BytesPlutusData.of(hex(POLICY_B_HEX)),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    vkeyCred(hex(GLOBAL_STATE_POLICY_HEX)));
+            String datum = serialize(node);
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+    }
+
+    // ----- Malformed inputs ------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Malformed inputs")
+    class MalformedInputs {
+
+        @Test
+        void returnsEmptyForInvalidHex() {
+            assertThat(parser.parse("invalid_hex")).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForNull() {
+            assertThat(parser.parse(null)).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForBlank() {
+            assertThat(parser.parse("  ")).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForArbitraryCbor() throws Exception {
+            // Valid CBOR but not a ConstrPlutusData — an integer literal.
+            String datum = serialize(BigIntPlutusData.of(BigInteger.valueOf(42)));
+
+            assertThat(parser.parse(datum)).isEmpty();
+        }
+
+        @Test
+        void rejectsHexExceedingMaxSize() {
+            // 4097 hex chars — over the 4096-char cap. Uses valid hex characters to prove
+            // the rejection is from the size cap, not from HexUtil failing on invalid input.
+            // This defends against library-layer DoS (deeply nested CBOR / pre-allocation bomb)
+            // by refusing to feed an oversized payload into PlutusData.deserialize at all.
+            String tooLarge = "a".repeat(4098); // even length so it's still decodable as hex
+
+            assertThat(parser.parse(tooLarge)).isEmpty();
+        }
+    }
+
+    // ----- Sentinel detection ----------------------------------------------------------
+
+    @Nested
+    @DisplayName("ParsedRegistryNode.isHeadSentinel")
+    class SentinelDetection {
+
+        @Test
+        void returnsTrueWhenKeyIsEmpty() throws Exception {
+            String datum = buildDatum(
+                    EMPTY_BYTES,
+                    hex(POLICY_A_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+            assertThat(result).isPresent();
+            assertThat(result.get().isHeadSentinel()).isTrue();
+        }
+
+        @Test
+        void returnsFalseForRealPolicy() throws Exception {
+            String datum = buildDatum(
+                    hex(POLICY_A_HEX),
+                    hex(POLICY_B_HEX),
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+            assertThat(result).isPresent();
+            assertThat(result.get().isHeadSentinel()).isFalse();
+        }
+
+        @Test
+        void returnsFalseForTailSentinelNode() throws Exception {
+            // A materialized tail sentinel node has a non-empty key (e.g. 32 bytes of 0xFF).
+            // It is not the HEAD sentinel.
+            String datum = buildDatum(
+                    TAIL_SENTINEL_32B,
+                    TAIL_SENTINEL_32B,  // self-loop / terminator — allowed by the parser
+                    vkeyCred(hex(CRED_TRANSFER_HEX)),
+                    vkeyCred(hex(CRED_THIRD_PARTY_HEX)),
+                    EMPTY_BYTES);
+
+            Optional<Cip113RegistryNodeParser.ParsedRegistryNode> result = parser.parse(datum);
+            assertThat(result).isPresent();
+            assertThat(result.get().isHeadSentinel()).isFalse();
+        }
+    }
+
+    // ----- Helpers ---------------------------------------------------------------------
+
+    /** Builds a well-formed 5-field RegistryNode datum (Constr 0) and returns its hex serialization. */
+    private static String buildDatum(byte[] key,
+                                     byte[] next,
+                                     PlutusData transferLogicScript,
+                                     PlutusData thirdPartyTransferLogicScript,
+                                     byte[] globalStateCs) throws Exception {
+        ConstrPlutusData node = ConstrPlutusData.of(0,
+                BytesPlutusData.of(key),
+                BytesPlutusData.of(next),
+                transferLogicScript,
+                thirdPartyTransferLogicScript,
+                BytesPlutusData.of(globalStateCs));
+        return serialize(node);
+    }
+
+    /** Wraps a hash in an Aiken {@code Credential.VerificationKey} Constr (alternative 0). */
+    private static PlutusData vkeyCred(byte[] hash) {
+        return ConstrPlutusData.of(0, BytesPlutusData.of(hash));
+    }
+
+    /** Wraps a hash in an Aiken {@code Credential.Script} Constr (alternative 1). */
+    private static PlutusData scriptCred(byte[] hash) {
+        return ConstrPlutusData.of(1, BytesPlutusData.of(hash));
+    }
+
+    private static String serialize(PlutusData data) throws Exception {
+        return HexUtil.encodeHexString(CborSerializationUtil.serialize(data.serialize()));
+    }
+
+    private static byte[] hex(String s) {
+        return HexUtil.decodeHexString(s);
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113ProcessorTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/processor/Cip113ProcessorTest.java
@@ -1,0 +1,232 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.processor;
+
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.plutus.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.events.EventMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNode;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.parser.Cip113RegistryNodeParser;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository.Cip113RegistryNodeRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.service.Cip113RegistryService;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressUtxoEvent;
+import com.bloxbean.cardano.yaci.store.utxo.domain.TxInputOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip113Processor")
+class Cip113ProcessorTest {
+
+    // All hash-shaped constants are exactly 56 hex chars = 28 bytes (Blake2b-224).
+    private static final String REGISTRY_NFT_POLICY_ID = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd";
+    private static final String REGISTERED_POLICY_ID = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeef";
+    private static final String TRANSFER_LOGIC = "11111111111111111111111111111111111111111111111111111111";
+    private static final String THIRD_PARTY_LOGIC = "22222222222222222222222222222222222222222222222222222222";
+    private static final String TX_HASH = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    private static final int TX_INDEX = 3;
+
+    @Mock
+    private Cip113RegistryNodeRepository repository;
+
+    private Cip113Configuration config;
+    private Cip113Processor processor;
+
+    @BeforeEach
+    void setUp() {
+        config = buildConfig(REGISTRY_NFT_POLICY_ID);
+
+        Cip113RegistryNodeParser parser = new Cip113RegistryNodeParser();
+        Cip113RegistryService registryService = new Cip113RegistryService(config);
+        processor = new Cip113Processor(config, parser, repository, registryService);
+    }
+
+    private static Cip113Configuration buildConfig(String... policyIds) {
+        Cip113Configuration cfg = org.mockito.Mockito.mock(Cip113Configuration.class,
+                org.mockito.Mockito.withSettings().lenient());
+        java.util.Set<String> policyIdSet = java.util.Set.of(policyIds);
+        org.mockito.Mockito.when(cfg.isEnabled()).thenReturn(!policyIdSet.isEmpty());
+        org.mockito.Mockito.when(cfg.getRegistryNftPolicyIdSet()).thenReturn(policyIdSet);
+        for (String id : policyIds) {
+            org.mockito.Mockito.when(cfg.isMonitoredPolicyId(id)).thenReturn(true);
+        }
+        return cfg;
+    }
+
+    @Nested
+    @DisplayName("Valid registry node UTxOs")
+    class ValidRegistryNode {
+
+        @Test
+        void savesEntityWithCorrectFields() throws Exception {
+            String datum = buildRegistryNodeDatum(REGISTERED_POLICY_ID, "ffffffffffff",
+                    TRANSFER_LOGIC, THIRD_PARTY_LOGIC, "");
+
+            processor.processTransaction(buildEvent(100L, REGISTRY_NFT_POLICY_ID, REGISTERED_POLICY_ID, datum, TX_HASH));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Cip113RegistryNode>> captor = ArgumentCaptor.forClass(List.class);
+            verify(repository).saveAll(captor.capture());
+
+            Cip113RegistryNode saved = captor.getValue().getFirst();
+            assertThat(saved.getKey()).isEqualTo(REGISTERED_POLICY_ID);
+            assertThat(saved.getSlot()).isEqualTo(100L);
+            assertThat(saved.getTxHash()).isEqualTo(TX_HASH);
+            assertThat(saved.getTxIndex()).isEqualTo(TX_INDEX);
+            assertThat(saved.getTransferLogicScript()).isEqualTo(TRANSFER_LOGIC);
+            assertThat(saved.getTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(saved.getThirdPartyTransferLogicScript()).isEqualTo(THIRD_PARTY_LOGIC);
+            assertThat(saved.getThirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(saved.getDatum()).isEqualTo(datum);
+        }
+
+        @Test
+        void savesEntityWithNullTransferLogicScript() throws Exception {
+            // transfer_logic_script encoded as empty plain bytes — parser's "absent credential"
+            // tolerance returns null, but the entry is still saved.
+            ConstrPlutusData registryNode = ConstrPlutusData.of(0,
+                    BytesPlutusData.of(HexUtil.decodeHexString(REGISTERED_POLICY_ID)),
+                    BytesPlutusData.of(HexUtil.decodeHexString("ffffffffffff")),
+                    BytesPlutusData.of(new byte[0]),  // not a Constr-wrapped credential → null
+                    ConstrPlutusData.of(0, BytesPlutusData.of(HexUtil.decodeHexString(THIRD_PARTY_LOGIC))),
+                    BytesPlutusData.of(new byte[0])   // global_state_cs absent
+            );
+            String datum = HexUtil.encodeHexString(CborSerializationUtil.serialize(registryNode.serialize()));
+
+            processor.processTransaction(buildEvent(100L, REGISTRY_NFT_POLICY_ID, REGISTERED_POLICY_ID, datum, TX_HASH));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Cip113RegistryNode>> captor = ArgumentCaptor.forClass(List.class);
+            verify(repository).saveAll(captor.capture());
+
+            Cip113RegistryNode saved = captor.getValue().getFirst();
+            // Absent credential: hash AND type are both null — they're populated together.
+            assertThat(saved.getTransferLogicScript()).isNull();
+            assertThat(saved.getTransferLogicScriptType()).isNull();
+            assertThat(saved.getThirdPartyTransferLogicScript()).isEqualTo(THIRD_PARTY_LOGIC);
+            assertThat(saved.getThirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("Skipped UTxOs")
+    class SkippedUtxos {
+
+        @Test
+        void skipsWhenNoPolicyIdsConfigured() {
+            config = buildConfig();
+            Cip113RegistryNodeParser parser = new Cip113RegistryNodeParser();
+            Cip113RegistryService registryService = new Cip113RegistryService(config);
+            processor = new Cip113Processor(config, parser, repository, registryService);
+            processor.processTransaction(buildEvent(100L, REGISTRY_NFT_POLICY_ID, REGISTERED_POLICY_ID, "d8799f40ff", TX_HASH));
+            verifyNoInteractions(repository);
+        }
+
+        @Test
+        void skipsNonMatchingPolicyId() throws Exception {
+            String otherPolicy = "9999999999999999999999999999999999999999999999999999999999";
+            String datum = buildRegistryNodeDatum(REGISTERED_POLICY_ID, "ff", TRANSFER_LOGIC, THIRD_PARTY_LOGIC, "");
+            processor.processTransaction(buildEvent(100L, otherPolicy, REGISTERED_POLICY_ID, datum, TX_HASH));
+            verifyNoInteractions(repository);
+        }
+
+        @Test
+        void skipsUtxoWithoutInlineDatum() {
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .inlineDatum(null)
+                    .amounts(List.of(Amt.builder()
+                            .policyId(REGISTRY_NFT_POLICY_ID)
+                            .unit(REGISTRY_NFT_POLICY_ID + REGISTERED_POLICY_ID)
+                            .quantity(BigInteger.ONE).build()))
+                    .build();
+
+            AddressUtxoEvent event = AddressUtxoEvent.builder()
+                    .metadata(EventMetadata.builder().slot(100L).build())
+                    .txInputOutputs(List.of(TxInputOutput.builder()
+                            .txHash(TX_HASH).outputs(List.of(utxo)).inputs(List.of()).build()))
+                    .build();
+
+            processor.processTransaction(event);
+            verifyNoInteractions(repository);
+        }
+
+        @Test
+        void skipsNftWithQuantityGreaterThanOne() throws Exception {
+            String datum = buildRegistryNodeDatum(REGISTERED_POLICY_ID, "ff", TRANSFER_LOGIC, THIRD_PARTY_LOGIC, "");
+
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .inlineDatum(datum)
+                    .amounts(List.of(Amt.builder()
+                            .policyId(REGISTRY_NFT_POLICY_ID)
+                            .unit(REGISTRY_NFT_POLICY_ID + REGISTERED_POLICY_ID)
+                            .quantity(BigInteger.TWO).build()))
+                    .build();
+
+            AddressUtxoEvent event = AddressUtxoEvent.builder()
+                    .metadata(EventMetadata.builder().slot(100L).build())
+                    .txInputOutputs(List.of(TxInputOutput.builder()
+                            .txHash(TX_HASH).outputs(List.of(utxo)).inputs(List.of()).build()))
+                    .build();
+
+            processor.processTransaction(event);
+            verifyNoInteractions(repository);
+        }
+
+        @Test
+        void skipsInvalidDatum() {
+            processor.processTransaction(buildEvent(100L, REGISTRY_NFT_POLICY_ID, REGISTERED_POLICY_ID, "deadbeef", TX_HASH));
+            verifyNoInteractions(repository);
+        }
+    }
+
+    private AddressUtxoEvent buildEvent(long slot, String nftPolicyId, String nftAssetName,
+                                         String inlineDatum, String txHash) {
+        AddressUtxo utxo = AddressUtxo.builder()
+                .txHash(txHash)
+                .txIndex(TX_INDEX)
+                .inlineDatum(inlineDatum)
+                .amounts(List.of(Amt.builder()
+                        .policyId(nftPolicyId)
+                        .unit(nftPolicyId + nftAssetName)
+                        .quantity(BigInteger.ONE).build()))
+                .build();
+
+        return AddressUtxoEvent.builder()
+                .metadata(EventMetadata.builder().slot(slot).build())
+                .txInputOutputs(List.of(TxInputOutput.builder()
+                        .txHash(txHash).outputs(List.of(utxo)).inputs(List.of()).build()))
+                .build();
+    }
+
+    private static String buildRegistryNodeDatum(String key, String next,
+                                                  String transferLogic, String thirdPartyLogic,
+                                                  String globalState) throws Exception {
+        ConstrPlutusData registryNode = ConstrPlutusData.of(0,
+                BytesPlutusData.of(HexUtil.decodeHexString(key)),
+                BytesPlutusData.of(HexUtil.decodeHexString(next)),
+                ConstrPlutusData.of(0, BytesPlutusData.of(HexUtil.decodeHexString(transferLogic))),
+                ConstrPlutusData.of(0, BytesPlutusData.of(HexUtil.decodeHexString(thirdPartyLogic))),
+                BytesPlutusData.of(globalState.isEmpty() ? new byte[0] : HexUtil.decodeHexString(globalState))
+        );
+        return HexUtil.encodeHexString(CborSerializationUtil.serialize(registryNode.serialize()));
+    }
+
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/service/Cip113RegistryServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/service/Cip113RegistryServiceTest.java
@@ -1,0 +1,87 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.service;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip113RegistryService")
+public class Cip113RegistryServiceTest {
+
+    private static final String MONITORED_POLICY = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd";
+    private static final String OTHER_POLICY = "9999999999999999999999999999999999999999999999999999999999";
+
+    private Cip113Configuration config;
+    private Cip113RegistryService service;
+
+    @BeforeEach
+    void setUp() {
+        config = buildConfig(MONITORED_POLICY);
+        service = new Cip113RegistryService(config);
+    }
+
+    public static Cip113Configuration buildConfig(String... policyIds) {
+        Cip113Configuration config = org.mockito.Mockito.mock(Cip113Configuration.class,
+                org.mockito.Mockito.withSettings().lenient());
+        java.util.Set<String> policyIdSet = java.util.Set.of(policyIds);
+        when(config.isEnabled()).thenReturn(!policyIdSet.isEmpty());
+        when(config.getRegistryNftPolicyIdSet()).thenReturn(policyIdSet);
+        for (String id : policyIds) {
+            when(config.isMonitoredPolicyId(id)).thenReturn(true);
+        }
+        return config;
+    }
+
+    @Nested
+    @DisplayName("containsRegistryNode")
+    class ContainsRegistryNode {
+
+        @Test
+        void returnsTrueForMatchingNft() {
+            AddressUtxo utxo = utxoWithAmount(MONITORED_POLICY, "deadbeef", BigInteger.ONE);
+            assertThat(service.containsRegistryNode(utxo)).isTrue();
+        }
+
+        @Test
+        void returnsFalseForNonMatchingPolicy() {
+            AddressUtxo utxo = utxoWithAmount(OTHER_POLICY, "deadbeef", BigInteger.ONE);
+            assertThat(service.containsRegistryNode(utxo)).isFalse();
+        }
+
+        @Test
+        void returnsFalseWhenQuantityNotOne() {
+            AddressUtxo utxo = utxoWithAmount(MONITORED_POLICY, "deadbeef", BigInteger.TEN);
+            assertThat(service.containsRegistryNode(utxo)).isFalse();
+        }
+
+        @Test
+        void returnsFalseWhenDisabled() {
+            config = buildConfig();
+            service = new Cip113RegistryService(config);
+            AddressUtxo utxo = utxoWithAmount(MONITORED_POLICY, "deadbeef", BigInteger.ONE);
+            assertThat(service.containsRegistryNode(utxo)).isFalse();
+        }
+
+        private AddressUtxo utxoWithAmount(String policyId, String assetName, BigInteger quantity) {
+            return AddressUtxo.builder()
+                    .amounts(List.of(Amt.builder()
+                            .policyId(policyId)
+                            .assetName(assetName)
+                            .unit(policyId + assetName)
+                            .quantity(quantity).build()))
+                    .build();
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReaderImplTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip113/storage/Cip113StorageReaderImplTest.java
@@ -1,0 +1,211 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.Cip113Configuration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.Cip113CredentialType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.model.Cip113RegistryNode;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.impl.repository.Cip113RegistryNodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.service.Cip113RegistryServiceTest.buildConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip113StorageReaderImpl")
+class Cip113StorageReaderImplTest {
+
+    private static final String MONITORED_POLICY = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd";
+
+    @Mock
+    private Cip113RegistryNodeRepository repository;
+
+    private Cip113Configuration config;
+    private Cip113StorageReaderImpl reader;
+
+    @BeforeEach
+    void setUp() {
+        config = buildConfig(MONITORED_POLICY);
+        reader = new Cip113StorageReaderImpl(repository, config);
+    }
+
+    @Nested
+    @DisplayName("findByPolicyId")
+    class FindByPolicyId {
+
+        @Test
+        void returnsDto() {
+            Cip113RegistryNode entity = Cip113RegistryNode.builder()
+                    .key("deadbeef")
+                    .transferLogicScript("script1")
+                    .transferLogicScriptType(Cip113CredentialType.SCRIPT)
+                    .thirdPartyTransferLogicScript("script2")
+                    .thirdPartyTransferLogicScriptType(Cip113CredentialType.VKEY)
+                    .globalStatePolicyId("globalState")
+                    .build();
+
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("deadbeef"))
+                    .thenReturn(Optional.of(entity));
+
+            Optional<ProgrammableTokenCip113> result = reader.findByPolicyId("deadbeef");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isEqualTo("script1");
+            assertThat(result.get().transferLogicScriptType()).isEqualTo(Cip113CredentialType.SCRIPT);
+            assertThat(result.get().thirdPartyTransferLogicScript()).isEqualTo("script2");
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+            assertThat(result.get().globalStatePolicyId()).isEqualTo("globalState");
+        }
+
+        @Test
+        void normalizesNullTransferLogicScript() {
+            // Absent transfer-logic credential: hash AND type both null on entity → both null on DTO.
+            Cip113RegistryNode entity = Cip113RegistryNode.builder()
+                    .key("deadbeef")
+                    .transferLogicScript(null)
+                    .transferLogicScriptType(null)
+                    .thirdPartyTransferLogicScript("script2")
+                    .thirdPartyTransferLogicScriptType(Cip113CredentialType.VKEY)
+                    .globalStatePolicyId(null)
+                    .build();
+
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("deadbeef"))
+                    .thenReturn(Optional.of(entity));
+
+            Optional<ProgrammableTokenCip113> result = reader.findByPolicyId("deadbeef");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isNull();
+            assertThat(result.get().transferLogicScriptType()).isNull();
+            assertThat(result.get().thirdPartyTransferLogicScript()).isEqualTo("script2");
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isEqualTo(Cip113CredentialType.VKEY);
+        }
+
+        @Test
+        void normalizesEmptyStringTransferLogicScriptToNullTypePair() {
+            // Defensive: if persistence has empty-string ('') for the hash, the type companion is
+            // also dropped to null on the DTO so the (hash, type) invariant holds out at the API.
+            Cip113RegistryNode entity = Cip113RegistryNode.builder()
+                    .key("deadbeef")
+                    .transferLogicScript("")
+                    .transferLogicScriptType(Cip113CredentialType.SCRIPT)
+                    .thirdPartyTransferLogicScript("script2")
+                    .thirdPartyTransferLogicScriptType(Cip113CredentialType.VKEY)
+                    .build();
+
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("deadbeef"))
+                    .thenReturn(Optional.of(entity));
+
+            Optional<ProgrammableTokenCip113> result = reader.findByPolicyId("deadbeef");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().transferLogicScript()).isNull();
+            assertThat(result.get().transferLogicScriptType()).isNull();
+        }
+
+        @Test
+        void normalizesEmptyStringThirdPartyTransferLogicScriptToNullTypePair() {
+            // Symmetric to the transfer-logic case above — same (hash, type) invariant must hold
+            // for the third-party credential pair.
+            Cip113RegistryNode entity = Cip113RegistryNode.builder()
+                    .key("deadbeef")
+                    .transferLogicScript("script1")
+                    .transferLogicScriptType(Cip113CredentialType.SCRIPT)
+                    .thirdPartyTransferLogicScript("")
+                    .thirdPartyTransferLogicScriptType(Cip113CredentialType.VKEY)
+                    .build();
+
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("deadbeef"))
+                    .thenReturn(Optional.of(entity));
+
+            Optional<ProgrammableTokenCip113> result = reader.findByPolicyId("deadbeef");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().thirdPartyTransferLogicScript()).isNull();
+            assertThat(result.get().thirdPartyTransferLogicScriptType()).isNull();
+            // Untouched neighbour stays populated.
+            assertThat(result.get().transferLogicScript()).isEqualTo("script1");
+        }
+
+        @Test
+        void normalizesEmptyStringGlobalStatePolicyIdToNull() {
+            // globalStatePolicyId has no companion type field, but the same empty-string-equals-null
+            // normalization applies so the API never emits a confusing "" string.
+            Cip113RegistryNode entity = Cip113RegistryNode.builder()
+                    .key("deadbeef")
+                    .transferLogicScript("script1")
+                    .transferLogicScriptType(Cip113CredentialType.SCRIPT)
+                    .globalStatePolicyId("")
+                    .build();
+
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("deadbeef"))
+                    .thenReturn(Optional.of(entity));
+
+            Optional<ProgrammableTokenCip113> result = reader.findByPolicyId("deadbeef");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().globalStatePolicyId()).isNull();
+        }
+
+        @Test
+        void returnsEmptyWhenNotFound() {
+            when(repository.findFirstByKeyOrderBySlotDescTxIndexDesc("unknown"))
+                    .thenReturn(Optional.empty());
+
+            assertThat(reader.findByPolicyId("unknown")).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyWhenDisabled() {
+            config = buildConfig();
+            reader = new Cip113StorageReaderImpl(repository, config);
+            assertThat(reader.findByPolicyId("deadbeef")).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByPolicyIds (batch)")
+    class FindByPolicyIds {
+
+        @Test
+        void returnsMappedDtos() {
+            Cip113RegistryNode entity1 = Cip113RegistryNode.builder()
+                    .key("policy1").transferLogicScript("s1")
+                    .thirdPartyTransferLogicScript("s2").globalStatePolicyId("").build();
+            Cip113RegistryNode entity2 = Cip113RegistryNode.builder()
+                    .key("policy2").transferLogicScript("s3")
+                    .thirdPartyTransferLogicScript("s4").globalStatePolicyId("gs").build();
+
+            when(repository.findLatestByKeys(List.of("policy1", "policy2")))
+                    .thenReturn(List.of(entity1, entity2));
+
+            Map<String, ProgrammableTokenCip113> result = reader.findByPolicyIds(List.of("policy1", "policy2"));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get("policy1").transferLogicScript()).isEqualTo("s1");
+            assertThat(result.get("policy2").transferLogicScript()).isEqualTo("s3");
+        }
+
+        @Test
+        void returnsEmptyMapWhenDisabled() {
+            config = buildConfig();
+            reader = new Cip113StorageReaderImpl(repository, config);
+            assertThat(reader.findByPolicyIds(List.of("policy1"))).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyMapForEmptyInput() {
+            assertThat(reader.findByPolicyIds(List.of())).isEmpty();
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/Cip26NetworkDefaultsTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/Cip26NetworkDefaultsTest.java
@@ -1,0 +1,155 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Cip26NetworkDefaults")
+class Cip26NetworkDefaultsTest {
+
+    private static final long MAINNET_MAGIC = 764824073L;
+    private static final long PREPROD_MAGIC = 1L;
+    private static final long PREVIEW_MAGIC = 2L;
+    private static final long SANCHONET_MAGIC = 4L;
+    private static final long DEVKIT_MAGIC = 42L;
+
+    private static Cip26NetworkDefaults resolve(long protocolMagic, AssetsExtStoreProperties.Cip26 cip26) {
+        StoreProperties storeProperties = new StoreProperties();
+        storeProperties.setProtocolMagic(protocolMagic);
+        AssetsExtStoreProperties assetsProps = new AssetsExtStoreProperties();
+        if (cip26 != null) {
+            assetsProps.setCip26(cip26);
+        }
+        Cip26NetworkDefaults defaults = new Cip26NetworkDefaults(storeProperties, assetsProps);
+        defaults.resolve();
+        return defaults;
+    }
+
+    @Nested
+    @DisplayName("default resolution per network (no user override)")
+    class DefaultsPerNetwork {
+
+        @Test
+        void mainnetUsesCardanoFoundation() {
+            Cip26NetworkDefaults defaults = resolve(MAINNET_MAGIC, null);
+
+            assertThat(defaults.isRegistryAvailable()).isTrue();
+            assertThat(defaults.getOrganization()).isEqualTo("cardano-foundation");
+            assertThat(defaults.getProjectName()).isEqualTo("cardano-token-registry");
+            assertThat(defaults.getMappingsFolder()).isEqualTo("mappings");
+        }
+
+        @Test
+        void preprodUsesIohkTestnetRegistry() {
+            // Regression: previously, hardcoded mainnet defaults in the starter's
+            // AssetsExtProperties.Cip26 leaked into AssetsExtStoreProperties and
+            // shadowed the per-network defaults — preprod ended up cloning
+            // cardano-foundation/cardano-token-registry instead of
+            // input-output-hk/metadata-registry-testnet.
+            Cip26NetworkDefaults defaults = resolve(PREPROD_MAGIC, null);
+
+            assertThat(defaults.isRegistryAvailable()).isTrue();
+            assertThat(defaults.getOrganization()).isEqualTo("input-output-hk");
+            assertThat(defaults.getProjectName()).isEqualTo("metadata-registry-testnet");
+            assertThat(defaults.getMappingsFolder()).isEqualTo("registry");
+        }
+
+        @Test
+        void previewHasNoRegistryAvailable() {
+            // Same regression class as preprod: with leaked mainnet defaults,
+            // preview would treat them as a "user override" and clone the
+            // mainnet registry on a preview-configured store.
+            Cip26NetworkDefaults defaults = resolve(PREVIEW_MAGIC, null);
+
+            assertThat(defaults.isRegistryAvailable()).isFalse();
+            assertThat(defaults.getOrganization()).isNull();
+            assertThat(defaults.getProjectName()).isNull();
+            assertThat(defaults.getMappingsFolder()).isNull();
+        }
+
+        @Test
+        void sanchonetHasNoRegistryAvailable() {
+            Cip26NetworkDefaults defaults = resolve(SANCHONET_MAGIC, null);
+
+            assertThat(defaults.isRegistryAvailable()).isFalse();
+            assertThat(defaults.getOrganization()).isNull();
+        }
+
+        @Test
+        void unknownNetworkHasNoRegistryAvailable() {
+            // DevKit / custom magic — no registry unless user explicitly configures one.
+            Cip26NetworkDefaults defaults = resolve(DEVKIT_MAGIC, null);
+
+            assertThat(defaults.isRegistryAvailable()).isFalse();
+            assertThat(defaults.getOrganization()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("user overrides take priority")
+    class UserOverrides {
+
+        @Test
+        void overrideWinsOnMainnet() {
+            AssetsExtStoreProperties.Cip26 cip26 = new AssetsExtStoreProperties.Cip26();
+            cip26.setGitOrganization("custom-org");
+
+            Cip26NetworkDefaults defaults = resolve(MAINNET_MAGIC, cip26);
+
+            assertThat(defaults.getOrganization()).isEqualTo("custom-org");
+            // Project / folder fall back to the mainnet defaults since the user
+            // didn't override them.
+            assertThat(defaults.getProjectName()).isEqualTo("cardano-token-registry");
+            assertThat(defaults.getMappingsFolder()).isEqualTo("mappings");
+        }
+
+        @Test
+        void overrideWinsOnPreprod() {
+            AssetsExtStoreProperties.Cip26 cip26 = new AssetsExtStoreProperties.Cip26();
+            cip26.setGitOrganization("custom-org");
+            cip26.setGitProjectName("custom-repo");
+            cip26.setGitMappingsFolder("custom-dir");
+
+            Cip26NetworkDefaults defaults = resolve(PREPROD_MAGIC, cip26);
+
+            assertThat(defaults.getOrganization()).isEqualTo("custom-org");
+            assertThat(defaults.getProjectName()).isEqualTo("custom-repo");
+            assertThat(defaults.getMappingsFolder()).isEqualTo("custom-dir");
+        }
+
+        @Test
+        void overrideEnablesRegistryOnPreview() {
+            // Operator pointing preview at a custom registry — sync becomes available.
+            AssetsExtStoreProperties.Cip26 cip26 = new AssetsExtStoreProperties.Cip26();
+            cip26.setGitOrganization("preview-tokens");
+            cip26.setGitProjectName("preview-registry");
+
+            Cip26NetworkDefaults defaults = resolve(PREVIEW_MAGIC, cip26);
+
+            assertThat(defaults.isRegistryAvailable()).isTrue();
+            assertThat(defaults.getOrganization()).isEqualTo("preview-tokens");
+            assertThat(defaults.getProjectName()).isEqualTo("preview-registry");
+            // No folder override → fallback default
+            assertThat(defaults.getMappingsFolder()).isEqualTo("mappings");
+        }
+
+        @Test
+        void blankOverrideIsIgnoredAsIfMissing() {
+            // Spring Boot relaxed binding can produce empty strings for unset
+            // properties — treat them like null so we don't accidentally clone
+            // from "https://github.com//.git".
+            AssetsExtStoreProperties.Cip26 cip26 = new AssetsExtStoreProperties.Cip26();
+            cip26.setGitOrganization("");
+            cip26.setGitProjectName("   ");
+
+            Cip26NetworkDefaults defaults = resolve(PREPROD_MAGIC, cip26);
+
+            assertThat(defaults.getOrganization()).isEqualTo("input-output-hk");
+            assertThat(defaults.getProjectName()).isEqualTo("metadata-registry-testnet");
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataServiceTest.java
@@ -1,0 +1,182 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26MetadataRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.Cip26MetadataValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip26MetadataService")
+class Cip26MetadataServiceTest {
+
+    @Mock private Cip26MetadataRepository cip26MetadataRepository;
+    @Mock private Cip26MetadataValidator cip26MetadataValidator;
+
+    private Cip26MetadataService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new Cip26MetadataService(cip26MetadataRepository, cip26MetadataValidator);
+    }
+
+    private static Mapping mapping(String subject) {
+        // Item record fields: (sequenceNumber, value, signatures)
+        return new Mapping(subject, null,
+                new Item(1, "Name", null), null, null,
+                new Item(1, "data:image/png;base64,iVBOR...", null), "policy",
+                new Item(1, "Description", null));
+    }
+
+    @Nested
+    @DisplayName("insertMapping")
+    class InsertMapping {
+
+        @Test
+        void returnsInsertedOnHappyPath() {
+            when(cip26MetadataValidator.validate(any())).thenReturn(true);
+
+            InsertOutcome outcome = service.insertMapping(
+                    mapping("subject1"), LocalDateTime.now(), "author@test.com");
+
+            assertThat(outcome).isEqualTo(InsertOutcome.INSERTED);
+            verify(cip26MetadataRepository).save(any(Cip26Metadata.class));
+        }
+
+        @Test
+        void returnsPermanentlySkippedWhenValidationFails() {
+            // The validator (yaci wrapper around cf-tokens-cip26) rejects the row.
+            // Retrying the same row will reject again — must not block the cursor.
+            when(cip26MetadataValidator.validate(any())).thenReturn(false);
+
+            InsertOutcome outcome = service.insertMapping(
+                    mapping("subject1"), LocalDateTime.now(), "author@test.com");
+
+            assertThat(outcome).isEqualTo(InsertOutcome.PERMANENTLY_SKIPPED);
+            verify(cip26MetadataRepository, never()).save(any(Cip26Metadata.class));
+        }
+
+        @Test
+        void returnsPermanentlySkippedOnNonTransientDataAccessException() {
+            // Constraint violation, value too long, encoding error. The same insert
+            // would fail again — advance past it instead of looping forever.
+            when(cip26MetadataValidator.validate(any())).thenReturn(true);
+            when(cip26MetadataRepository.save(any(Cip26Metadata.class)))
+                    .thenThrow(new DataIntegrityViolationException("value too long for column"));
+
+            InsertOutcome outcome = service.insertMapping(
+                    mapping("subject1"), LocalDateTime.now(), "author@test.com");
+
+            assertThat(outcome).isEqualTo(InsertOutcome.PERMANENTLY_SKIPPED);
+        }
+
+        @Test
+        void returnsTransientlyFailedOnTransientDataAccessException() {
+            // Lock timeout, lost connection — likely to succeed next time. Block
+            // the cursor advance so the next sync retries this entry.
+            when(cip26MetadataValidator.validate(any())).thenReturn(true);
+            when(cip26MetadataRepository.save(any(Cip26Metadata.class)))
+                    .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+            InsertOutcome outcome = service.insertMapping(
+                    mapping("subject1"), LocalDateTime.now(), "author@test.com");
+
+            assertThat(outcome).isEqualTo(InsertOutcome.TRANSIENTLY_FAILED);
+        }
+
+        @Test
+        void returnsTransientlyFailedOnUnknownException() {
+            // Conservative default: anything we can't classify is treated as
+            // transient so we don't silently drop. Recurring failures will show
+            // up in logs every sync and need human investigation.
+            when(cip26MetadataValidator.validate(any())).thenReturn(true);
+            when(cip26MetadataRepository.save(any(Cip26Metadata.class)))
+                    .thenThrow(new RuntimeException("something unexpected"));
+
+            InsertOutcome outcome = service.insertMapping(
+                    mapping("subject1"), LocalDateTime.now(), "author@test.com");
+
+            assertThat(outcome).isEqualTo(InsertOutcome.TRANSIENTLY_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("insertLogo (updates existing Cip26Metadata row)")
+    class InsertLogo {
+
+        @Test
+        void updatesLogoOnExistingRow() {
+            Cip26Metadata existing = new Cip26Metadata();
+            existing.setSubject("subject1");
+            when(cip26MetadataValidator.validateLogo(any(), any())).thenReturn(true);
+            when(cip26MetadataRepository.findById("subject1")).thenReturn(Optional.of(existing));
+
+            InsertOutcome outcome = service.insertLogo(mapping("subject1"));
+
+            assertThat(outcome).isEqualTo(InsertOutcome.INSERTED);
+            // Logo is now set on the merged-in Cip26Metadata row, not a separate TokenLogo entity.
+            verify(cip26MetadataRepository).save(existing);
+            assertThat(existing.getLogo()).isEqualTo("data:image/png;base64,iVBOR...");
+        }
+
+        @Test
+        void permanentlySkipsWhenNoMetadataRowExists() {
+            // Orphan logo — the registry has a logo file but no metadata file. Skip
+            // permanently because retrying won't change the registry's state and an
+            // orphan row would have nowhere to surface in the API.
+            when(cip26MetadataValidator.validateLogo(any(), any())).thenReturn(true);
+            when(cip26MetadataRepository.findById("subject1")).thenReturn(Optional.empty());
+
+            InsertOutcome outcome = service.insertLogo(mapping("subject1"));
+
+            assertThat(outcome).isEqualTo(InsertOutcome.PERMANENTLY_SKIPPED);
+            verify(cip26MetadataRepository, never()).save(any(Cip26Metadata.class));
+        }
+
+        @Test
+        void returnsPermanentlySkippedOnNonTransientDataAccessException() {
+            Cip26Metadata existing = new Cip26Metadata();
+            existing.setSubject("subject1");
+            when(cip26MetadataValidator.validateLogo(any(), any())).thenReturn(true);
+            when(cip26MetadataRepository.findById("subject1")).thenReturn(Optional.of(existing));
+            when(cip26MetadataRepository.save(any(Cip26Metadata.class)))
+                    .thenThrow(new DataIntegrityViolationException("logo too large"));
+
+            InsertOutcome outcome = service.insertLogo(mapping("subject1"));
+
+            assertThat(outcome).isEqualTo(InsertOutcome.PERMANENTLY_SKIPPED);
+        }
+
+        @Test
+        void returnsTransientlyFailedOnTransientDataAccessException() {
+            Cip26Metadata existing = new Cip26Metadata();
+            existing.setSubject("subject1");
+            when(cip26MetadataValidator.validateLogo(any(), any())).thenReturn(true);
+            when(cip26MetadataRepository.findById("subject1")).thenReturn(Optional.of(existing));
+            when(cip26MetadataRepository.save(any(Cip26Metadata.class)))
+                    .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+            InsertOutcome outcome = service.insertLogo(mapping("subject1"));
+
+            assertThat(outcome).isEqualTo(InsertOutcome.TRANSIENTLY_FAILED);
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncServiceTest.java
@@ -1,0 +1,345 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26SyncState;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.repository.Cip26SyncStateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip26MetadataSyncService")
+class Cip26MetadataSyncServiceTest {
+
+    private static final String OLD_HASH = "aaaa000000000000000000000000000000000000";
+    private static final String NEW_HASH = "bbbb000000000000000000000000000000000000";
+
+    @Mock private GitService gitService;
+    @Mock private Cip26MetadataService tokenMetadataService;
+    @Mock private TokenMappingService tokenMappingService;
+    @Mock private Cip26SyncStateRepository syncStateRepository;
+    @Mock private Cip26NetworkDefaults networkDefaults;
+
+    private AssetsExtStoreProperties assetsStoreProperties;
+    private Cip26MetadataSyncService service;
+
+    @BeforeEach
+    void setUp() {
+        assetsStoreProperties = new AssetsExtStoreProperties();
+        service = new Cip26MetadataSyncService(
+                gitService, tokenMetadataService, tokenMappingService,
+                syncStateRepository, networkDefaults, assetsStoreProperties);
+    }
+
+    @Nested
+    @DisplayName("initSyncStatus")
+    class InitSyncStatus {
+
+        @Test
+        void setsNotStartedWhenCip26Enabled() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_NOT_STARTED);
+            assertThat(service.getSyncStatus().isInitialSyncDone()).isFalse();
+        }
+
+        @Test
+        void setsDisabledWhenCip26Disabled() {
+            assetsStoreProperties.getCip26().setEnabled(false);
+            service.initSyncStatus();
+
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DISABLED);
+            assertThat(service.getSyncStatus().isInitialSyncDone()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("synchronizeDatabase — skipped")
+    class SyncSkipped {
+
+        @BeforeEach
+        void initStatus() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+        }
+
+        @Test
+        void skipsWhenRegistryNotAvailable() {
+            when(networkDefaults.isRegistryAvailable()).thenReturn(false);
+
+            service.synchronizeDatabase();
+
+            verifyNoInteractions(gitService);
+        }
+
+        @Test
+        void skipsProcessingWhenNoNewCommits() {
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+            when(syncStateRepository.findTopByOrderByIdDesc())
+                    .thenReturn(Optional.of(offChainState(OLD_HASH)));
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(OLD_HASH));
+
+            service.synchronizeDatabase();
+
+            verify(gitService, never()).getChangedFiles(any(), any());
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+
+        @Test
+        void setsErrorWhenCloneFails() {
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.empty());
+
+            service.synchronizeDatabase();
+
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_ERROR);
+        }
+    }
+
+    @Nested
+    @DisplayName("synchronizeDatabase — incremental sync")
+    class IncrementalSync {
+
+        @BeforeEach
+        void initStatus() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+        }
+
+        @Test
+        void processesChangedFilesAndAdvancesHash() {
+            when(syncStateRepository.findTopByOrderByIdDesc())
+                    .thenReturn(Optional.of(offChainState(OLD_HASH)));
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+
+            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
+                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/test.json")));
+
+            // filename ("test") MUST equal inner subject — the sync now skips mismatches deterministically.
+            Mapping mockMapping = new Mapping("test", null, null, null, null, null, null, null);
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mockMapping));
+            when(gitService.getAllMappingDetails(any()))
+                    .thenReturn(Map.of("test.json", new MappingUpdateDetails("author@test.com", LocalDateTime.now())));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.INSERTED);
+            when(tokenMetadataService.insertLogo(any())).thenReturn(InsertOutcome.INSERTED);
+
+            service.synchronizeDatabase();
+
+            verify(tokenMetadataService).insertMapping(any(), any(), any());
+            verify(tokenMetadataService).insertLogo(any());
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+            assertThat(service.getSyncStatus().isInitialSyncDone()).isTrue();
+        }
+
+        @Test
+        void doesNotAdvanceHashOnTransientFailure() {
+            // Transient outcomes block the cursor advance so the next sync retries.
+            when(syncStateRepository.findTopByOrderByIdDesc())
+                    .thenReturn(Optional.of(offChainState(OLD_HASH)));
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+
+            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
+                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/fail.json")));
+
+            Mapping mockMapping = new Mapping("fail", null, null, null, null, null, null, null);
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mockMapping));
+            when(gitService.getAllMappingDetails(any()))
+                    .thenReturn(Map.of("fail.json", new MappingUpdateDetails("author@test.com", LocalDateTime.now())));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.TRANSIENTLY_FAILED);
+
+            service.synchronizeDatabase();
+
+            verify(syncStateRepository, never()).save(any(Cip26SyncState.class));
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+
+        @Test
+        void advancesHashWhenAllFailuresArePermanent() {
+            // Permanent skips (validation rejected, non-transient DB errors) must
+            // NOT block the cursor — otherwise the sync loops forever on bad data.
+            when(syncStateRepository.findTopByOrderByIdDesc())
+                    .thenReturn(Optional.of(offChainState(OLD_HASH)));
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+
+            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
+                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/perm.json")));
+
+            Mapping mockMapping = new Mapping("perm", null, null, null, null, null, null, null);
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mockMapping));
+            when(gitService.getAllMappingDetails(any()))
+                    .thenReturn(Map.of("perm.json", new MappingUpdateDetails("author@test.com", LocalDateTime.now())));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.PERMANENTLY_SKIPPED);
+
+            service.synchronizeDatabase();
+
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+            verify(tokenMetadataService, never()).insertLogo(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("synchronizeDatabase — full sync")
+    class FullSync {
+
+        @BeforeEach
+        void initStatus() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+        }
+
+        @Test
+        void runsFullSyncWhenNoLastHash() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+            when(gitService.getAllMappingDetails(any())).thenReturn(Map.of());
+
+            service.synchronizeDatabase();
+
+            // Full sync doesn't call getChangedFiles — uses listFiles instead
+            verify(gitService, never()).getChangedFiles(any(), any());
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+    }
+
+    @Nested
+    @DisplayName("processMappingFiles — edge cases")
+    class ProcessMappingFiles {
+
+        @TempDir
+        Path repoDir;
+
+        @BeforeEach
+        void initStatus() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(repoDir));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+        }
+
+        @Test
+        void skipsFileWhenMappingParsingFails() throws IOException {
+            Files.writeString(repoDir.resolve("bad.json"), "{}");
+            when(gitService.getAllMappingDetails(any())).thenReturn(
+                    Map.of("bad.json", new MappingUpdateDetails("a@test.com", LocalDateTime.now())));
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.empty());
+
+            service.synchronizeDatabase();
+
+            verifyNoInteractions(tokenMetadataService);
+            // Hash still advanced — parsing failures are skipped, not errors
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+        }
+
+        @Test
+        void skipsFileWhenGitHistoryMissing() throws IOException {
+            Files.writeString(repoDir.resolve("any.json"), "{}");
+            when(gitService.getAllMappingDetails(any())).thenReturn(Map.of()); // no history resolved
+
+            // filename ("any") matches the inner subject so the new filename-vs-subject
+            // filter doesn't short-circuit before we hit the missing-history branch.
+            Mapping mapping = new Mapping("any", null, null, null, null, null, null, null);
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mapping));
+
+            service.synchronizeDatabase();
+
+            verifyNoInteractions(tokenMetadataService);
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+        }
+
+        @Test
+        void skipsLogoInsertWhenMetadataNotInserted() throws IOException {
+            Files.writeString(repoDir.resolve("exists.json"), "{}");
+            when(gitService.getAllMappingDetails(any())).thenReturn(
+                    Map.of("exists.json", new MappingUpdateDetails("a@test.com", LocalDateTime.now())));
+
+            Mapping mapping = new Mapping("exists", null, null, null, null, null, null, null);
+            when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mapping));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.PERMANENTLY_SKIPPED);
+
+            service.synchronizeDatabase();
+
+            verify(tokenMetadataService).insertMapping(any(), any(), any());
+            verify(tokenMetadataService, never()).insertLogo(any());
+        }
+
+        @Test
+        void skipsFilesWhereFilenameDoesNotMatchInnerSubject() throws IOException {
+            // Real-world QA discovery: the testnet registry has many files whose
+            // filename doesn't equal the inner `subject` field (typos, spam,
+            // legacy entries). Indexing them all would mean last-write-wins by
+            // File.listFiles() order and silently swap a token's content. We
+            // skip mismatches so each subject maps to exactly one canonical file.
+            Files.writeString(repoDir.resolve("legit.json"), "{}");
+            Files.writeString(repoDir.resolve("garbage.json"), "{}");
+            when(gitService.getAllMappingDetails(any())).thenReturn(Map.of(
+                    "legit.json", new MappingUpdateDetails("a@test.com", LocalDateTime.now()),
+                    "garbage.json", new MappingUpdateDetails("a@test.com", LocalDateTime.now())));
+
+            // legit.json's inner subject matches the filename → accepted.
+            // garbage.json's inner subject claims to be "legit" too → skipped.
+            when(tokenMappingService.parseMappings(argThat(f -> f != null && f.getName().equals("legit.json"))))
+                    .thenReturn(Optional.of(new Mapping("legit", null, null, null, null, null, null, null)));
+            when(tokenMappingService.parseMappings(argThat(f -> f != null && f.getName().equals("garbage.json"))))
+                    .thenReturn(Optional.of(new Mapping("legit", null, null, null, null, null, null, null)));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.INSERTED);
+            when(tokenMetadataService.insertLogo(any())).thenReturn(InsertOutcome.INSERTED);
+
+            service.synchronizeDatabase();
+
+            // Only the legit file's mapping made it through to insertMapping.
+            verify(tokenMetadataService, times(1)).insertMapping(any(), any(), any());
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+        }
+    }
+
+    private static Cip26SyncState offChainState(String hash) {
+        Cip26SyncState state = new Cip26SyncState();
+        state.setLastCommitHash(hash);
+        return state;
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitServiceTest.java
@@ -1,0 +1,317 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("GitService")
+class GitServiceTest {
+
+    private GitService gitService;
+
+    @TempDir
+    Path tempDir;
+
+    private Git testRepo;
+
+    @BeforeEach
+    void setUp() {
+        Cip26NetworkDefaults networkDefaults = mock(Cip26NetworkDefaults.class);
+        AssetsExtStoreProperties props = new AssetsExtStoreProperties();
+        gitService = new GitService(networkDefaults, props);
+        gitService.organization = "test-org";
+        gitService.projectName = "test-repo";
+        gitService.mappingsFolderName = "mappings";
+        gitService.gitTempFolder = tempDir.toString();
+        gitService.forceClone = false;
+    }
+
+    @AfterEach
+    void tearDown() {
+        gitService.cleanup();
+        if (testRepo != null && testRepo != gitService.git) {
+            testRepo.close();
+        }
+        testRepo = null;
+    }
+
+    private Git initRepoWithMappings() throws GitAPIException, IOException {
+        Path repoDir = tempDir.resolve("test-repo");
+        Files.createDirectories(repoDir.resolve("mappings"));
+        Git git = Git.init().setDirectory(repoDir.toFile()).call();
+
+        Files.writeString(repoDir.resolve("README.md"), "init");
+        git.add().addFilepattern("README.md").call();
+        git.commit().setMessage("initial commit")
+                .setAuthor(new PersonIdent("Init", "init@test.com"))
+                .call();
+
+        return git;
+    }
+
+    private RevCommit addMappingFile(Git git, String fileName, String content, String email) throws Exception {
+        Path mappingsDir = git.getRepository().getWorkTree().toPath().resolve("mappings");
+        Files.createDirectories(mappingsDir);
+        Files.writeString(mappingsDir.resolve(fileName), content);
+        git.add().addFilepattern("mappings/" + fileName).call();
+        return git.commit().setMessage("add " + fileName)
+                .setAuthor(new PersonIdent("Test Author", email))
+                .call();
+    }
+
+    @Nested
+    @DisplayName("getHeadCommitHash")
+    class GetHeadCommitHash {
+
+        @Test
+        void returnsHashFromRepo() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            Optional<String> result = gitService.getHeadCommitHash();
+
+            assertThat(result).isPresent();
+            assertThat(result.get()).hasSize(40).matches("[0-9a-f]+");
+        }
+
+        @Test
+        void returnsEmptyWhenGitIsNull() {
+            assertThat(gitService.getHeadCommitHash()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getChangedFiles")
+    class GetChangedFiles {
+
+        @Test
+        void returnsChangedMappingFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            String oldHash = testRepo.log().setMaxCount(1).call().iterator().next().getName();
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String newHash = testRepo.log().setMaxCount(1).call().iterator().next().getName();
+
+            List<Path> changed = gitService.getChangedFiles(oldHash, newHash);
+
+            assertThat(changed).hasSize(1);
+            assertThat(changed.getFirst().getFileName().toString()).isEqualTo("token1.json");
+        }
+
+        @Test
+        void returnsEmptyWhenGitIsNull() {
+            assertThat(gitService.getChangedFiles("aaa", "bbb")).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForUnresolvableHashes() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            assertThat(gitService.getChangedFiles("0000000000000000000000000000000000000000",
+                    "1111111111111111111111111111111111111111")).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllMappingDetails")
+    class GetAllMappingDetails {
+
+        @Test
+        @DisplayName("resolves files from root commit (single-commit repo)")
+        void resolvesFilesFromRootCommit() throws Exception {
+            // This is the exact scenario that broke before the recursive TreeWalk fix:
+            // a repo with only one commit containing mapping files.
+            Path repoDir = tempDir.resolve("test-repo");
+            Files.createDirectories(repoDir.resolve("mappings"));
+            testRepo = Git.init().setDirectory(repoDir.toFile()).call();
+
+            Files.writeString(repoDir.resolve("mappings/token1.json"), "{}");
+            Files.writeString(repoDir.resolve("mappings/token2.json"), "{}");
+            testRepo.add().addFilepattern("mappings/").call();
+            testRepo.commit().setMessage("initial with mappings")
+                    .setAuthor(new PersonIdent("Author", "author@test.com"))
+                    .call();
+            gitService.git = testRepo;
+
+            Map<String, MappingUpdateDetails> result = gitService.getAllMappingDetails(
+                    Set.of("token1.json", "token2.json"));
+
+            assertThat(result).hasSize(2);
+            assertThat(result).containsKeys("token1.json", "token2.json");
+            assertThat(result.get("token1.json").updatedBy()).isEqualTo("author@test.com");
+            assertThat(result.get("token2.json").updatedBy()).isEqualTo("author@test.com");
+        }
+
+        @Test
+        void resolvesFilesAcrossMultipleCommits() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            addMappingFile(testRepo, "token1.json", "{}", "first@test.com");
+            addMappingFile(testRepo, "token2.json", "{}", "second@test.com");
+
+            Map<String, MappingUpdateDetails> result = gitService.getAllMappingDetails(
+                    Set.of("token1.json", "token2.json"));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get("token1.json").updatedBy()).isEqualTo("first@test.com");
+            assertThat(result.get("token2.json").updatedBy()).isEqualTo("second@test.com");
+        }
+
+        @Test
+        void returnsLatestCommitForUpdatedFile() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            addMappingFile(testRepo, "token1.json", "{\"v\":1}", "old@test.com");
+            addMappingFile(testRepo, "token1.json", "{\"v\":2}", "new@test.com");
+
+            Map<String, MappingUpdateDetails> result = gitService.getAllMappingDetails(
+                    Set.of("token1.json"));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get("token1.json").updatedBy()).isEqualTo("new@test.com");
+        }
+
+        @Test
+        void returnsEmptyMapWhenGitIsNull() {
+            Map<String, MappingUpdateDetails> result = gitService.getAllMappingDetails(
+                    Set.of("token1.json"));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void ignoresUnrequestedFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+
+            Map<String, MappingUpdateDetails> result = gitService.getAllMappingDetails(
+                    Set.of("token1.json"));
+
+            assertThat(result).hasSize(1);
+            assertThat(result).containsKey("token1.json");
+            assertThat(result).doesNotContainKey("token2.json");
+        }
+    }
+
+    @Nested
+    @DisplayName("remote-URL mismatch detection")
+    class RemoteUrlMismatch {
+
+        /**
+         * Initialise an on-disk repo at {@code <tempDir>/<projectName>} with a
+         * {@code remote.origin.url} of our choosing — simulates a leftover
+         * clone from a previous run pointing at some upstream.
+         */
+        private void writeExistingCloneWithRemote(String remoteUrl) throws Exception {
+            Path repoDir = tempDir.resolve(gitService.projectName);
+            Files.createDirectories(repoDir);
+            Git initialized = Git.init().setDirectory(repoDir.toFile()).call();
+            try {
+                org.eclipse.jgit.lib.StoredConfig config = initialized.getRepository().getConfig();
+                config.setString("remote", "origin", "url", remoteUrl);
+                config.save();
+            } finally {
+                initialized.close();
+            }
+        }
+
+        @Test
+        void readExistingRemoteUrlReturnsNullWhenFolderMissing() {
+            // gitService.projectName="test-repo" not yet on disk under tempDir.
+            assertThat(gitService.readExistingRemoteUrl()).isNull();
+        }
+
+        @Test
+        void readExistingRemoteUrlReadsTheConfiguredOriginUrl() throws Exception {
+            writeExistingCloneWithRemote("https://github.com/somebody/something.git");
+
+            assertThat(gitService.readExistingRemoteUrl())
+                    .isEqualTo("https://github.com/somebody/something.git");
+        }
+
+        @Test
+        void expectedRemoteUrlBuildsFromOrgAndProject() {
+            // setUp() set organization=test-org, projectName=test-repo
+            assertThat(gitService.expectedRemoteUrl())
+                    .isEqualTo("https://github.com/test-org/test-repo.git");
+        }
+
+        @Test
+        void reasonToFreshCloneIsForceCloneWhenFlagSet() {
+            gitService.forceClone = true;
+            assertThat(gitService.reasonToFreshClone()).isEqualTo("force-clone enabled");
+        }
+
+        @Test
+        void reasonToFreshCloneFlagsNonGitFolder() throws Exception {
+            // Make a folder that exists but isn't a git repo.
+            Files.createDirectories(tempDir.resolve(gitService.projectName));
+
+            assertThat(gitService.reasonToFreshClone())
+                    .isEqualTo("folder exists but is not a git repository");
+        }
+
+        @Test
+        void reasonToFreshCloneFlagsRemoteUrlMismatch() throws Exception {
+            // The leftover-mainnet-clone-on-a-preprod-config scenario from QA.
+            writeExistingCloneWithRemote(
+                    "https://github.com/cardano-foundation/cardano-token-registry.git");
+
+            String reason = gitService.reasonToFreshClone();
+
+            assertThat(reason).startsWith("remote URL mismatch");
+            assertThat(reason).contains(
+                    "existing='https://github.com/cardano-foundation/cardano-token-registry.git'");
+            assertThat(reason).contains(
+                    "expected='https://github.com/test-org/test-repo.git'");
+        }
+
+        @Test
+        void reasonToFreshCloneIsNullWhenRemoteMatches() throws Exception {
+            writeExistingCloneWithRemote("https://github.com/test-org/test-repo.git");
+
+            assertThat(gitService.reasonToFreshClone()).isNull();
+        }
+
+        @Test
+        void reasonToFreshCloneFlagsMissingRemoteUrl() throws Exception {
+            // Repo exists, .git/config has no `remote.origin.url` at all.
+            Path repoDir = tempDir.resolve(gitService.projectName);
+            Files.createDirectories(repoDir);
+            Git.init().setDirectory(repoDir.toFile()).call().close();
+
+            String reason = gitService.reasonToFreshClone();
+
+            assertThat(reason).startsWith("remote URL mismatch");
+            assertThat(reason).contains("existing='null'");
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Cip26MetadataValidatorTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/Cip26MetadataValidatorTest.java
@@ -1,0 +1,168 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("java:S2187") // tests are in @Nested inner classes
+@DisplayName("Cip26MetadataValidator")
+class Cip26MetadataValidatorTest {
+
+    // Valid 56-char hex subject (28-byte policy ID + short asset name)
+    private static final String VALID_SUBJECT = "025146866af908340247fe4e9672d5ac7059f1e8534696b5f920c9e66362544848";
+
+    private final Cip26MetadataValidator validator = new Cip26MetadataValidator();
+
+    private static Cip26Metadata metadata(String subject, String name, String description) {
+        Cip26Metadata m = new Cip26Metadata();
+        m.setSubject(subject);
+        m.setName(name);
+        m.setDescription(description);
+        return m;
+    }
+
+    @Nested
+    @DisplayName("validate — valid metadata")
+    class ValidMetadata {
+
+        @Test
+        void acceptsMinimalValidMetadata() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Nutcoin", "A test token");
+            assertThat(validator.validate(m)).isTrue();
+        }
+
+        @Test
+        void acceptsMetadataWithAllOptionalFields() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Nutcoin", "A test token");
+            m.setTicker("NUT");
+            m.setUrl("https://example.com");
+            m.setDecimals(6L);
+            assertThat(validator.validate(m)).isTrue();
+        }
+
+        @Test
+        void acceptsZeroDecimals() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "Description");
+            m.setDecimals(0L);
+            assertThat(validator.validate(m)).isTrue();
+        }
+
+        @Test
+        void acceptsMaxDecimals() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "Description");
+            m.setDecimals(255L);
+            assertThat(validator.validate(m)).isTrue();
+        }
+
+        @Test
+        void acceptsDescriptionAtMaxLength() {
+            // CIP-26: description max 500 chars.
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "d".repeat(500));
+            assertThat(validator.validate(m)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("validate — invalid metadata")
+    class InvalidMetadata {
+
+        @Test
+        void rejectsMissingName() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, null, "A description");
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsMissingDescription() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Nutcoin", null);
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsMissingSubject() {
+            Cip26Metadata m = metadata(null, "Nutcoin", "A description");
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsNameExceedingMaxLength() {
+            String longName = "A".repeat(100);
+            Cip26Metadata m = metadata(VALID_SUBJECT, longName, "A description");
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsTickerExceedingMaxLength() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "Description");
+            m.setTicker("ABCDEFGHIJ"); // CIP-26: ticker max 9 chars
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsUrlExceedingMaxLength() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "Description");
+            m.setUrl("https://example.com/" + "a".repeat(300)); // CIP-26: url max 250 chars
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsNegativeDecimals() {
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "Description");
+            m.setDecimals(-1L);
+            assertThat(validator.validate(m)).isFalse();
+        }
+
+        @Test
+        void rejectsDescriptionExceedingMaxLength() {
+            // CIP-26 description: max 500 chars per spec; cf-tokens-cip26 enforces this
+            // via its MAX_DESCRIPTION_LENGTH constant in MetadataValidationRules.
+            Cip26Metadata m = metadata(VALID_SUBJECT, "Token", "d".repeat(501));
+            assertThat(validator.validate(m)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("validateLogo")
+    class ValidateLogo {
+
+        @Test
+        void acceptsNullLogo() {
+            assertThat(validator.validateLogo(VALID_SUBJECT, null)).isTrue();
+        }
+
+        @Test
+        void acceptsEmptyLogo() {
+            assertThat(validator.validateLogo(VALID_SUBJECT, "")).isTrue();
+        }
+
+        @Test
+        void acceptsValidBase64PngLogo() {
+            // Minimal valid PNG as base64 (1x1 transparent pixel)
+            String validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+            assertThat(validator.validateLogo(VALID_SUBJECT, validPng)).isTrue();
+        }
+
+        @Test
+        void rejectsLogoExceedingMaxSize() {
+            // CIP-26: logo max 87400 base64 chars (65 KB decoded)
+            String oversizedLogo = "A".repeat(90000);
+            assertThat(validator.validateLogo(VALID_SUBJECT, oversizedLogo)).isFalse();
+        }
+
+        @Test
+        void rejectsNonBase64Garbage() {
+            // Characters outside the base64 alphabet — Base64.getDecoder() throws IAE,
+            // which validateLogo turns into false (not a thrown exception).
+            assertThat(validator.validateLogo(VALID_SUBJECT, "this-is-not!!base64@@")).isFalse();
+        }
+
+        @Test
+        void handlesInvalidSubjectGracefully() {
+            // Invalid subject should not crash — validation may fail on subject, not logo
+            assertThat(validator.validateLogo("invalid", null)).isTrue();
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/MappingsUtilTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/util/MappingsUtilTest.java
@@ -1,0 +1,168 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Item;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pinned tests for {@link MappingsUtil#toCip26Metadata}.
+ *
+ * <p>Two paths matter most: the invalid-decimals fallback (a malformed registry entry must
+ * not crash the sync — decimals lands as {@code null} and a WARN is logged) and the {@code Item
+ * == null} pass-through (any optional field can be missing in a real registry JSON).
+ */
+@SuppressWarnings("java:S2187") // tests are in @Nested inner classes
+@DisplayName("MappingsUtil.toCip26Metadata")
+class MappingsUtilTest {
+
+    private static final String SUBJECT = "0011fbab202151eca9e9ef7680569d9419d12e51e693cb05a2edd2ed4341524b";
+    private static final String POLICY = "82018201828200581c0c0c6dc5f6b02995465ae5de8bdf07d5466932288bea414614ca7d2a";
+    private static final String UPDATED_BY = "registry-bot";
+    private static final LocalDateTime UPDATED_AT = LocalDateTime.of(2026, 5, 7, 10, 0);
+
+    private static Item item(String value) {
+        return new Item(null, value, null);
+    }
+
+    private static Mapping mapping(Item name, Item ticker, Item url, Item decimals, Item logo, Item description) {
+        return new Mapping(SUBJECT, url, name, ticker, decimals, logo, POLICY, description);
+    }
+
+    @Nested
+    @DisplayName("happy path")
+    class HappyPath {
+
+        @Test
+        void allFieldsPopulatedAreLifted() {
+            Mapping m = mapping(
+                    item("Cardano Ark Token"),
+                    item("CARK"),
+                    item("https://example.com"),
+                    item("6"),
+                    item("base64-logo-bytes"),
+                    item("Sample description"));
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getSubject()).isEqualTo(SUBJECT);
+            assertThat(out.getPolicy()).isEqualTo(POLICY);
+            assertThat(out.getName()).isEqualTo("Cardano Ark Token");
+            assertThat(out.getTicker()).isEqualTo("CARK");
+            assertThat(out.getUrl()).isEqualTo("https://example.com");
+            assertThat(out.getDecimals()).isEqualTo(6L);
+            assertThat(out.getDescription()).isEqualTo("Sample description");
+            assertThat(out.getUpdatedBy()).isEqualTo(UPDATED_BY);
+            assertThat(out.getUpdated()).isEqualTo(UPDATED_AT);
+            // The full Mapping is also stored verbatim on `properties` so the V2 wire shape can
+            // pick up signatures + sequenceNumbers without a re-parse.
+            assertThat(out.getProperties()).isSameAs(m);
+        }
+    }
+
+    @Nested
+    @DisplayName("decimals fallback")
+    class DecimalsFallback {
+
+        @Test
+        void invalidNumericResolvesToNullWithoutThrowing() {
+            // CIP-26 registry sometimes contains malformed entries; a sync run must keep
+            // going. The util parses decimals from String → Long via Long.valueOf which
+            // throws NumberFormatException on garbage; toCip26Metadata catches it and logs.
+            Mapping m = mapping(null, null, null, item("not-a-number"), null, null);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getDecimals()).isNull();
+        }
+
+        @Test
+        void absentDecimalsItemResolvesToNull() {
+            // Optional field, absent altogether — common case for tokens that don't declare decimals.
+            Mapping m = mapping(item("Token"), null, null, null, null, null);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getDecimals()).isNull();
+        }
+
+        @Test
+        void itemWithNullValueResolvesToNull() {
+            // Item present but its value is explicitly null in the JSON.
+            Mapping m = mapping(null, null, null, new Item(null, null, null), null, null);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getDecimals()).isNull();
+        }
+
+        @Test
+        void validIntegerValueIsParsed() {
+            Mapping m = mapping(null, null, null, item("8"), null, null);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getDecimals()).isEqualTo(8L);
+        }
+    }
+
+    @Nested
+    @DisplayName("null Item pass-through")
+    class NullItemPassThrough {
+
+        @Test
+        void allOptionalFieldsCanBeAbsent() {
+            // Minimal valid mapping: only subject/policy. Util must not throw.
+            Mapping m = new Mapping(SUBJECT, null, null, null, null, null, POLICY, null);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getSubject()).isEqualTo(SUBJECT);
+            assertThat(out.getPolicy()).isEqualTo(POLICY);
+            assertThat(out.getName()).isNull();
+            assertThat(out.getTicker()).isNull();
+            assertThat(out.getUrl()).isNull();
+            assertThat(out.getDecimals()).isNull();
+            assertThat(out.getDescription()).isNull();
+        }
+
+        @Test
+        void itemPresentButValueNullResolvesEachFieldToNull() {
+            Item nullValue = new Item(null, null, null);
+            Mapping m = mapping(nullValue, nullValue, nullValue, nullValue, nullValue, nullValue);
+
+            Cip26Metadata out = MappingsUtil.toCip26Metadata(m, UPDATED_BY, UPDATED_AT);
+
+            assertThat(out.getName()).isNull();
+            assertThat(out.getTicker()).isNull();
+            assertThat(out.getUrl()).isNull();
+            assertThat(out.getDecimals()).isNull();
+            assertThat(out.getDescription()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("extractLogo")
+    class ExtractLogo {
+
+        @Test
+        void returnsNullWhenLogoItemIsAbsent() {
+            Mapping m = new Mapping(SUBJECT, null, null, null, null, null, POLICY, null);
+
+            assertThat(MappingsUtil.extractLogo(m)).isNull();
+        }
+
+        @Test
+        void returnsLogoValueWhenPresent() {
+            Mapping m = mapping(null, null, null, null, item("base64-logo"), null);
+
+            assertThat(MappingsUtil.extractLogo(m)).isEqualTo("base64-logo");
+        }
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/AssetTypeTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/model/AssetTypeTest.java
@@ -1,0 +1,119 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("java:S2187") // tests are in @Nested inner classes
+class AssetTypeTest {
+
+    private static final String POLICY_ID_56 = "f6f49b186751e61f1fb8c64e7504e771f968cea9f4d11f5222b169e3";
+    private static final String ASSET_NAME_HEX = "744d494e";
+
+    @Nested
+    @DisplayName("fromUnit")
+    class FromUnit {
+
+        @Nested
+        @DisplayName("lovelace / empty handling")
+        class LovelaceAndEmpty {
+
+            @Test
+            void lovelace_returnsPolicyEmptyAndAssetLovelace() {
+                AssetType result = AssetType.fromUnit("lovelace");
+
+                assertThat(result.policyId()).isEmpty();
+                assertThat(result.assetName()).isEqualTo("lovelace");
+            }
+
+            @Test
+            void lovelaceUpperCase_returnsSameAsLovelace() {
+                AssetType result = AssetType.fromUnit("LOVELACE");
+
+                assertThat(result.policyId()).isEmpty();
+                assertThat(result.assetName()).isEqualTo("lovelace");
+            }
+
+            @Test
+            void emptyString_returnsSameAsLovelace() {
+                AssetType result = AssetType.fromUnit("  ");
+
+                assertThat(result.policyId()).isEmpty();
+                assertThat(result.assetName()).isEqualTo("lovelace");
+            }
+        }
+
+        @Nested
+        @DisplayName("valid units (policy + asset name)")
+        class ValidUnits {
+
+            @Test
+            void unitLongerThan56Chars_splitsPolicyAndAssetName() {
+                String unit = POLICY_ID_56 + ASSET_NAME_HEX;
+
+                AssetType result = AssetType.fromUnit(unit);
+
+                assertThat(result.policyId()).isEqualTo(POLICY_ID_56);
+                assertThat(result.assetName()).isEqualTo(ASSET_NAME_HEX);
+            }
+
+            @Test
+            void unitExactly56Chars_returnsPolicyWithEmptyAssetName() {
+                AssetType result = AssetType.fromUnit(POLICY_ID_56);
+
+                assertThat(result.policyId()).isEqualTo(POLICY_ID_56);
+                assertThat(result.assetName()).isEmpty();
+            }
+
+            @Test
+            void unitWithDots_removesDotsBeforeParsing() {
+                String unit = POLICY_ID_56 + "." + ASSET_NAME_HEX;
+
+                AssetType result = AssetType.fromUnit(unit);
+
+                assertThat(result.policyId()).isEqualTo(POLICY_ID_56);
+                assertThat(result.assetName()).isEqualTo(ASSET_NAME_HEX);
+            }
+        }
+
+        @Nested
+        @DisplayName("short / invalid units")
+        class ShortUnits {
+
+            @ParameterizedTest(name = "short unit \"{0}\" does not throw")
+            @ValueSource(strings = {"abcdef", "a", "nonexistent"})
+            void shortUnit_doesNotThrow_andUsesInputAsPolicyId(String unit) {
+                AssetType result = AssetType.fromUnit(unit);
+
+                assertThat(result.policyId()).isEqualTo(unit);
+                assertThat(result.assetName()).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("toUnit")
+    class ToUnit {
+
+        @Test
+        void concatenatesPolicyAndAssetName() {
+            AssetType assetType = new AssetType(POLICY_ID_56, ASSET_NAME_HEX);
+
+            assertThat(assetType.toUnit()).isEqualTo(POLICY_ID_56 + ASSET_NAME_HEX);
+        }
+
+        @Test
+        void roundTripsWithFromUnit() {
+            String original = POLICY_ID_56 + ASSET_NAME_HEX;
+
+            AssetType result = AssetType.fromUnit(original);
+
+            assertThat(result.toUnit()).isEqualTo(original);
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/parser/Cip68DatumParserTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/parser/Cip68DatumParserTest.java
@@ -1,0 +1,317 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.parser;
+
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.plutus.spec.*;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Cip68DatumParserTest {
+
+    private Cip68DatumParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new Cip68DatumParser();
+    }
+
+    @Nested
+    class ParseValidDatum {
+
+        @Test
+        void shouldParseAllFields() throws Exception {
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("TestToken"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("A test token"));
+            properties.put(BytesPlutusData.of("ticker"), BytesPlutusData.of("TT"));
+            properties.put(BytesPlutusData.of("url"), BytesPlutusData.of("https://example.com"));
+            properties.put(BytesPlutusData.of("decimals"), BigIntPlutusData.of(6));
+            properties.put(BytesPlutusData.of("logo"), BytesPlutusData.of("iVBORw0KGgo="));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0,
+                    properties,
+                    BigIntPlutusData.of(1));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            ParsedCip68Datum metadata = result.get();
+            assertThat(metadata.name()).isEqualTo("TestToken");
+            assertThat(metadata.description()).isEqualTo("A test token");
+            assertThat(metadata.ticker()).isEqualTo("TT");
+            assertThat(metadata.url()).isEqualTo("https://example.com");
+            assertThat(metadata.decimals()).isEqualTo(6L);
+            assertThat(metadata.logo()).isEqualTo("iVBORw0KGgo=");
+            assertThat(metadata.version()).isEqualTo(1L);
+        }
+
+        @Test
+        void shouldParseWithOnlyRequiredFields() throws Exception {
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("MinToken"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Minimal"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0,
+                    properties,
+                    BigIntPlutusData.of(2));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            ParsedCip68Datum metadata = result.get();
+            assertThat(metadata.name()).isEqualTo("MinToken");
+            assertThat(metadata.description()).isEqualTo("Minimal");
+            assertThat(metadata.ticker()).isNull();
+            assertThat(metadata.url()).isNull();
+            assertThat(metadata.decimals()).isNull();
+            assertThat(metadata.logo()).isNull();
+            assertThat(metadata.version()).isEqualTo(2L);
+        }
+
+        @Test
+        void shouldStripNullCharactersFromStrings() throws Exception {
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("Test\0Token"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("A\0desc"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0,
+                    properties,
+                    BigIntPlutusData.of(1));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().name()).isEqualTo("TestToken");
+            assertThat(result.get().description()).isEqualTo("Adesc");
+        }
+
+        @Test
+        void shouldExtractNftFieldsImageAndMediaType() throws Exception {
+            // CIP-68 NFT-shape datum (label 222) — exercises the image / mediaType code path.
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("KhonsuMoon #4651"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("A celestial collectible"));
+            properties.put(BytesPlutusData.of("image"), BytesPlutusData.of("ipfs://QmMain"));
+            properties.put(BytesPlutusData.of("mediaType"), BytesPlutusData.of("image/png"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties, BigIntPlutusData.of(1));
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().image()).isEqualTo("ipfs://QmMain");
+            assertThat(result.get().mediaType()).isEqualTo("image/png");
+        }
+
+        @Test
+        void shouldHandleChunkedImageUriAsListOfStrings() throws Exception {
+            // CIP-25 inheritance: image may be split into a list of byte-string chunks
+            // when the URI exceeds Cardano's 64-byte raw-string limit. The parser should
+            // concatenate them.
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("ChunkedToken"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Has a long IPFS hash"));
+
+            ListPlutusData chunks = new ListPlutusData();
+            chunks.add(BytesPlutusData.of("ipfs://QmFirstChunk"));
+            chunks.add(BytesPlutusData.of("AndSecondChunkConcat"));
+            properties.put(BytesPlutusData.of("image"), chunks);
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties, BigIntPlutusData.of(1));
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().image()).isEqualTo("ipfs://QmFirstChunkAndSecondChunkConcat");
+        }
+
+        @Test
+        void shouldExtractFilesArrayIntoPropertiesJson() throws Exception {
+            // files[]: list of {name, mediaType, src} maps. Ends up under
+            // properties["files"] in the JSONB column.
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("MultiMediaNft"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Has multiple files"));
+
+            MapPlutusData file1 = new MapPlutusData();
+            file1.put(BytesPlutusData.of("name"), BytesPlutusData.of("main"));
+            file1.put(BytesPlutusData.of("mediaType"), BytesPlutusData.of("image/png"));
+            file1.put(BytesPlutusData.of("src"), BytesPlutusData.of("ipfs://QmMain"));
+
+            MapPlutusData file2 = new MapPlutusData();
+            file2.put(BytesPlutusData.of("name"), BytesPlutusData.of("hires"));
+            file2.put(BytesPlutusData.of("mediaType"), BytesPlutusData.of("image/png"));
+            file2.put(BytesPlutusData.of("src"), BytesPlutusData.of("ipfs://QmHires"));
+
+            ListPlutusData filesList = new ListPlutusData();
+            filesList.add(file1);
+            filesList.add(file2);
+            properties.put(BytesPlutusData.of("files"), filesList);
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties, BigIntPlutusData.of(1));
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().properties()).isNotNull();
+            assertThat(result.get().properties()).containsKey("files");
+            @SuppressWarnings("unchecked")
+            java.util.List<java.util.Map<String, Object>> files =
+                    (java.util.List<java.util.Map<String, Object>>) result.get().properties().get("files");
+            assertThat(files).hasSize(2);
+            assertThat(files.get(0)).containsEntry("name", "main")
+                    .containsEntry("mediaType", "image/png")
+                    .containsEntry("src", "ipfs://QmMain");
+            assertThat(files.get(1)).containsEntry("name", "hires");
+        }
+
+        @Test
+        void shouldCaptureUnknownPropertiesUnderAdditionalProperties() throws Exception {
+            // Project-specific keys (attributes, traits) should land under
+            // properties["additional_properties"], not be silently dropped.
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("AttributeToken"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Has custom traits"));
+            properties.put(BytesPlutusData.of("rarity"), BytesPlutusData.of("legendary"));
+            properties.put(BytesPlutusData.of("level"), BigIntPlutusData.of(42));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties, BigIntPlutusData.of(1));
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().properties()).isNotNull();
+            assertThat(result.get().properties()).containsKey("additional_properties");
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> additional =
+                    (java.util.Map<String, Object>) result.get().properties().get("additional_properties");
+            assertThat(additional).containsEntry("rarity", "legendary");
+            assertThat(additional.get("level")).isEqualTo(java.math.BigInteger.valueOf(42));
+        }
+
+        @Test
+        void shouldReturnNullPropertiesWhenNoFilesNoAdditionalProperties() throws Exception {
+            // Pure FT-shape datum with only well-known keys → properties JSONB is null
+            // (no need to materialise an empty wrapper).
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("PureFt"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Just an FT"));
+            properties.put(BytesPlutusData.of("ticker"), BytesPlutusData.of("PFT"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties, BigIntPlutusData.of(1));
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().properties()).isNull();
+        }
+    }
+
+    @Nested
+    class ParseInvalidDatum {
+
+        @Test
+        void shouldReturnEmptyForNullInput() {
+            Optional<ParsedCip68Datum> result = parser.parse(null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyForEmptyString() {
+            Optional<ParsedCip68Datum> result = parser.parse("");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyForBlankString() {
+            Optional<ParsedCip68Datum> result = parser.parse("   ");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyForInvalidHex() {
+            Optional<ParsedCip68Datum> result = parser.parse("not-valid-hex");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenNotConstrPlutusData() throws Exception {
+            MapPlutusData mapData = new MapPlutusData();
+            mapData.put(BytesPlutusData.of("name"), BytesPlutusData.of("Test"));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(mapData.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenDataListTooSmall() throws Exception {
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("Test"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0, properties);
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenFirstElementIsNotMap() throws Exception {
+            ConstrPlutusData datum = ConstrPlutusData.of(0,
+                    BytesPlutusData.of("not-a-map"),
+                    BigIntPlutusData.of(1));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenVersionIsNotBigInt() throws Exception {
+            MapPlutusData properties = new MapPlutusData();
+            properties.put(BytesPlutusData.of("name"), BytesPlutusData.of("Test"));
+            properties.put(BytesPlutusData.of("description"), BytesPlutusData.of("Desc"));
+
+            ConstrPlutusData datum = ConstrPlutusData.of(0,
+                    properties,
+                    BytesPlutusData.of("not-a-number"));
+
+            String hexDatum = HexUtil.encodeHexString(CborSerializationUtil.serialize(datum.serialize()));
+
+            Optional<ParsedCip68Datum> result = parser.parse(hexDatum);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68ProcessorTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/processor/Cip68ProcessorTest.java
@@ -1,0 +1,271 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.processor;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.events.EventMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.Cip68Constants;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.parser.Cip68DatumParser;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository.Cip68MetadataRepository;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service.Cip68TokenService;
+import com.bloxbean.cardano.yaci.store.utxo.domain.AddressUtxoEvent;
+import com.bloxbean.cardano.yaci.store.utxo.domain.TxInputOutput;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip68Processor")
+class Cip68ProcessorTest {
+
+    private static final String POLICY_ID = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd";
+    private static final String REF_NFT_ASSET_NAME = "000643b0464c4454";
+    private static final String TX_HASH = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    private static final int TX_INDEX = 3;
+
+    @Mock
+    private Cip68TokenService cip68TokenService;
+
+    @Mock
+    private Cip68DatumParser cip68DatumParser;
+
+    @Mock
+    private Cip68MetadataRepository metadataReferenceNftRepository;
+
+    @InjectMocks
+    private Cip68Processor processor;
+
+    @Nested
+    @DisplayName("Valid reference NFT UTxOs")
+    class ValidReferenceNft {
+
+        @Test
+        void savesEntityWithCorrectFields() {
+            String datum = "d8799fa34446756e6e";
+            ParsedCip68Datum metadata = new ParsedCip68Datum(
+                    6L, "A test token", "logo", "TestToken", "TST", "https://test.com", 1L, null, null, null);
+
+            Amt refNftAmt = Amt.builder()
+                    .unit(POLICY_ID + REF_NFT_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .txIndex(TX_INDEX)
+                    .inlineDatum(datum)
+                    .amounts(List.of(refNftAmt))
+                    .build();
+
+            when(cip68TokenService.extractReferenceNft(utxo)).thenReturn(Optional.of(refNftAmt));
+            when(cip68DatumParser.parse(datum)).thenReturn(Optional.of(metadata));
+            when(cip68TokenService.isValidMetadata(metadata)).thenReturn(true);
+
+            processor.processTransaction(buildEvent(100L, utxo));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Iterable<Cip68Metadata>> captor = ArgumentCaptor.forClass(Iterable.class);
+            verify(metadataReferenceNftRepository).saveAll(captor.capture());
+
+            Cip68Metadata saved = captor.getValue().iterator().next();
+            assertThat(saved.getPolicyId()).isEqualTo(POLICY_ID);
+            assertThat(saved.getAssetName()).isEqualTo(REF_NFT_ASSET_NAME);
+            assertThat(saved.getSlot()).isEqualTo(100L);
+            assertThat(saved.getTxHash()).isEqualTo(TX_HASH);
+            assertThat(saved.getTxIndex()).isEqualTo(TX_INDEX);
+            assertThat(saved.getName()).isEqualTo("TestToken");
+            assertThat(saved.getDescription()).isEqualTo("A test token");
+            assertThat(saved.getTicker()).isEqualTo("TST");
+            assertThat(saved.getDecimals()).isEqualTo(6);
+            assertThat(saved.getDatum()).isEqualTo(datum);
+        }
+    }
+
+    @Nested
+    @DisplayName("Skipped UTxOs")
+    class SkippedUtxos {
+
+        @Test
+        void skipsWhenNoReferenceNft() {
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .amounts(List.of(Amt.builder()
+                            .unit(POLICY_ID + "deadbeef")
+                            .quantity(BigInteger.TEN)
+                            .build()))
+                    .build();
+
+            when(cip68TokenService.extractReferenceNft(utxo)).thenReturn(Optional.empty());
+
+            processor.processTransaction(buildEvent(100L, utxo));
+
+            verifyNoInteractions(metadataReferenceNftRepository);
+        }
+
+        @Test
+        void skipsWhenDatumParsingFails() {
+            String datum = "invalid";
+            Amt refNftAmt = Amt.builder()
+                    .unit(POLICY_ID + REF_NFT_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .txIndex(TX_INDEX)
+                    .inlineDatum(datum)
+                    .amounts(List.of(refNftAmt))
+                    .build();
+
+            when(cip68TokenService.extractReferenceNft(utxo)).thenReturn(Optional.of(refNftAmt));
+            when(cip68DatumParser.parse(datum)).thenReturn(Optional.empty());
+
+            processor.processTransaction(buildEvent(100L, utxo));
+
+            verifyNoInteractions(metadataReferenceNftRepository);
+        }
+
+        @Test
+        void skipsWhenMetadataInvalid() {
+            String datum = "d8799fa34446756e6e";
+            ParsedCip68Datum metadata = new ParsedCip68Datum(
+                    null, null, null, null, null, null, null, null, null, null);
+
+            Amt refNftAmt = Amt.builder()
+                    .unit(POLICY_ID + REF_NFT_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+
+            AddressUtxo utxo = AddressUtxo.builder()
+                    .txHash(TX_HASH)
+                    .txIndex(TX_INDEX)
+                    .inlineDatum(datum)
+                    .amounts(List.of(refNftAmt))
+                    .build();
+
+            when(cip68TokenService.extractReferenceNft(utxo)).thenReturn(Optional.of(refNftAmt));
+            when(cip68DatumParser.parse(datum)).thenReturn(Optional.of(metadata));
+            when(cip68TokenService.isValidMetadata(metadata)).thenReturn(false);
+
+            processor.processTransaction(buildEvent(100L, utxo));
+
+            verifyNoInteractions(metadataReferenceNftRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("Label classification (cross-output detection)")
+    class LabelClassification {
+
+        // Common token base name "fdt" (== 464c4454 hex). The reference NFT and the
+        // user-token share this base name and only differ by the 4-byte prefix.
+        private static final String BASE_NAME_HEX = "464c4454";
+        private static final String FT_USER_TOKEN_NAME  = "0014df10" + BASE_NAME_HEX;
+        private static final String NFT_USER_TOKEN_NAME = "000de140" + BASE_NAME_HEX;
+        private static final String RFT_USER_TOKEN_NAME = "001bc280" + BASE_NAME_HEX;
+
+        @Test
+        void labelsAsFtWhenCoMintedWithFungibleUserToken() {
+            verifyLabel(FT_USER_TOKEN_NAME, Cip68Constants.LABEL_FT);
+        }
+
+        @Test
+        void labelsAsNftWhenCoMintedWithNftUserToken() {
+            verifyLabel(NFT_USER_TOKEN_NAME, Cip68Constants.LABEL_NFT);
+        }
+
+        @Test
+        void labelsAsRftWhenCoMintedWithRftUserToken() {
+            verifyLabel(RFT_USER_TOKEN_NAME, Cip68Constants.LABEL_RFT);
+        }
+
+        @Test
+        void fallsBackToFtWhenNoCoMintedUserToken() {
+            // Orphan reference NFT: only 000643b0 in the tx, no user-token prefix.
+            String datum = "d8799fa34446756e6e";
+            ParsedCip68Datum metadata = new ParsedCip68Datum(
+                    6L, "Orphan", null, "Orphan", "ORPH", null, 1L, null, null, null);
+            Amt refNftAmt = refNftAmount();
+            AddressUtxo refNftUtxo = AddressUtxo.builder()
+                    .txHash(TX_HASH).inlineDatum(datum).amounts(List.of(refNftAmt)).build();
+
+            when(cip68TokenService.extractReferenceNft(refNftUtxo)).thenReturn(Optional.of(refNftAmt));
+            when(cip68DatumParser.parse(datum)).thenReturn(Optional.of(metadata));
+            when(cip68TokenService.isValidMetadata(metadata)).thenReturn(true);
+
+            processor.processTransaction(buildEvent(100L, List.of(refNftUtxo)));
+
+            assertThat(captureSavedLabel()).isEqualTo(Cip68Constants.LABEL_FT);
+        }
+
+        // Helper: build a tx with the ref-NFT output + a co-minted user-token output
+        // having the given asset name; assert the saved row's label matches expected.
+        private void verifyLabel(String coMintedAssetName, int expectedLabel) {
+            String datum = "d8799fa34446756e6e";
+            ParsedCip68Datum metadata = new ParsedCip68Datum(
+                    6L, "Test", null, "Test", "TST", null, 1L, null, null, null);
+
+            Amt refNftAmt = refNftAmount();
+            AddressUtxo refNftUtxo = AddressUtxo.builder()
+                    .txHash(TX_HASH).inlineDatum(datum).amounts(List.of(refNftAmt)).build();
+
+            // Co-minted user token in another output of the same tx
+            Amt userTokenAmt = Amt.builder()
+                    .unit(POLICY_ID + coMintedAssetName)
+                    .quantity(BigInteger.ONE)
+                    .build();
+            AddressUtxo userTokenUtxo = AddressUtxo.builder()
+                    .txHash(TX_HASH).amounts(List.of(userTokenAmt)).build();
+
+            when(cip68TokenService.extractReferenceNft(refNftUtxo)).thenReturn(Optional.of(refNftAmt));
+            when(cip68TokenService.extractReferenceNft(userTokenUtxo)).thenReturn(Optional.empty());
+            when(cip68DatumParser.parse(datum)).thenReturn(Optional.of(metadata));
+            when(cip68TokenService.isValidMetadata(metadata)).thenReturn(true);
+
+            // Both outputs in the same tx — that's how cross-output detection sees them.
+            processor.processTransaction(buildEvent(100L, List.of(refNftUtxo, userTokenUtxo)));
+
+            assertThat(captureSavedLabel()).isEqualTo(expectedLabel);
+        }
+
+        private Amt refNftAmount() {
+            return Amt.builder()
+                    .unit(POLICY_ID + REF_NFT_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+        }
+
+        private int captureSavedLabel() {
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Iterable<Cip68Metadata>> captor = ArgumentCaptor.forClass(Iterable.class);
+            verify(metadataReferenceNftRepository).saveAll(captor.capture());
+            return captor.getValue().iterator().next().getLabel();
+        }
+    }
+
+    private AddressUtxoEvent buildEvent(long slot, AddressUtxo utxo) {
+        return buildEvent(slot, List.of(utxo));
+    }
+
+    private AddressUtxoEvent buildEvent(long slot, List<AddressUtxo> outputs) {
+        return AddressUtxoEvent.builder()
+                .metadata(EventMetadata.builder().slot(slot).build())
+                .txInputOutputs(List.of(TxInputOutput.builder().outputs(outputs).build()))
+                .build();
+    }
+
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/service/Cip68TokenServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip68/service/Cip68TokenServiceTest.java
@@ -1,0 +1,364 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.service;
+
+import com.bloxbean.cardano.yaci.store.common.domain.AddressUtxo;
+import com.bloxbean.cardano.yaci.store.common.domain.Amt;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.AssetType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.ParsedCip68Datum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.model.Cip68Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.impl.repository.Cip68MetadataRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S2187")
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Cip68TokenService")
+class Cip68TokenServiceTest {
+
+    private static final String POLICY_ID = "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e";
+    private static final String BASE_NAME = "464c4454";  // "FLDT" in hex
+    private static final String FT_ASSET_NAME = "0014df10" + BASE_NAME;     // fungible token prefix + name
+    private static final String REF_ASSET_NAME = "000643b0" + BASE_NAME;    // reference NFT prefix + name
+    private static final String NFT_ASSET_NAME = "000de140" + BASE_NAME;    // NFT prefix + name
+    private static final String FT_SUBJECT = POLICY_ID + FT_ASSET_NAME;
+    private static final String REF_SUBJECT = POLICY_ID + REF_ASSET_NAME;
+
+    @Mock
+    private Cip68MetadataRepository repository;
+
+    @InjectMocks
+    private Cip68TokenService service;
+
+    @Nested
+    @DisplayName("getReferenceNftSubject")
+    class GetReferenceNftSubject {
+
+        @Test
+        void convertsFungibleTokenSubjectToReferenceNft() {
+            Optional<AssetType> result = service.getReferenceNftSubject(FT_SUBJECT);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().policyId()).isEqualTo(POLICY_ID);
+            assertThat(result.get().assetName()).isEqualTo(REF_ASSET_NAME);
+        }
+
+        @Test
+        void preservesPolicyId() {
+            Optional<AssetType> result = service.getReferenceNftSubject(FT_SUBJECT);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().policyId()).isEqualTo(POLICY_ID);
+        }
+
+        @Test
+        void swapsPrefixButKeepsBaseName() {
+            Optional<AssetType> result = service.getReferenceNftSubject(FT_SUBJECT);
+
+            assertThat(result).isPresent();
+            // Base name after the 8-char prefix should be identical
+            assertThat(result.get().assetName().substring(8)).isEqualTo(BASE_NAME);
+            // Prefix should be reference NFT, not fungible token
+            assertThat(result.get().assetName().substring(0, 8)).isEqualTo("000643b0");
+        }
+
+        @Test
+        void returnsEmptyForReferenceNftSubject() {
+            // Reference NFT prefix (000643b0) is not a fungible token — should return empty
+            Optional<AssetType> result = service.getReferenceNftSubject(REF_SUBJECT);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForNftSubject() {
+            String nftSubject = POLICY_ID + NFT_ASSET_NAME;
+            Optional<AssetType> result = service.getReferenceNftSubject(nftSubject);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForPolicyOnlySubject() {
+            Optional<AssetType> result = service.getReferenceNftSubject(POLICY_ID);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForLovelace() {
+            Optional<AssetType> result = service.getReferenceNftSubject("lovelace");
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void roundTripsWithToUnit() {
+            Optional<AssetType> refNft = service.getReferenceNftSubject(FT_SUBJECT);
+
+            assertThat(refNft).isPresent();
+            assertThat(refNft.get().toUnit()).isEqualTo(POLICY_ID + REF_ASSET_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("isReferenceNft")
+    class IsReferenceNft {
+
+        @Test
+        void returnsTrueForReferenceNftWithQuantityOne() {
+            Amt amt = Amt.builder()
+                    .unit(POLICY_ID + REF_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+            assertThat(service.isReferenceNft(amt)).isTrue();
+        }
+
+        @Test
+        void returnsFalseForFungibleTokenPrefix() {
+            Amt amt = Amt.builder()
+                    .unit(FT_SUBJECT)
+                    .quantity(BigInteger.ONE)
+                    .build();
+            assertThat(service.isReferenceNft(amt)).isFalse();
+        }
+
+        @Test
+        void returnsFalseForQuantityGreaterThanOne() {
+            Amt amt = Amt.builder()
+                    .unit(POLICY_ID + REF_ASSET_NAME)
+                    .quantity(BigInteger.TWO)
+                    .build();
+            assertThat(service.isReferenceNft(amt)).isFalse();
+        }
+
+        @Test
+        void returnsFalseForNftPrefix() {
+            Amt amt = Amt.builder()
+                    .unit(POLICY_ID + NFT_ASSET_NAME)
+                    .quantity(BigInteger.ONE)
+                    .build();
+            assertThat(service.isReferenceNft(amt)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("containsReferenceNft / extractReferenceNft")
+    class ContainsAndExtract {
+
+        @Test
+        void containsReturnsTrueWhenReferenceNftPresent() {
+            AddressUtxo utxo = utxoWith(POLICY_ID + REF_ASSET_NAME, BigInteger.ONE);
+            assertThat(service.containsReferenceNft(utxo)).isTrue();
+        }
+
+        @Test
+        void containsReturnsFalseWhenNoReferenceNft() {
+            AddressUtxo utxo = utxoWith(FT_SUBJECT, BigInteger.ONE);
+            assertThat(service.containsReferenceNft(utxo)).isFalse();
+        }
+
+        @Test
+        void extractReturnsAmtWhenPresent() {
+            AddressUtxo utxo = utxoWith(POLICY_ID + REF_ASSET_NAME, BigInteger.ONE);
+            Optional<Amt> result = service.extractReferenceNft(utxo);
+            assertThat(result).isPresent();
+            assertThat(result.get().getUnit()).isEqualTo(POLICY_ID + REF_ASSET_NAME);
+        }
+
+        @Test
+        void extractReturnsEmptyWhenAbsent() {
+            AddressUtxo utxo = utxoWith(FT_SUBJECT, BigInteger.ONE);
+            assertThat(service.extractReferenceNft(utxo)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("isValidMetadata")
+    class IsValidMetadata {
+
+        @Test
+        void validWhenNameAndDescriptionPresent() {
+            ParsedCip68Datum m = new ParsedCip68Datum(null, "desc", null, "name", null, null, null, null, null, null);
+            assertThat(service.isValidMetadata(m)).isTrue();
+        }
+
+        @Test
+        void invalidWhenNameMissing() {
+            ParsedCip68Datum m = new ParsedCip68Datum(null, "desc", null, null, null, null, null, null, null, null);
+            assertThat(service.isValidMetadata(m)).isFalse();
+        }
+
+        @Test
+        void invalidWhenDescriptionMissing() {
+            ParsedCip68Datum m = new ParsedCip68Datum(null, null, null, "name", null, null, null, null, null, null);
+            assertThat(service.isValidMetadata(m)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSubjects (batch)")
+    class FindSubjects {
+
+        private static final String POLICY_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        private static final String POLICY_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        private static final String REF_NAME_A = "000643b0aaaa"; // reference NFT asset name
+        private static final String REF_NAME_B = "000643b0bbbb";
+
+        @Test
+        void returnsEmptyMapForEmptyInput() {
+            Map<String, FungibleTokenMetadata> result = service.findSubjects(List.of(), List.of());
+
+            assertThat(result).isEmpty();
+            verifyNoInteractions(repository);
+        }
+
+        @Test
+        void issuesSingleBatchQuery() {
+            List<AssetType> keys = List.of(
+                    new AssetType(POLICY_A, REF_NAME_A),
+                    new AssetType(POLICY_B, REF_NAME_B));
+            when(repository.findLatestByConcatenatedKeys(anyCollection()))
+                    .thenReturn(List.of());
+
+            service.findSubjects(keys, List.of());
+
+            verify(repository).findLatestByConcatenatedKeys(
+                    List.of(POLICY_A + REF_NAME_A, POLICY_B + REF_NAME_B));
+        }
+
+        @Test
+        void mapsResultsKeyedByRefNftSubject() {
+            List<AssetType> keys = List.of(new AssetType(POLICY_A, REF_NAME_A));
+            Cip68Metadata row = Cip68Metadata.builder()
+                    .policyId(POLICY_A).assetName(REF_NAME_A).slot(100L).label(333)
+                    .name("TokenA").description("desc A").ticker("TKA").decimals(6L).version(1L).build();
+            when(repository.findLatestByConcatenatedKeys(anyCollection()))
+                    .thenReturn(List.of(row));
+
+            Map<String, FungibleTokenMetadata> result = service.findSubjects(keys, List.of());
+
+            assertThat(result).hasSize(1);
+            FungibleTokenMetadata md = result.get(POLICY_A + REF_NAME_A);
+            assertThat(md).isNotNull();
+            assertThat(md.name()).isEqualTo("TokenA");
+            assertThat(md.description()).isEqualTo("desc A");
+            assertThat(md.ticker()).isEqualTo("TKA");
+            assertThat(md.decimals()).isEqualTo(6L);
+            assertThat(md.version()).isEqualTo(1L);
+        }
+
+        @Test
+        void omitsPairsWithNoData() {
+            List<AssetType> keys = List.of(
+                    new AssetType(POLICY_A, REF_NAME_A),
+                    new AssetType(POLICY_B, REF_NAME_B));
+            Cip68Metadata rowA = Cip68Metadata.builder()
+                    .policyId(POLICY_A).assetName(REF_NAME_A).slot(100L).label(333)
+                    .name("A").description("desc A").version(1L).build();
+            // Only one row returned from the DB — POLICY_B has no matching row
+            when(repository.findLatestByConcatenatedKeys(anyCollection()))
+                    .thenReturn(List.of(rowA));
+
+            Map<String, FungibleTokenMetadata> result = service.findSubjects(keys, List.of());
+
+            assertThat(result).hasSize(1);
+            assertThat(result).containsOnlyKeys(POLICY_A + REF_NAME_A);
+        }
+
+        @Test
+        void appliesPropertyFilter() {
+            List<AssetType> keys = List.of(new AssetType(POLICY_A, REF_NAME_A));
+            Cip68Metadata row = Cip68Metadata.builder()
+                    .policyId(POLICY_A).assetName(REF_NAME_A).slot(100L).label(333)
+                    .name("TokenA").description("desc A").ticker("TKA").decimals(6L).version(1L)
+                    .logo("aGVsbG8=").url("https://example.com").build();
+            when(repository.findLatestByConcatenatedKeys(anyCollection()))
+                    .thenReturn(List.of(row));
+
+            // Request only name and decimals — everything else should be null
+            Map<String, FungibleTokenMetadata> result =
+                    service.findSubjects(keys, List.of("name", "decimals"));
+
+            FungibleTokenMetadata md = result.get(POLICY_A + REF_NAME_A);
+            assertThat(md.name()).isEqualTo("TokenA");
+            assertThat(md.decimals()).isEqualTo(6L);
+            assertThat(md.description()).isNull();
+            assertThat(md.ticker()).isNull();
+            assertThat(md.logo()).isNull();
+            assertThat(md.url()).isNull();
+            assertThat(md.version()).isNull();
+        }
+
+        @Test
+        void labelIsNotPassedToRepository() {
+            // Regression: a single reference NFT may have rows under multiple labels
+            // (the cross-output classifier tags rows by whichever user-token was co-minted).
+            // The service contract is "return latest by slot, regardless of label" — i.e.
+            // the repository must be called WITHOUT a label argument. Verified observationally
+            // on mainnet for cLBC/SHLF, Buckazoids, Burballa/Pernis, Diamond, UTXO, etc.
+            List<AssetType> keys = List.of(new AssetType(POLICY_A, REF_NAME_A));
+            when(repository.findLatestByConcatenatedKeys(anyCollection()))
+                    .thenReturn(List.of());
+
+            service.findSubjects(keys, List.of());
+
+            // No label-aware overload should be invoked.
+            verify(repository).findLatestByConcatenatedKeys(anyCollection());
+        }
+    }
+
+    @Nested
+    @DisplayName("findSubject (single)")
+    class FindSubject {
+
+        private static final String POLICY = "ccccccccccccccccccccccccccccccccccccccccccccccccccccccc1";
+        private static final String REF_NAME = "000643b0cafe";
+
+        @Test
+        void returnsLatestRowRegardlessOfLabel() {
+            // The mocked repo represents the post-fix contract: it returns the row at the
+            // greatest slot for this (policy, asset_name), without any label filter. In real
+            // mainnet data, the latest row for a renamed FT (e.g. cLBC → SHLF) lands at
+            // label=222 because a 222 token was co-minted in that update transaction — the
+            // service must still surface that row's metadata.
+            Cip68Metadata latestUnderLabel222 = Cip68Metadata.builder()
+                    .policyId(POLICY).assetName(REF_NAME).slot(200L).label(222)
+                    .name("SHLF").description("SHLF").ticker("SHLF").decimals(3L).version(1L).build();
+            when(repository.findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc(POLICY, REF_NAME))
+                    .thenReturn(Optional.of(latestUnderLabel222));
+
+            Optional<FungibleTokenMetadata> result = service.findSubject(POLICY, REF_NAME, List.of());
+
+            assertThat(result).isPresent();
+            assertThat(result.get().name()).isEqualTo("SHLF");
+            // The label-aware overload must not be invoked — see findSubject javadoc.
+            verify(repository).findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc(POLICY, REF_NAME);
+        }
+
+        @Test
+        void returnsEmptyWhenNoRowFound() {
+            when(repository.findFirstByPolicyIdAndAssetNameOrderBySlotDescTxIndexDesc(POLICY, REF_NAME))
+                    .thenReturn(Optional.empty());
+
+            assertThat(service.findSubject(POLICY, REF_NAME, List.of())).isEmpty();
+        }
+    }
+
+    private static AddressUtxo utxoWith(String unit, BigInteger quantity) {
+        return AddressUtxo.builder()
+                .amounts(List.of(Amt.builder().unit(unit).quantity(quantity).build()))
+                .build();
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/health/OffchainSyncHealthIndicatorTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/health/OffchainSyncHealthIndicatorTest.java
@@ -1,0 +1,114 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.health;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service.Cip26MetadataSyncService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service.SyncStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pinned mapping from {@link SyncStatusEnum} to Spring Boot {@link Health}.
+ *
+ * <p>Operators rely on this output for probe-group composition (startup / liveness / readiness),
+ * so the enum-to-status mapping is part of the operational contract — not an implementation
+ * detail. These tests prevent silent regressions.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OffchainSyncHealthIndicator")
+class OffchainSyncHealthIndicatorTest {
+
+    @Mock
+    private Cip26MetadataSyncService syncService;
+
+    @InjectMocks
+    private OffchainSyncHealthIndicator indicator;
+
+    @BeforeEach
+    void resetMocks() {
+        // Mockito @Mock + @InjectMocks: nothing extra needed.
+    }
+
+    @Test
+    void unknownWhenSyncStatusIsNull() {
+        // Indicator is registered as soon as Cip26MetadataSyncCronJob is on the context, but
+        // the sync service's @PostConstruct may not have run yet for the very first probe call.
+        // We surface "Not initialized" rather than NPE'ing.
+        when(syncService.getSyncStatus()).thenReturn(null);
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Not initialized");
+    }
+
+    @Test
+    void upOnSyncDone() {
+        when(syncService.getSyncStatus()).thenReturn(SyncStatus.builder().isInitialSyncDone(true).status(SyncStatusEnum.SYNC_DONE).build());
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Sync done");
+    }
+
+    @Test
+    void upOnSyncDisabled() {
+        // In-process CIP-26 sync disabled by config: this indicator reports UP on the assumption
+        // that the operator who turned the cron off is keeping the registry data fresh by some
+        // external means; returning DOWN here would falsely page on every probe.
+        when(syncService.getSyncStatus())
+                .thenReturn(SyncStatus.builder().isInitialSyncDone(true).status(SyncStatusEnum.SYNC_DISABLED).build());
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Sync disabled");
+    }
+
+    @Test
+    void outOfServiceOnSyncInProgress() {
+        // Mid-sync — the registry data may be partially stale. Useful to gate readiness probes
+        // so traffic isn't routed to a process that's still rebuilding its in-memory caches.
+        when(syncService.getSyncStatus())
+                .thenReturn(SyncStatus.builder().isInitialSyncDone(false).status(SyncStatusEnum.SYNC_IN_PROGRESS).build());
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Sync in progress");
+    }
+
+    @Test
+    void outOfServiceOnSyncNotStarted() {
+        // Pre-first-sync state. Same readiness story as in-progress.
+        when(syncService.getSyncStatus())
+                .thenReturn(SyncStatus.builder().isInitialSyncDone(false).status(SyncStatusEnum.SYNC_NOT_STARTED).build());
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Sync not started");
+    }
+
+    @Test
+    void downOnSyncError() {
+        // Hard failure: most recent sync ended in an exception. DOWN so liveness/alerting picks
+        // it up (some probe groups treat OUT_OF_SERVICE as "wait it out" while DOWN is alertable).
+        when(syncService.getSyncStatus()).thenReturn(SyncStatus.builder().isInitialSyncDone(false).status(SyncStatusEnum.SYNC_ERROR).build());
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Error while syncing");
+    }
+}

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/service/AssetsReaderTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/service/AssetsReaderTest.java
@@ -1,0 +1,225 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.service;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.QueryPriority;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.StringProperty;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.Subject;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.dto.TokenType;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.api.service.TokenQueryService.BatchPrefetchData;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.model.ProgrammableTokenCip113;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip113.storage.Cip113StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.Cip26StorageReader;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.model.FungibleTokenMetadata;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip68.storage.Cip68StorageReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for {@link AssetsReader} — the top-level facade that library consumers (no REST
+ * controller) use to query token metadata. Each public method is a thin delegate, so the tests
+ * verify (a) happy-path delegation reaches the right downstream and (b) not-found from the
+ * downstream is propagated through {@link Optional}/empty-collection contract.
+ *
+ * <p>Mock-based; no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AssetsReader")
+class AssetsReaderTest {
+
+    private static final String SUBJECT = "0011fbab202151eca9e9ef7680569d9419d12e51e693cb05a2edd2ed4341524b";
+    private static final String POLICY = "0011fbab202151eca9e9ef7680569d9419d12e51e693cb05a2edd2ed";
+
+    @Mock private TokenQueryService tokenQueryService;
+    @Mock private Cip26StorageReader cip26StorageReader;
+    @Mock private Cip68StorageReader cip68StorageReader;
+    @Mock private Cip113StorageReader cip113StorageReader;
+
+    @InjectMocks private AssetsReader assetsReader;
+
+    @Nested
+    @DisplayName("getSubject (merged)")
+    class GetSubject {
+
+        @Test
+        void defaultPriorityIsCip68ThenCip26() {
+            // The single-arg overload supplies the canonical priority order. If a future change
+            // accidentally swaps it, every consumer that didn't pass an explicit priority would
+            // silently start returning CIP-26-prioritised data.
+            ArgumentCaptor<List<QueryPriority>> priorityCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            when(tokenQueryService.querySubject(eq(SUBJECT), priorityCaptor.capture(), eq(List.of()), eq(false)))
+                    .thenReturn(Optional.of(subject(SUBJECT)));
+
+            assetsReader.getSubject(SUBJECT);
+
+            assertThat(priorityCaptor.getValue())
+                    .containsExactly(QueryPriority.CIP_68, QueryPriority.CIP_26);
+        }
+
+        @Test
+        void explicitPriorityIsForwardedVerbatim() {
+            List<QueryPriority> priority = List.of(QueryPriority.CIP_26, QueryPriority.CIP_68);
+            when(tokenQueryService.querySubject(SUBJECT, priority, List.of(), false))
+                    .thenReturn(Optional.of(subject(SUBJECT)));
+
+            Optional<Subject> result = assetsReader.getSubject(SUBJECT, priority);
+
+            assertThat(result).isPresent();
+            verify(tokenQueryService).querySubject(SUBJECT, priority, List.of(), false);
+        }
+
+        @Test
+        void notFoundReturnsEmpty() {
+            when(tokenQueryService.querySubject(any(), any(), any(), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            assertThat(assetsReader.getSubject(SUBJECT)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubjects (batch)")
+    class GetSubjects {
+
+        @Test
+        void invalidMetadataSubjectsAreFilteredOut() {
+            // The batch facade silently drops subjects whose metadata is incomplete (no name +
+            // description), so callers don't have to defend against half-populated rows.
+            List<String> subjects = List.of("a-valid-subject", "an-invalid-subject");
+            BatchPrefetchData prefetch = new BatchPrefetchData(Map.of(), Map.of(), Map.of(), Map.of());
+
+            when(tokenQueryService.prefetchBatch(subjects, List.of())).thenReturn(prefetch);
+            when(tokenQueryService.querySubjectBatch(eq("a-valid-subject"), any(), any(), eq(prefetch), eq(false)))
+                    .thenReturn(subject("a-valid-subject"));
+            when(tokenQueryService.querySubjectBatch(eq("an-invalid-subject"), any(), any(), eq(prefetch), eq(false)))
+                    .thenReturn(subjectWithoutMetadata("an-invalid-subject"));
+
+            List<Subject> result = assetsReader.getSubjects(subjects, List.of(QueryPriority.CIP_68));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().subject()).isEqualTo("a-valid-subject");
+        }
+
+        @Test
+        void emptyInputReturnsEmptyResult() {
+            when(tokenQueryService.prefetchBatch(List.of(), List.of()))
+                    .thenReturn(new BatchPrefetchData(Map.of(), Map.of(), Map.of(), Map.of()));
+
+            assertThat(assetsReader.getSubjects(List.of(), List.of(QueryPriority.CIP_68))).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("per-CIP queries")
+    class PerCip {
+
+        @Test
+        void getCip26MetadataDelegatesToReader() {
+            Cip26Metadata m = new Cip26Metadata();
+            when(cip26StorageReader.findBySubject(SUBJECT)).thenReturn(Optional.of(m));
+
+            assertThat(assetsReader.getCip26Metadata(SUBJECT)).containsSame(m);
+        }
+
+        @Test
+        void getCip26MetadataReturnsEmptyWhenNotFound() {
+            when(cip26StorageReader.findBySubject(SUBJECT)).thenReturn(Optional.empty());
+
+            assertThat(assetsReader.getCip26Metadata(SUBJECT)).isEmpty();
+        }
+
+        @Test
+        void getCip26LogoDelegatesToReader() {
+            when(cip26StorageReader.findLogoBySubject(SUBJECT)).thenReturn(Optional.of("base64"));
+
+            assertThat(assetsReader.getCip26Logo(SUBJECT)).contains("base64");
+        }
+
+        @Test
+        void getCip68MetadataDelegatesToReader() {
+            FungibleTokenMetadata m = new FungibleTokenMetadata(6L, "desc", null, "Token", "TKN", "https://x", 1L);
+            when(cip68StorageReader.findBySubject(SUBJECT)).thenReturn(Optional.of(m));
+
+            assertThat(assetsReader.getCip68Metadata(SUBJECT)).contains(m);
+        }
+
+        @Test
+        void getCip68MetadataReturnsEmptyWhenNotFound() {
+            when(cip68StorageReader.findBySubject(SUBJECT)).thenReturn(Optional.empty());
+
+            assertThat(assetsReader.getCip68Metadata(SUBJECT)).isEmpty();
+        }
+
+        @Test
+        void getCip113RegistryNodeDelegatesToReader() {
+            ProgrammableTokenCip113 token = new ProgrammableTokenCip113("script", null, null, null, null);
+            when(cip113StorageReader.findByPolicyId(POLICY)).thenReturn(Optional.of(token));
+
+            assertThat(assetsReader.getCip113RegistryNode(POLICY)).contains(token);
+        }
+
+        @Test
+        void getCip113RegistryNodeReturnsEmptyWhenNotFound() {
+            // Either CIP-113 disabled or the policy is not in the registry — both surface as empty.
+            when(cip113StorageReader.findByPolicyId(POLICY)).thenReturn(Optional.empty());
+
+            assertThat(assetsReader.getCip113RegistryNode(POLICY)).isEmpty();
+        }
+
+        @Test
+        void getCip113RegistryNodesBatchDelegatesToReader() {
+            List<String> policies = List.of(POLICY, "another-policy-id");
+            ProgrammableTokenCip113 token = new ProgrammableTokenCip113("script", null, null, null, null);
+            when(cip113StorageReader.findByPolicyIds(policies)).thenReturn(Map.of(POLICY, token));
+
+            Map<String, ProgrammableTokenCip113> result = assetsReader.getCip113RegistryNodes(policies);
+
+            assertThat(result).containsOnlyKeys(POLICY);
+            // `another-policy-id` legitimately absent — facade does not fabricate empty entries.
+            verify(cip113StorageReader, never()).findByPolicyId(any());
+        }
+
+        @Test
+        void isProgrammableTokenDelegatesToReader() {
+            when(cip113StorageReader.isProgrammableToken(POLICY)).thenReturn(true);
+            assertThat(assetsReader.isProgrammableToken(POLICY)).isTrue();
+
+            when(cip113StorageReader.isProgrammableToken(POLICY)).thenReturn(false);
+            assertThat(assetsReader.isProgrammableToken(POLICY)).isFalse();
+        }
+    }
+
+    private static Subject subject(String subjectId) {
+        // valid metadata: name + description both set so Metadata.isValid() returns true
+        Metadata metadata = Metadata.builder()
+                .name(new StringProperty("a name", QueryPriority.CIP_26.name()))
+                .description(new StringProperty("a description", QueryPriority.CIP_26.name()))
+                .build();
+        return new Subject(subjectId, TokenType.NATIVE, metadata, null, null);
+    }
+
+    private static Subject subjectWithoutMetadata(String subjectId) {
+        // no name → Metadata.isValid() = false → batch facade filters this out
+        return new Subject(subjectId, TokenType.NATIVE, Metadata.empty(), null, null);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -83,4 +83,9 @@ include ':starters:adapot-spring-boot-starter'
 include ':extensions:utxo-rocksdb'
 include ':extensions:account-rocksdb'
 
+include ':extensions:assets-ext'
+project(':extensions:assets-ext').projectDir = new File('extensions/assets-ext')
+
+include ':starters:assets-ext-spring-boot-starter'
+
 include 'e2e-tests'

--- a/starters/assets-ext-spring-boot-starter/build.gradle
+++ b/starters/assets-ext-spring-boot-starter/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    api project(":extensions:assets-ext")
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+}
+
+tasks.named('compileJava') {
+    inputs.files(tasks.named('processResources'))
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yaci Store Assets Extension Spring Boot Starter'
+                description = 'Yaci Store Assets Extension Spring Boot Starter'
+            }
+        }
+    }
+}

--- a/starters/assets-ext-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtAutoConfiguration.java
+++ b/starters/assets-ext-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtAutoConfiguration.java
@@ -1,0 +1,43 @@
+package com.bloxbean.cardano.yaci.store.starter.assetstore;
+
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtConfiguration;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@EnableConfigurationProperties(AssetsExtProperties.class)
+@Import({AssetsExtConfiguration.class})
+@Slf4j
+public class AssetsExtAutoConfiguration {
+
+    @Autowired
+    AssetsExtProperties properties;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AssetsExtStoreProperties assetsStoreProperties() {
+        AssetsExtStoreProperties.Cip26 cip26 = new AssetsExtStoreProperties.Cip26();
+        cip26.setEnabled(properties.getCip26().isEnabled());
+        cip26.setGitOrganization(properties.getCip26().getGitOrganization());
+        cip26.setGitProjectName(properties.getCip26().getGitProjectName());
+        cip26.setGitMappingsFolder(properties.getCip26().getGitMappingsFolder());
+        cip26.setGitTmpFolder(properties.getCip26().getGitTmpFolder());
+        cip26.setForceClone(properties.getCip26().isForceClone());
+
+        AssetsExtStoreProperties.Cip113 cip113 = new AssetsExtStoreProperties.Cip113();
+        cip113.setEnabled(properties.getCip113().isEnabled());
+        cip113.setRegistryNftPolicyIds(properties.getCip113().getRegistryNftPolicyIds());
+
+        AssetsExtStoreProperties assetsStoreProperties = new AssetsExtStoreProperties();
+        assetsStoreProperties.setCip26(cip26);
+        assetsStoreProperties.setCip113(cip113);
+        assetsStoreProperties.setDefaultQueryPriority(properties.getQuery().getPriority());
+        return assetsStoreProperties;
+    }
+}

--- a/starters/assets-ext-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtProperties.java
+++ b/starters/assets-ext-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtProperties.java
@@ -1,0 +1,88 @@
+package com.bloxbean.cardano.yaci.store.starter.assetstore;
+
+import jakarta.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "store.assets.ext", ignoreUnknownFields = true)
+public class AssetsExtProperties {
+    // Defaults mirror the @ConditionalOnProperty gates so config metadata matches runtime.
+    // Blockfrost-extension pattern: the master flag is OFF by default; the sub-flags CIP-26 and
+    // CIP-68 default ON, so enabling the master flag alone yields the default behaviour. CIP-113
+    // is the exception and stays OFF until it is live on mainnet.
+    private boolean enabled = false;
+    private Cip26 cip26 = new Cip26();
+    private Cip68 cip68 = new Cip68();
+    private Cip113 cip113 = new Cip113();
+    private Query query = new Query();
+
+    /**
+     * CIP-26 GitHub registry settings.
+     *
+     * <h2>Why {@link #gitOrganization}, {@link #gitProjectName} and
+     * {@link #gitMappingsFolder} must stay {@code null} by default</h2>
+     *
+     * <p>{@link com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults}
+     * resolves these per {@code store.cardano.protocol-magic}: mainnet →
+     * {@code cardano-foundation/cardano-token-registry}, preprod →
+     * {@code input-output-hk/metadata-registry-testnet}, others → no registry.
+     * It only fills in defaults when the user-supplied values are {@code null}
+     * (or blank).
+     *
+     * <p>If we hardcoded mainnet values here, they would flow via
+     * {@link AssetsExtAutoConfiguration} into {@code AssetsExtStoreProperties}
+     * and shadow the per-network resolution — every network would end up
+     * cloning the mainnet registry. That regression was caught on preprod QA
+     * (yaci silently indexed 7929 mainnet tokens on a preprod-configured
+     * store). See {@code AssetsExtPropertiesTest} for the regression lock.
+     */
+    @Getter
+    @Setter
+    public static final class Cip26 {
+        // Enabled by default (blockfrost-extension pattern): once the master flag
+        // store.assets.ext.enabled is on, CIP-26 sync runs as part of the default behaviour.
+        // The git-* fields below stay null so Cip26NetworkDefaults resolves the correct
+        // registry per protocol-magic — that per-network resolution, not a default-off flag,
+        // is what prevents a preprod node from indexing mainnet metadata.
+        private boolean enabled = true;
+        @Nullable private String gitOrganization;
+        @Nullable private String gitProjectName;
+        @Nullable private String gitMappingsFolder;
+        private String gitTmpFolder = "/tmp";
+        private long syncIntervalMinutes = 60;
+        private boolean forceClone = false;
+    }
+
+    @Getter
+    @Setter
+    public static final class Cip68 {
+        private boolean enabled = true;
+    }
+
+    @Getter
+    @Setter
+    public static final class Cip113 {
+        // Disabled by default until CIP-113 is officially live on mainnet.
+        // Re-enable per deployment via store.assets.ext.cip113.enabled=true.
+        private boolean enabled = false;
+        /**
+         * Comma-separated list of CIP-113 registry NFT policy IDs to monitor.
+         * If empty (and no per-network defaults exist), CIP-113 is disabled.
+         * If empty but defaults are available, policy IDs are auto-detected from
+         * the network's property file.
+         */
+        private List<String> registryNftPolicyIds = new ArrayList<>();
+    }
+
+    @Getter
+    @Setter
+    public static final class Query {
+        private String priority = "CIP_68,CIP_26";
+    }
+}

--- a/starters/assets-ext-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/starters/assets-ext-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.bloxbean.cardano.yaci.store.starter.assetstore.AssetsExtAutoConfiguration

--- a/starters/assets-ext-spring-boot-starter/src/test/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtPropertiesTest.java
+++ b/starters/assets-ext-spring-boot-starter/src/test/java/com/bloxbean/cardano/yaci/store/starter/assetstore/AssetsExtPropertiesTest.java
@@ -1,0 +1,83 @@
+package com.bloxbean.cardano.yaci.store.starter.assetstore;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression-lock for {@link AssetsExtProperties}.
+ *
+ * <p>The CIP-26 git-registry fields ({@code gitOrganization},
+ * {@code gitProjectName}, {@code gitMappingsFolder}) MUST default to
+ * {@code null} so that
+ * {@link com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults}
+ * can resolve them per {@code protocol-magic}. Hardcoding mainnet values
+ * here was the root cause of an incident where a preprod-configured yaci
+ * silently indexed mainnet tokens (because the non-null values shadowed the
+ * per-network defaults). See {@code AssetsExtProperties.Cip26} javadoc for
+ * the full rationale.
+ *
+ * <p>If a future change re-introduces non-null defaults for these fields,
+ * this test will fail — that's the point. Do <em>not</em> "fix" this test
+ * by relaxing the assertions; fix the source.
+ */
+@DisplayName("AssetsExtProperties")
+class AssetsExtPropertiesTest {
+
+    @Test
+    @DisplayName("CIP-26 git-* fields default to null so per-network resolution can fire")
+    void cip26GitFieldsAreNullByDefault() {
+        AssetsExtProperties.Cip26 cip26 = new AssetsExtProperties.Cip26();
+
+        assertThat(cip26.getGitOrganization())
+                .as("gitOrganization must be null — Cip26NetworkDefaults resolves it from protocol-magic")
+                .isNull();
+        assertThat(cip26.getGitProjectName())
+                .as("gitProjectName must be null — Cip26NetworkDefaults resolves it from protocol-magic")
+                .isNull();
+        assertThat(cip26.getGitMappingsFolder())
+                .as("gitMappingsFolder must be null — Cip26NetworkDefaults resolves it from protocol-magic")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("CIP-26 is enabled by default once the master flag is on (blockfrost pattern)")
+    void cip26IsEnabledByDefault() {
+        // Aligned with the blockfrost extension: sub-flags default on, so enabling the
+        // master flag (store.assets.ext.enabled) alone gives the default behaviour. The
+        // safeguard against a preprod node indexing mainnet metadata is the per-network
+        // git-* resolution (see cip26GitFieldsAreNullByDefault), not a default-off flag.
+        assertThat(new AssetsExtProperties.Cip26().isEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("non-network-specific CIP-26 defaults are unchanged")
+    void cip26NonNetworkDefaultsAreSet() {
+        AssetsExtProperties.Cip26 cip26 = new AssetsExtProperties.Cip26();
+
+        // Defaults that apply once the operator opts in via cip26.enabled=true.
+        assertThat(cip26.getGitTmpFolder()).isEqualTo("/tmp");
+        assertThat(cip26.getSyncIntervalMinutes()).isEqualTo(60L);
+        assertThat(cip26.isForceClone()).isFalse();
+    }
+
+    @Test
+    @DisplayName("CIP-113 is disabled by default until officially live on mainnet")
+    void cip113IsDisabledByDefault() {
+        // Team decision while CIP-113 is still pre-mainnet — see commit history.
+        // If this is ever flipped back to true, expect a coordinated yaci-store
+        // release that ships matching registry NFT policy IDs.
+        assertThat(new AssetsExtProperties.Cip113().isEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("master extension flag is disabled by default (blockfrost pattern — opt in via one flag)")
+    void rootEnabledIsFalseByDefault() {
+        // Mirrors the AssetsExtConfiguration @ConditionalOnProperty(matchIfMissing = false)
+        // master gate, matching the blockfrost extension (BFAutoConfiguration): the whole
+        // extension stays off until an operator sets store.assets.ext.enabled=true, which
+        // then brings up CIP-26 + CIP-68 by default (CIP-113 stays off).
+        assertThat(new AssetsExtProperties().isEnabled()).isFalse();
+    }
+}

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/ByronUtxoProcessor.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/ByronUtxoProcessor.java
@@ -48,7 +48,9 @@ public class ByronUtxoProcessor {
                 .collect(Collectors.toList());
 
         List<TxInputOutput> txInputOutputList = new ArrayList<>();
+        int txIndex = 0;
         for (ByronTx byronTx : byronTxList) {
+            final int currentTxIndex = txIndex++;
             //set spent for input
             List<TxInput> spentOutputs = byronTx.getInputs().stream()
                     .map(txIn -> new UtxoKey(txIn.getTxId(), txIn.getIndex()))
@@ -67,7 +69,7 @@ public class ByronUtxoProcessor {
 
             List<Utxo> utxos = getUtxosFromByronOutput(byronTx);
             List<AddressUtxo> outputAddressUtxos = utxos.stream()
-                    .map(utxo -> getAddressUtxo(metadata, utxo))
+                    .map(utxo -> getAddressUtxo(metadata, utxo, currentTxIndex))
                     .collect(Collectors.toList());
 
             if (outputAddressUtxos.size() > 0) //unspent utxos
@@ -105,7 +107,7 @@ public class ByronUtxoProcessor {
         return utxos;
     }
 
-    private AddressUtxo getAddressUtxo(@NonNull EventMetadata eventMetadata, @NonNull Utxo utxo) {
+    private AddressUtxo getAddressUtxo(@NonNull EventMetadata eventMetadata, @NonNull Utxo utxo, int txIndex) {
         //Fix -- some asset name contains \u0000 -- postgres can't convert this to text. so replace
         List<Amt> amounts = utxo.getAmounts().stream().map(amount ->
                         Amt.builder()
@@ -133,6 +135,7 @@ public class ByronUtxoProcessor {
                 .epoch(eventMetadata.getEpochNumber())
                 .txHash(utxo.getTxHash())
                 .outputIndex(utxo.getIndex())
+                .txIndex(txIndex)
                 .ownerAddr(utxo.getAddress())
                 .ownerStakeAddr(stakeAddress)
                 .ownerPaymentCredential(paymentKeyHash)

--- a/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
+++ b/stores/utxo/src/main/java/com/bloxbean/cardano/yaci/store/utxo/processor/UtxoProcessor.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.bloxbean.cardano.yaci.core.util.Constants.LOVELACE;
 import static com.bloxbean.cardano.yaci.store.utxo.UtxoStoreConfiguration.STORE_UTXO_ENABLED;
@@ -70,20 +69,20 @@ public class UtxoProcessor {
             if (transactions == null)
                 return;
 
-            Stream<Transaction> transactionStream = transactions.stream(); //dependencyFound? transactions.stream(): transactions.parallelStream();
-            List<TxInputOutput> txInputOutputs = transactionStream.map(
-                    transaction -> {
-                        Optional<TxInputOutput> txInputOutputOptional;
-                        if (transaction.isInvalid()) {
-                            txInputOutputOptional = handleInvalidTransaction(event.getMetadata(), transaction);
-                        } else {
-                            txInputOutputOptional = handleValidTransaction(event.getMetadata(), transaction);
-                        }
-
-                        return txInputOutputOptional;
-                    }).filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(Collectors.toList());
+            // Iterate by position so each output can be stamped with its producing transaction's
+            // index within the block (tx_index). The index counts every transaction, including any
+            // that yield no TxInputOutput, so it stays aligned with the canonical block tx order.
+            List<TxInputOutput> txInputOutputs = new ArrayList<>();
+            for (int txIndex = 0; txIndex < transactions.size(); txIndex++) {
+                Transaction transaction = transactions.get(txIndex);
+                Optional<TxInputOutput> txInputOutputOptional;
+                if (transaction.isInvalid()) {
+                    txInputOutputOptional = handleInvalidTransaction(event.getMetadata(), transaction, txIndex);
+                } else {
+                    txInputOutputOptional = handleValidTransaction(event.getMetadata(), transaction, txIndex);
+                }
+                txInputOutputOptional.ifPresent(txInputOutputs::add);
+            }
 
             utxoStorage.saveSpent(txInputOutputs.stream()
                     .flatMap(txInputOutput -> txInputOutput.getInputs().stream()).collect(Collectors.toList()));
@@ -99,7 +98,7 @@ public class UtxoProcessor {
         }
     }
 
-    private Optional<TxInputOutput> handleValidTransaction(EventMetadata metadata, Transaction transaction) {
+    private Optional<TxInputOutput> handleValidTransaction(EventMetadata metadata, Transaction transaction, int txIndex) {
         if (transaction.isInvalid())
             return Optional.empty();
 
@@ -124,7 +123,7 @@ public class UtxoProcessor {
         //                    utxoStorage.findById(addressUtxo.getTxHash(), addressUtxo.getOutputIndex())
         //                            .ifPresent(existingAddressUtxo -> addressUtxo.setSpent(existingAddressUtxo.getSpent()));
         List<AddressUtxo> outputAddressUtxos = transaction.getUtxos().stream()
-                .map(utxo -> getAddressUtxo(metadata, utxo))
+                .map(utxo -> getAddressUtxo(metadata, utxo, txIndex))
                 .collect(Collectors.toList());
 
         //publish event
@@ -136,13 +135,13 @@ public class UtxoProcessor {
         }
     }
 
-    private Optional<TxInputOutput> handleInvalidTransaction(EventMetadata metadata, Transaction transaction) {
+    private Optional<TxInputOutput> handleInvalidTransaction(EventMetadata metadata, Transaction transaction, int txIndex) {
         if (!transaction.isInvalid())
             return Optional.empty();
 
         //collateral output
         AddressUtxo collateralOutputUtxo = Optional.ofNullable(transaction.getCollateralReturnUtxo())
-                .map(utxo -> getCollateralReturnAddressUtxo(metadata, utxo))
+                .map(utxo -> getCollateralReturnAddressUtxo(metadata, utxo, txIndex))
                 .orElse(null);
 
         //Also, change in Yaci to return collateral output index as size of tx outputs
@@ -178,7 +177,7 @@ public class UtxoProcessor {
         return Optional.of(new TxInputOutput(transaction.getTxHash(), collateralInputUtxos, outputs));
     }
 
-    private AddressUtxo getAddressUtxo(@NonNull EventMetadata eventMetadata, @NonNull Utxo utxo) {
+    private AddressUtxo getAddressUtxo(@NonNull EventMetadata eventMetadata, @NonNull Utxo utxo, int txIndex) {
         //Fix -- some asset name contains \u0000 -- postgres can't convert this to text. so replace
         List<Amt> amounts = utxo.getAmounts().stream().map(amount ->
                         Amt.builder()
@@ -232,6 +231,7 @@ public class UtxoProcessor {
                 .epoch(eventMetadata.getEpochNumber())
                 .txHash(utxo.getTxHash())
                 .outputIndex(utxo.getIndex())
+                .txIndex(txIndex)
                 .ownerAddr(utxo.getAddress())
                 .ownerStakeAddr(stakeAddress)
                 .ownerPaymentCredential(paymentKeyHash)
@@ -245,8 +245,8 @@ public class UtxoProcessor {
                 .build();
     }
 
-    private AddressUtxo getCollateralReturnAddressUtxo(EventMetadata metadata, Utxo utxo) {
-        AddressUtxo addressUtxo = getAddressUtxo(metadata, utxo);
+    private AddressUtxo getCollateralReturnAddressUtxo(EventMetadata metadata, Utxo utxo, int txIndex) {
+        AddressUtxo addressUtxo = getAddressUtxo(metadata, utxo, txIndex);
         addressUtxo.setIsCollateralReturn(Boolean.TRUE);
         return addressUtxo;
     }


### PR DESCRIPTION
  ## Summary

  Backports the assets-ext token metadata extension from `main` to `release/2.0.x`.

  This PR cherry-picks `fa9ddf267` from `main`, which was created by merging PR https://github.com/bloxbean/yaci-store/pull/870. The original PR adds support for CIP-26, CIP-68 FT/NFT metadata handling, and CIP-113 programmable token metadata.
  
 
  ## Backport Notes

  `release/2.0.x` still applies `publish-common.gradle` from `extensions/build.gradle`, while `main` no longer does this for extensions.

  Because of that branch difference, this backport includes one manual adaptation:

  - Removed the duplicate `apply from : "../../publish-common.gradle"` from `extensions/assets-ext/build.gradle`.

  Without this adjustment, Gradle fails with:

  ```text
  Maven publication 'mavenJava' cannot include multiple components

  