### PR TITLE
feat(transaction): store full transaction CBOR behind save-full-tx-cbor

### DIFF
--- a/starters/transaction-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/transaction/TransactionAutoConfigProperties.java
+++ b/starters/transaction-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/transaction/TransactionAutoConfigProperties.java
@@ -46,6 +46,17 @@ public class TransactionAutoConfigProperties {
       private boolean saveCbor = false;
 
       /**
+       * Enable/disable saving of the full signed transaction CBOR (body + witness set + isValid + auxiliary data)
+       * instead of the transaction body-only CBOR.
+       * When enabled, the indexer reassembles the full transaction CBOR (CBOR array, tag 84) from its
+       * constituent parts and stores that instead of the body-only CBOR (CBOR map, tag a4).
+       * This is useful for wallets and clients that need the complete signed transaction, e.g. for re-broadcast
+       * or witness verification.
+       * Note: Has no effect unless {@code saveCbor} is also enabled.
+       */
+      private boolean saveFullTxCbor = false;
+
+      /**
        * Enable/disable pruning of block CBOR data.
        * When enabled, CBOR data older than cborPruningSafeSlots will be automatically deleted.
        */

--- a/starters/transaction-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/transaction/TransactionStoreAutoConfiguration.java
+++ b/starters/transaction-spring-boot-starter/src/main/java/com/bloxbean/cardano/yaci/store/starter/transaction/TransactionStoreAutoConfiguration.java
@@ -28,6 +28,7 @@ public class TransactionStoreAutoConfiguration {
         transactionStoreProperties.setPruningSafeSlots(properties.getTransaction().getPruningSafeSlots());
         transactionStoreProperties.setSaveWitness(properties.getTransaction().isSaveWitness());
         transactionStoreProperties.setSaveCbor(properties.getTransaction().isSaveCbor());
+        transactionStoreProperties.setSaveFullTxCbor(properties.getTransaction().isSaveFullTxCbor());
         transactionStoreProperties.setCborPruningEnabled(properties.getTransaction().isCborPruningEnabled());
         transactionStoreProperties.setCborPruningSafeSlots(properties.getTransaction().getCborPruningSafeSlots());
 

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/TransactionStoreProperties.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/TransactionStoreProperties.java
@@ -38,6 +38,18 @@ public class TransactionStoreProperties {
     private boolean saveCbor = false;
 
     /**
+     * Enable/disable saving of the full signed transaction CBOR (body + witness set + isValid + auxiliary data)
+     * instead of the transaction body-only CBOR.
+     * When enabled, the indexer reassembles the full transaction CBOR (CBOR array, tag 84) from its
+     * constituent parts and stores that instead of the body-only CBOR (CBOR map, tag a4).
+     * This is useful for wallets and clients that need the complete signed transaction, e.g. for re-broadcast
+     * or witness verification.
+     * Note: Works standalone -- does not require {@code saveCbor} to also be enabled.
+     */
+    @Builder.Default
+    private boolean saveFullTxCbor = false;
+
+    /**
      * Enable/disable pruning of transaction CBOR data.
      * When enabled, CBOR data older than cborPruningSafeSlots will be automatically deleted.
      */

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassembler.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassembler.java
@@ -17,7 +17,9 @@ import com.bloxbean.cardano.client.transaction.spec.BootstrapWitness;
 import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
 import com.bloxbean.cardano.client.transaction.spec.VkeyWitness;
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+import com.bloxbean.cardano.yaci.core.model.AuxData;
 import com.bloxbean.cardano.yaci.core.model.PlutusScript;
+import com.bloxbean.cardano.yaci.core.model.Witnesses;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -108,11 +110,57 @@ public class FullTxCborReassembler {
     private static TransactionWitnessSet buildWitnessSet(com.bloxbean.cardano.yaci.helper.model.Transaction tx) {
         TransactionWitnessSet.TransactionWitnessSetBuilder builder = TransactionWitnessSet.builder();
 
-        var witnesses = tx.getWitnesses();
+        Witnesses witnesses = tx.getWitnesses();
         if (witnesses == null) {
             return builder.build();
         }
 
+        String txHash = tx.getTxHash();
+
+        List<VkeyWitness> vkeyWitnesses = mapVkeyWitnesses(witnesses, txHash);
+        if (!vkeyWitnesses.isEmpty()) {
+            builder.vkeyWitnesses(vkeyWitnesses);
+        }
+
+        List<BootstrapWitness> bootstrapWitnesses = mapBootstrapWitnesses(witnesses, txHash);
+        if (!bootstrapWitnesses.isEmpty()) {
+            builder.bootstrapWitnesses(bootstrapWitnesses);
+        }
+
+        List<PlutusV1Script> plutusV1Scripts = mapWitnessPlutusV1Scripts(witnesses, txHash);
+        if (!plutusV1Scripts.isEmpty()) {
+            builder.plutusV1Scripts(plutusV1Scripts);
+        }
+
+        List<PlutusV2Script> plutusV2Scripts = mapWitnessPlutusV2Scripts(witnesses, txHash);
+        if (!plutusV2Scripts.isEmpty()) {
+            builder.plutusV2Scripts(plutusV2Scripts);
+        }
+
+        List<PlutusV3Script> plutusV3Scripts = mapWitnessPlutusV3Scripts(witnesses, txHash);
+        if (!plutusV3Scripts.isEmpty()) {
+            builder.plutusV3Scripts(plutusV3Scripts);
+        }
+
+        List<NativeScript> nativeScripts = mapWitnessNativeScripts(witnesses, txHash);
+        if (!nativeScripts.isEmpty()) {
+            builder.nativeScripts(nativeScripts);
+        }
+
+        List<Redeemer> redeemers = mapRedeemers(witnesses, txHash);
+        if (!redeemers.isEmpty()) {
+            builder.redeemers(redeemers);
+        }
+
+        List<PlutusData> plutusDataList = mapWitnessDatums(witnesses, txHash);
+        if (!plutusDataList.isEmpty()) {
+            builder.plutusDataList(plutusDataList);
+        }
+
+        return builder.build();
+    }
+
+    private static List<VkeyWitness> mapVkeyWitnesses(Witnesses witnesses, String txHash) {
         List<VkeyWitness> vkeyWitnesses = new ArrayList<>();
         if (witnesses.getVkeyWitnesses() != null) {
             for (var vkeyWitness : witnesses.getVkeyWitnesses()) {
@@ -121,14 +169,14 @@ public class FullTxCborReassembler {
                             HexUtil.decodeHexString(vkeyWitness.getKey()),
                             HexUtil.decodeHexString(vkeyWitness.getSignature())));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed vkey witness for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed vkey witness for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!vkeyWitnesses.isEmpty()) {
-            builder.vkeyWitnesses(vkeyWitnesses);
-        }
+        return vkeyWitnesses;
+    }
 
+    private static List<BootstrapWitness> mapBootstrapWitnesses(Witnesses witnesses, String txHash) {
         List<BootstrapWitness> bootstrapWitnesses = new ArrayList<>();
         if (witnesses.getBootstrapWitnesses() != null) {
             for (var bootstrapWitness : witnesses.getBootstrapWitnesses()) {
@@ -140,71 +188,71 @@ public class FullTxCborReassembler {
                             .attributes(HexUtil.decodeHexString(bootstrapWitness.getAttributes()))
                             .build());
                 } catch (Exception e) {
-                    log.debug("Skipping malformed bootstrap witness for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed bootstrap witness for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!bootstrapWitnesses.isEmpty()) {
-            builder.bootstrapWitnesses(bootstrapWitnesses);
-        }
+        return bootstrapWitnesses;
+    }
 
+    private static List<PlutusV1Script> mapWitnessPlutusV1Scripts(Witnesses witnesses, String txHash) {
         List<PlutusV1Script> plutusV1Scripts = new ArrayList<>();
         if (witnesses.getPlutusV1Scripts() != null) {
             for (PlutusScript plutusScript : witnesses.getPlutusV1Scripts()) {
                 try {
                     plutusV1Scripts.add(PlutusV1Script.deserialize(decodeAsByteString(plutusScript.getContent())));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed PlutusV1 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed PlutusV1 script for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!plutusV1Scripts.isEmpty()) {
-            builder.plutusV1Scripts(plutusV1Scripts);
-        }
+        return plutusV1Scripts;
+    }
 
+    private static List<PlutusV2Script> mapWitnessPlutusV2Scripts(Witnesses witnesses, String txHash) {
         List<PlutusV2Script> plutusV2Scripts = new ArrayList<>();
         if (witnesses.getPlutusV2Scripts() != null) {
             for (PlutusScript plutusScript : witnesses.getPlutusV2Scripts()) {
                 try {
                     plutusV2Scripts.add(PlutusV2Script.deserialize(decodeAsByteString(plutusScript.getContent())));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed PlutusV2 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed PlutusV2 script for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!plutusV2Scripts.isEmpty()) {
-            builder.plutusV2Scripts(plutusV2Scripts);
-        }
+        return plutusV2Scripts;
+    }
 
+    private static List<PlutusV3Script> mapWitnessPlutusV3Scripts(Witnesses witnesses, String txHash) {
         List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
         if (witnesses.getPlutusV3Scripts() != null) {
             for (PlutusScript plutusScript : witnesses.getPlutusV3Scripts()) {
                 try {
                     plutusV3Scripts.add(PlutusV3Script.deserialize(decodeAsByteString(plutusScript.getContent())));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed PlutusV3 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed PlutusV3 script for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!plutusV3Scripts.isEmpty()) {
-            builder.plutusV3Scripts(plutusV3Scripts);
-        }
+        return plutusV3Scripts;
+    }
 
-        // Native script JSON shape may not map cleanly onto CCL's NativeScript -- skip silently per-item on failure.
+    // Native script JSON shape may not map cleanly onto CCL's NativeScript -- skip silently per-item on failure.
+    private static List<NativeScript> mapWitnessNativeScripts(Witnesses witnesses, String txHash) {
         List<NativeScript> nativeScripts = new ArrayList<>();
         if (witnesses.getNativeScripts() != null) {
             for (var nativeScript : witnesses.getNativeScripts()) {
                 try {
                     nativeScripts.add(NativeScript.deserializeJson(nativeScript.getContent()));
                 } catch (Exception e) {
-                    log.debug("Skipping native script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping native script for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!nativeScripts.isEmpty()) {
-            builder.nativeScripts(nativeScripts);
-        }
+        return nativeScripts;
+    }
 
+    private static List<Redeemer> mapRedeemers(Witnesses witnesses, String txHash) {
         List<Redeemer> redeemers = new ArrayList<>();
         if (witnesses.getRedeemers() != null) {
             for (var redeemer : witnesses.getRedeemers()) {
@@ -215,29 +263,25 @@ public class FullTxCborReassembler {
                     DataItem redeemerDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(redeemer.getCbor()));
                     redeemers.add(Redeemer.deserializePreConway((Array) redeemerDataItem));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed redeemer for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed redeemer for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!redeemers.isEmpty()) {
-            builder.redeemers(redeemers);
-        }
+        return redeemers;
+    }
 
+    private static List<PlutusData> mapWitnessDatums(Witnesses witnesses, String txHash) {
         List<PlutusData> plutusDataList = new ArrayList<>();
         if (witnesses.getDatums() != null) {
             for (var datum : witnesses.getDatums()) {
                 try {
                     plutusDataList.add(PlutusData.deserialize(HexUtil.decodeHexString(datum.getCbor())));
                 } catch (Exception e) {
-                    log.debug("Skipping malformed datum for tx {}: {}", tx.getTxHash(), e.getMessage());
+                    log.debug("Skipping malformed datum for tx {}: {}", txHash, e.getMessage());
                 }
             }
         }
-        if (!plutusDataList.isEmpty()) {
-            builder.plutusDataList(plutusDataList);
-        }
-
-        return builder.build();
+        return plutusDataList;
     }
 
     /**
@@ -246,87 +290,117 @@ public class FullTxCborReassembler {
      * there's no aux data at all, or nothing could be mapped from it (caller then emits CBOR {@code null}).
      */
     private static AuxiliaryData buildAuxiliaryData(com.bloxbean.cardano.yaci.helper.model.Transaction tx) {
-        var auxData = tx.getAuxData();
+        AuxData auxData = tx.getAuxData();
         if (auxData == null) {
             return null;
         }
 
+        String txHash = tx.getTxHash();
         AuxiliaryData.AuxiliaryDataBuilder builder = AuxiliaryData.builder();
         boolean hasContent = false;
 
-        String metadataCborHex = auxData.getMetadataCbor();
-        if (metadataCborHex != null && !metadataCborHex.isEmpty()) {
-            try {
-                DataItem metadataDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(metadataCborHex));
-                CBORMetadata cborMetadata = CBORMetadata.deserialize((Map) metadataDataItem);
-                builder.metadata(cborMetadata);
-                hasContent = true;
-            } catch (Exception e) {
-                log.debug("Skipping malformed auxiliary metadata for tx {}: {}", tx.getTxHash(), e.getMessage());
-            }
+        CBORMetadata cborMetadata = mapAuxiliaryMetadata(auxData, txHash);
+        if (cborMetadata != null) {
+            builder.metadata(cborMetadata);
+            hasContent = true;
         }
 
-        List<NativeScript> nativeScripts = new ArrayList<>();
-        if (auxData.getNativeScripts() != null) {
-            for (var nativeScript : auxData.getNativeScripts()) {
-                try {
-                    nativeScripts.add(NativeScript.deserializeJson(nativeScript.getContent()));
-                } catch (Exception e) {
-                    log.debug("Skipping malformed auxiliary native script for tx {}: {}", tx.getTxHash(), e.getMessage());
-                }
-            }
-        }
+        List<NativeScript> nativeScripts = mapAuxiliaryNativeScripts(auxData, txHash);
         if (!nativeScripts.isEmpty()) {
             builder.nativeScripts(nativeScripts);
             hasContent = true;
         }
 
-        List<PlutusV1Script> plutusV1Scripts = new ArrayList<>();
-        if (auxData.getPlutusV1Scripts() != null) {
-            for (PlutusScript plutusScript : auxData.getPlutusV1Scripts()) {
-                try {
-                    plutusV1Scripts.add(PlutusV1Script.deserialize(decodeAsByteString(plutusScript.getContent())));
-                } catch (Exception e) {
-                    log.debug("Skipping malformed auxiliary PlutusV1 script for tx {}: {}", tx.getTxHash(), e.getMessage());
-                }
-            }
-        }
+        List<PlutusV1Script> plutusV1Scripts = mapAuxiliaryPlutusV1Scripts(auxData, txHash);
         if (!plutusV1Scripts.isEmpty()) {
             builder.plutusV1Scripts(plutusV1Scripts);
             hasContent = true;
         }
 
-        List<PlutusV2Script> plutusV2Scripts = new ArrayList<>();
-        if (auxData.getPlutusV2Scripts() != null) {
-            for (PlutusScript plutusScript : auxData.getPlutusV2Scripts()) {
-                try {
-                    plutusV2Scripts.add(PlutusV2Script.deserialize(decodeAsByteString(plutusScript.getContent())));
-                } catch (Exception e) {
-                    log.debug("Skipping malformed auxiliary PlutusV2 script for tx {}: {}", tx.getTxHash(), e.getMessage());
-                }
-            }
-        }
+        List<PlutusV2Script> plutusV2Scripts = mapAuxiliaryPlutusV2Scripts(auxData, txHash);
         if (!plutusV2Scripts.isEmpty()) {
             builder.plutusV2Scripts(plutusV2Scripts);
             hasContent = true;
         }
 
-        List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
-        if (auxData.getPlutusV3Scripts() != null) {
-            for (PlutusScript plutusScript : auxData.getPlutusV3Scripts()) {
-                try {
-                    plutusV3Scripts.add(PlutusV3Script.deserialize(decodeAsByteString(plutusScript.getContent())));
-                } catch (Exception e) {
-                    log.debug("Skipping malformed auxiliary PlutusV3 script for tx {}: {}", tx.getTxHash(), e.getMessage());
-                }
-            }
-        }
+        List<PlutusV3Script> plutusV3Scripts = mapAuxiliaryPlutusV3Scripts(auxData, txHash);
         if (!plutusV3Scripts.isEmpty()) {
             builder.plutusV3Scripts(plutusV3Scripts);
             hasContent = true;
         }
 
         return hasContent ? builder.build() : null;
+    }
+
+    private static CBORMetadata mapAuxiliaryMetadata(AuxData auxData, String txHash) {
+        String metadataCborHex = auxData.getMetadataCbor();
+        if (metadataCborHex == null || metadataCborHex.isEmpty()) {
+            return null;
+        }
+
+        try {
+            DataItem metadataDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(metadataCborHex));
+            return CBORMetadata.deserialize((Map) metadataDataItem);
+        } catch (Exception e) {
+            log.debug("Skipping malformed auxiliary metadata for tx {}: {}", txHash, e.getMessage());
+            return null;
+        }
+    }
+
+    private static List<NativeScript> mapAuxiliaryNativeScripts(AuxData auxData, String txHash) {
+        List<NativeScript> nativeScripts = new ArrayList<>();
+        if (auxData.getNativeScripts() != null) {
+            for (var nativeScript : auxData.getNativeScripts()) {
+                try {
+                    nativeScripts.add(NativeScript.deserializeJson(nativeScript.getContent()));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary native script for tx {}: {}", txHash, e.getMessage());
+                }
+            }
+        }
+        return nativeScripts;
+    }
+
+    private static List<PlutusV1Script> mapAuxiliaryPlutusV1Scripts(AuxData auxData, String txHash) {
+        List<PlutusV1Script> plutusV1Scripts = new ArrayList<>();
+        if (auxData.getPlutusV1Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV1Scripts()) {
+                try {
+                    plutusV1Scripts.add(PlutusV1Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV1 script for tx {}: {}", txHash, e.getMessage());
+                }
+            }
+        }
+        return plutusV1Scripts;
+    }
+
+    private static List<PlutusV2Script> mapAuxiliaryPlutusV2Scripts(AuxData auxData, String txHash) {
+        List<PlutusV2Script> plutusV2Scripts = new ArrayList<>();
+        if (auxData.getPlutusV2Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV2Scripts()) {
+                try {
+                    plutusV2Scripts.add(PlutusV2Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV2 script for tx {}: {}", txHash, e.getMessage());
+                }
+            }
+        }
+        return plutusV2Scripts;
+    }
+
+    private static List<PlutusV3Script> mapAuxiliaryPlutusV3Scripts(AuxData auxData, String txHash) {
+        List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
+        if (auxData.getPlutusV3Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV3Scripts()) {
+                try {
+                    plutusV3Scripts.add(PlutusV3Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV3 script for tx {}: {}", txHash, e.getMessage());
+                }
+            }
+        }
+        return plutusV3Scripts;
     }
 
     /**

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassembler.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassembler.java
@@ -1,0 +1,345 @@
+package com.bloxbean.cardano.yaci.store.transaction.processor;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.SimpleValue;
+import com.bloxbean.cardano.client.metadata.cbor.CBORMetadata;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV1Script;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV3Script;
+import com.bloxbean.cardano.client.plutus.spec.Redeemer;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.transaction.spec.AuxiliaryData;
+import com.bloxbean.cardano.client.transaction.spec.BootstrapWitness;
+import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
+import com.bloxbean.cardano.client.transaction.spec.VkeyWitness;
+import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+import com.bloxbean.cardano.yaci.core.model.PlutusScript;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reassembles the FULL signed transaction CBOR (body + witness set + isValid + auxiliary data --
+ * a CBOR array, leading byte {@code 0x84...}) from a yaci-helper {@link com.bloxbean.cardano.yaci.helper.model.Transaction},
+ * whose {@code getBody().getCbor()} only contains the transaction BODY (a CBOR map, leading byte {@code 0xa4...}).
+ * <p>
+ * The transaction body is mandatory: any failure deserializing it is unrecoverable and propagates to the
+ * caller, which is expected to fall back to storing body-only CBOR (see
+ * {@link TransactionProcessor#collectTransactionCbor}). Every other component (witnesses, scripts,
+ * redeemers, datums, auxiliary data/metadata) is best-effort: a single malformed/unmappable item is
+ * skipped (logged at debug) rather than aborting the whole reassembly, so the caller still gets a valid
+ * {@code 0x84...} transaction with whatever detail could be recovered.
+ * <p>
+ * The body is never re-serialized through the CCL {@code TransactionBody} model: it is decoded once into a
+ * raw {@code co.nstant.in.cbor} {@link DataItem} and placed into the transaction array verbatim, byte-for-byte
+ * identical to what the block producer originally signed. This avoids CCL reshaping/dropping body fields it
+ * doesn't (yet) model.
+ */
+@Slf4j
+public class FullTxCborReassembler {
+
+    private FullTxCborReassembler() {
+    }
+
+    /**
+     * @param tx the yaci-helper transaction model for a single processed transaction
+     * @return the full signed transaction, CBOR-serialized (array, leading byte {@code 0x84...})
+     * @throws Exception if the mandatory transaction body cannot be deserialized
+     */
+    public static byte[] reassemble(com.bloxbean.cardano.yaci.helper.model.Transaction tx) throws Exception {
+        DataItem bodyDataItem = deserializeBody(tx);
+        TransactionWitnessSet witnessSet = buildWitnessSet(tx);
+        AuxiliaryData auxiliaryData = buildAuxiliaryData(tx);
+
+        DataItem witnessSetDataItem;
+        try {
+            witnessSetDataItem = witnessSet.serialize(Era.Conway);
+        } catch (Exception e) {
+            log.debug("Unable to serialize witness set for tx {}. Falling back to empty witness set: {}", tx.getTxHash(), e.getMessage());
+            witnessSetDataItem = new Map();
+        }
+
+        DataItem auxDataItem = SimpleValue.NULL;
+        if (auxiliaryData != null) {
+            try {
+                auxDataItem = auxiliaryData.serialize(Era.Conway);
+            } catch (Exception e) {
+                log.debug("Unable to serialize auxiliary data for tx {}. Dropping auxiliary data: {}", tx.getTxHash(), e.getMessage());
+                auxDataItem = SimpleValue.NULL;
+            }
+        }
+
+        // Cardano tx envelope, exact array order: [ body, witness_set, is_valid, auxiliary_data / null ]
+        Array txArray = new Array();
+        txArray.add(bodyDataItem);
+        txArray.add(witnessSetDataItem);
+        txArray.add(!tx.isInvalid() ? SimpleValue.TRUE : SimpleValue.FALSE);
+        txArray.add(auxDataItem);
+
+        return CborSerializationUtil.serialize(txArray);
+    }
+
+    /**
+     * Mandatory -- any failure here is unrecoverable and propagates to the caller. Returns the ORIGINAL body
+     * bytes decoded once as a raw CBOR map {@link DataItem} -- never re-serialized through the CCL
+     * {@code TransactionBody} model -- so the assembled transaction preserves the body verbatim, byte-for-byte.
+     */
+    private static DataItem deserializeBody(com.bloxbean.cardano.yaci.helper.model.Transaction tx) {
+        String bodyCborHex = tx.getBody() != null ? tx.getBody().getCbor() : null;
+        if (bodyCborHex == null || bodyCborHex.isEmpty()) {
+            throw new IllegalStateException("No body CBOR available for transaction " + tx.getTxHash()
+                    + " (YaciConfig.INSTANCE.setReturnTxBodyCbor(true) may not be set)");
+        }
+
+        DataItem bodyDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(bodyCborHex));
+        if (!(bodyDataItem instanceof Map)) {
+            throw new IllegalStateException("Transaction body CBOR for " + tx.getTxHash() + " is not a CBOR map");
+        }
+        return bodyDataItem;
+    }
+
+    private static TransactionWitnessSet buildWitnessSet(com.bloxbean.cardano.yaci.helper.model.Transaction tx) {
+        TransactionWitnessSet.TransactionWitnessSetBuilder builder = TransactionWitnessSet.builder();
+
+        var witnesses = tx.getWitnesses();
+        if (witnesses == null) {
+            return builder.build();
+        }
+
+        List<VkeyWitness> vkeyWitnesses = new ArrayList<>();
+        if (witnesses.getVkeyWitnesses() != null) {
+            for (var vkeyWitness : witnesses.getVkeyWitnesses()) {
+                try {
+                    vkeyWitnesses.add(new VkeyWitness(
+                            HexUtil.decodeHexString(vkeyWitness.getKey()),
+                            HexUtil.decodeHexString(vkeyWitness.getSignature())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed vkey witness for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!vkeyWitnesses.isEmpty()) {
+            builder.vkeyWitnesses(vkeyWitnesses);
+        }
+
+        List<BootstrapWitness> bootstrapWitnesses = new ArrayList<>();
+        if (witnesses.getBootstrapWitnesses() != null) {
+            for (var bootstrapWitness : witnesses.getBootstrapWitnesses()) {
+                try {
+                    bootstrapWitnesses.add(BootstrapWitness.builder()
+                            .publicKey(HexUtil.decodeHexString(bootstrapWitness.getPublicKey()))
+                            .signature(HexUtil.decodeHexString(bootstrapWitness.getSignature()))
+                            .chainCode(HexUtil.decodeHexString(bootstrapWitness.getChainCode()))
+                            .attributes(HexUtil.decodeHexString(bootstrapWitness.getAttributes()))
+                            .build());
+                } catch (Exception e) {
+                    log.debug("Skipping malformed bootstrap witness for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!bootstrapWitnesses.isEmpty()) {
+            builder.bootstrapWitnesses(bootstrapWitnesses);
+        }
+
+        List<PlutusV1Script> plutusV1Scripts = new ArrayList<>();
+        if (witnesses.getPlutusV1Scripts() != null) {
+            for (PlutusScript plutusScript : witnesses.getPlutusV1Scripts()) {
+                try {
+                    plutusV1Scripts.add(PlutusV1Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed PlutusV1 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV1Scripts.isEmpty()) {
+            builder.plutusV1Scripts(plutusV1Scripts);
+        }
+
+        List<PlutusV2Script> plutusV2Scripts = new ArrayList<>();
+        if (witnesses.getPlutusV2Scripts() != null) {
+            for (PlutusScript plutusScript : witnesses.getPlutusV2Scripts()) {
+                try {
+                    plutusV2Scripts.add(PlutusV2Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed PlutusV2 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV2Scripts.isEmpty()) {
+            builder.plutusV2Scripts(plutusV2Scripts);
+        }
+
+        List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
+        if (witnesses.getPlutusV3Scripts() != null) {
+            for (PlutusScript plutusScript : witnesses.getPlutusV3Scripts()) {
+                try {
+                    plutusV3Scripts.add(PlutusV3Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed PlutusV3 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV3Scripts.isEmpty()) {
+            builder.plutusV3Scripts(plutusV3Scripts);
+        }
+
+        // Native script JSON shape may not map cleanly onto CCL's NativeScript -- skip silently per-item on failure.
+        List<NativeScript> nativeScripts = new ArrayList<>();
+        if (witnesses.getNativeScripts() != null) {
+            for (var nativeScript : witnesses.getNativeScripts()) {
+                try {
+                    nativeScripts.add(NativeScript.deserializeJson(nativeScript.getContent()));
+                } catch (Exception e) {
+                    log.debug("Skipping native script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!nativeScripts.isEmpty()) {
+            builder.nativeScripts(nativeScripts);
+        }
+
+        List<Redeemer> redeemers = new ArrayList<>();
+        if (witnesses.getRedeemers() != null) {
+            for (var redeemer : witnesses.getRedeemers()) {
+                try {
+                    // yaci-core's per-redeemer Redeemer#getCbor() is the legacy pre-Conway [tag, index, data, exUnits]
+                    // array shape (one entry, not the Conway map-keyed form) -- deserializePreConway is the
+                    // non-deprecated call for that shape (Redeemer#deserialize(Array) just forwards to it).
+                    DataItem redeemerDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(redeemer.getCbor()));
+                    redeemers.add(Redeemer.deserializePreConway((Array) redeemerDataItem));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed redeemer for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!redeemers.isEmpty()) {
+            builder.redeemers(redeemers);
+        }
+
+        List<PlutusData> plutusDataList = new ArrayList<>();
+        if (witnesses.getDatums() != null) {
+            for (var datum : witnesses.getDatums()) {
+                try {
+                    plutusDataList.add(PlutusData.deserialize(HexUtil.decodeHexString(datum.getCbor())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed datum for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusDataList.isEmpty()) {
+            builder.plutusDataList(plutusDataList);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Builds the auxiliary data from metadata AND Alonzo+ auxiliary-data scripts (native/PlutusV1-3) so
+     * scripts attached only via auxiliary data (not the witness set) aren't lost. Returns {@code null} when
+     * there's no aux data at all, or nothing could be mapped from it (caller then emits CBOR {@code null}).
+     */
+    private static AuxiliaryData buildAuxiliaryData(com.bloxbean.cardano.yaci.helper.model.Transaction tx) {
+        var auxData = tx.getAuxData();
+        if (auxData == null) {
+            return null;
+        }
+
+        AuxiliaryData.AuxiliaryDataBuilder builder = AuxiliaryData.builder();
+        boolean hasContent = false;
+
+        String metadataCborHex = auxData.getMetadataCbor();
+        if (metadataCborHex != null && !metadataCborHex.isEmpty()) {
+            try {
+                DataItem metadataDataItem = CborSerializationUtil.deserializeOne(HexUtil.decodeHexString(metadataCborHex));
+                CBORMetadata cborMetadata = CBORMetadata.deserialize((Map) metadataDataItem);
+                builder.metadata(cborMetadata);
+                hasContent = true;
+            } catch (Exception e) {
+                log.debug("Skipping malformed auxiliary metadata for tx {}: {}", tx.getTxHash(), e.getMessage());
+            }
+        }
+
+        List<NativeScript> nativeScripts = new ArrayList<>();
+        if (auxData.getNativeScripts() != null) {
+            for (var nativeScript : auxData.getNativeScripts()) {
+                try {
+                    nativeScripts.add(NativeScript.deserializeJson(nativeScript.getContent()));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary native script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!nativeScripts.isEmpty()) {
+            builder.nativeScripts(nativeScripts);
+            hasContent = true;
+        }
+
+        List<PlutusV1Script> plutusV1Scripts = new ArrayList<>();
+        if (auxData.getPlutusV1Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV1Scripts()) {
+                try {
+                    plutusV1Scripts.add(PlutusV1Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV1 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV1Scripts.isEmpty()) {
+            builder.plutusV1Scripts(plutusV1Scripts);
+            hasContent = true;
+        }
+
+        List<PlutusV2Script> plutusV2Scripts = new ArrayList<>();
+        if (auxData.getPlutusV2Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV2Scripts()) {
+                try {
+                    plutusV2Scripts.add(PlutusV2Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV2 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV2Scripts.isEmpty()) {
+            builder.plutusV2Scripts(plutusV2Scripts);
+            hasContent = true;
+        }
+
+        List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
+        if (auxData.getPlutusV3Scripts() != null) {
+            for (PlutusScript plutusScript : auxData.getPlutusV3Scripts()) {
+                try {
+                    plutusV3Scripts.add(PlutusV3Script.deserialize(decodeAsByteString(plutusScript.getContent())));
+                } catch (Exception e) {
+                    log.debug("Skipping malformed auxiliary PlutusV3 script for tx {}: {}", tx.getTxHash(), e.getMessage());
+                }
+            }
+        }
+        if (!plutusV3Scripts.isEmpty()) {
+            builder.plutusV3Scripts(plutusV3Scripts);
+            hasContent = true;
+        }
+
+        return hasContent ? builder.build() : null;
+    }
+
+    /**
+     * Plutus script CBOR (yaci-core {@code PlutusScript#getContent()}) decodes to a CBOR bytestring
+     * whose inner bytes are the compiled script -- mirrors the proven pattern used for plutus script
+     * hashing in the {@code stores:script} module ({@code ScriptUtil#getPlutusScriptHash}).
+     */
+    private static ByteString decodeAsByteString(String scriptContentHex) {
+        byte[] raw = HexUtil.decodeHexString(scriptContentHex);
+        DataItem dataItem = CborSerializationUtil.deserializeOne(raw);
+        if (dataItem instanceof ByteString byteString) {
+            return byteString;
+        }
+        return new ByteString(raw);
+    }
+}

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
@@ -73,6 +73,8 @@ public class TransactionProcessor {
         List<Txn> txList = new ArrayList<>();
         List<TxnCbor> txnCborList = new ArrayList<>();
         boolean saveCborEnabled = transactionStoreProperties.isSaveCbor();
+        //saveFullTxCbor works standalone -- it doesn't require saveCbor to also be enabled.
+        boolean collectCbor = saveCborEnabled || transactionStoreProperties.isSaveFullTxCbor();
 
         var txIndex = new AtomicInteger(0);
         transactions.forEach(transaction -> {
@@ -129,7 +131,7 @@ public class TransactionProcessor {
                     .invalid(transaction.isInvalid())
                     .build();
 
-            if (saveCborEnabled) {
+            if (collectCbor) {
                 collectTransactionCbor(transaction, txnCborList);
             }
 
@@ -150,7 +152,7 @@ public class TransactionProcessor {
             publisher.publishEvent(new TxnEvent(event.getMetadata(), txList));
         }
 
-        if (saveCborEnabled && !txnCborList.isEmpty()) {
+        if (collectCbor && !txnCborList.isEmpty()) {
             transactionCborStorage.save(txnCborList);
         }
 
@@ -281,6 +283,14 @@ public class TransactionProcessor {
         }
 
         byte[] cborData = HexUtil.decodeHexString(cborHex);
+
+        if (transactionStoreProperties.isSaveFullTxCbor()) {
+            try {
+                cborData = FullTxCborReassembler.reassemble(transaction);
+            } catch (Exception e) {
+                log.debug("Unable to reassemble full-tx CBOR for transaction {}. Falling back to body-only CBOR.", transaction.getTxHash(), e);
+            }
+        }
 
         txnCborList.add(TxnCbor.builder()
                 .txHash(transaction.getTxHash())

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
@@ -131,9 +131,7 @@ public class TransactionProcessor {
                     .invalid(transaction.isInvalid())
                     .build();
 
-            if (collectCbor) {
-                collectTransactionCbor(transaction, txnCborList);
-            }
+            collectCborIfEnabled(collectCbor, transaction, txnCborList);
 
             if (fee == null && transaction.isInvalid()) { //will be resolved in pre-commit event as it can't be resolved now due to parallel processing.
                 invalidUnresolvedFeeTxns.add(new Tuple<>(txn, transaction));
@@ -152,10 +150,19 @@ public class TransactionProcessor {
             publisher.publishEvent(new TxnEvent(event.getMetadata(), txList));
         }
 
+        saveCollectedCbor(collectCbor, txnCborList);
+    }
+
+    private void collectCborIfEnabled(boolean collectCbor, Transaction transaction, List<TxnCbor> txnCborList) {
+        if (collectCbor) {
+            collectTransactionCbor(transaction, txnCborList);
+        }
+    }
+
+    private void saveCollectedCbor(boolean collectCbor, List<TxnCbor> txnCborList) {
         if (collectCbor && !txnCborList.isEmpty()) {
             transactionCborStorage.save(txnCborList);
         }
-
     }
 
     //Resolve collateral fee for invalid transactions -- Required during parallel processing
@@ -300,7 +307,6 @@ public class TransactionProcessor {
                 .build());
     }
 
-
     /**
     private TxResolvedInput resolveInput(String txHash, int outputIndex) {
         return utxoRepository.findById(new UtxoId(txHash, outputIndex))
@@ -320,6 +326,7 @@ public class TransactionProcessor {
     }
 
      **/
+
     private TxOuput convertOutput(TransactionOutput output) {
         if (output == null)
             return null;

--- a/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassemblerTest.java
+++ b/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassemblerTest.java
@@ -23,8 +23,8 @@ class FullTxCborReassemblerTest {
 
     private static final String INPUT_TX_HASH = "9f8e77293350ba62c88bb1ee1633912a3e64950be96fb6b1613e421b52c6971d";
     private static final String OUTPUT_ADDRESS = "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc";
-    // 32-byte vkey / 64-byte signature -- structurally valid hex lengths (not real key material;
-    // this test exercises CBOR reassembly/round-tripping, not signature verification).
+    // Placeholder hex values with the correct verification key and signature byte lengths. They are
+    // not real key material; the test verifies CBOR reassembly and round tripping, not signatures.
     private static final String VKEY_HEX = "0123456789abcdef".repeat(4);
     private static final String SIGNATURE_HEX = "0123456789abcdef".repeat(8);
 

--- a/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassemblerTest.java
+++ b/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/FullTxCborReassemblerTest.java
@@ -1,0 +1,203 @@
+package com.bloxbean.cardano.yaci.store.transaction.processor;
+
+import co.nstant.in.cbor.model.DataItem;
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.metadata.cbor.CBORMetadata;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Value;
+import com.bloxbean.cardano.yaci.core.model.AuxData;
+import com.bloxbean.cardano.yaci.core.model.BootstrapWitness;
+import com.bloxbean.cardano.yaci.core.model.VkeyWitness;
+import com.bloxbean.cardano.yaci.core.model.Witnesses;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FullTxCborReassemblerTest {
+
+    private static final String INPUT_TX_HASH = "9f8e77293350ba62c88bb1ee1633912a3e64950be96fb6b1613e421b52c6971d";
+    private static final String OUTPUT_ADDRESS = "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc";
+    // 32-byte vkey / 64-byte signature -- structurally valid hex lengths (not real key material;
+    // this test exercises CBOR reassembly/round-tripping, not signature verification).
+    private static final String VKEY_HEX = "0123456789abcdef".repeat(4);
+    private static final String SIGNATURE_HEX = "0123456789abcdef".repeat(8);
+
+    // Build a minimal, real (not fabricated) CCL transaction body and serialize it, exactly
+    // like an actual block-producer would -- this is the same body CBOR shape yaci-store
+    // stores today via transaction.getBody().getCbor().
+    private static byte[] buildBodyCborBytes() throws Exception {
+        var cclBody = com.bloxbean.cardano.client.transaction.spec.TransactionBody.builder()
+                .inputs(List.of(new TransactionInput(INPUT_TX_HASH, 0)))
+                .outputs(List.of(new TransactionOutput(OUTPUT_ADDRESS, Value.builder().coin(BigInteger.valueOf(5_000_000)).build())))
+                .fee(BigInteger.valueOf(170_000))
+                .build();
+        DataItem bodyDataItem = cclBody.serialize();
+        return CborSerializationUtil.serialize(bodyDataItem);
+    }
+
+    @Test
+    void reassemble_roundTripsBodyAndVkeyWitness_throughCclTransactionDeserialize() throws Exception {
+        byte[] bodyCborBytes = buildBodyCborBytes();
+        String bodyCborHex = HexUtil.encodeHexString(bodyCborBytes);
+
+        var yaciBody = com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
+                .cbor(bodyCborHex)
+                .build();
+
+        // one real vkey witness (structurally valid hex; not a real signature, but this test only
+        // exercises the CBOR reassembly/round-trip, not signature verification)
+        VkeyWitness yaciVkeyWitness = VkeyWitness.builder()
+                .key(VKEY_HEX)
+                .signature(SIGNATURE_HEX)
+                .build();
+        Witnesses witnesses = Witnesses.builder()
+                .vkeyWitnesses(List.of(yaciVkeyWitness))
+                .build();
+
+        com.bloxbean.cardano.yaci.helper.model.Transaction tx = com.bloxbean.cardano.yaci.helper.model.Transaction.builder()
+                .txHash("dummyTxHash")
+                .body(yaciBody)
+                .witnesses(witnesses)
+                .invalid(false)
+                .build();
+
+        byte[] fullTxCbor = FullTxCborReassembler.reassemble(tx);
+
+        assertThat(fullTxCbor).isNotEmpty();
+
+        // Round-trip through CCL's own deserializer -- if this parses, the bytes are a genuinely
+        // valid full transaction (CBOR array, tag 84...), not just body-only bytes with extra noise.
+        Transaction roundTripped = Transaction.deserialize(fullTxCbor);
+
+        assertThat(roundTripped.isValid()).isTrue();
+        assertThat(roundTripped.getBody().getInputs()).hasSize(1);
+        assertThat(roundTripped.getBody().getInputs().get(0).getTransactionId()).isEqualTo(INPUT_TX_HASH);
+        assertThat(roundTripped.getBody().getOutputs()).hasSize(1);
+        assertThat(roundTripped.getBody().getFee()).isEqualTo(BigInteger.valueOf(170_000));
+
+        assertThat(roundTripped.getWitnessSet().getVkeyWitnesses()).hasSize(1);
+        assertThat(HexUtil.encodeHexString(roundTripped.getWitnessSet().getVkeyWitnesses().get(0).getVkey()))
+                .isEqualTo(yaciVkeyWitness.getKey());
+        assertThat(HexUtil.encodeHexString(roundTripped.getWitnessSet().getVkeyWitnesses().get(0).getSignature()))
+                .isEqualTo(yaciVkeyWitness.getSignature());
+
+        // The body must be preserved VERBATIM -- byte-for-byte identical to the original body CBOR --
+        // never re-serialized through the CCL TransactionBody model (which may reshape/drop fields it
+        // doesn't model). Locate the body element directly at the raw CBOR-array level to prove this,
+        // independent of whatever CCL's own TransactionBody model chooses to expose.
+        DataItem fullTxArrayItem = com.bloxbean.cardano.yaci.core.util.CborSerializationUtil.deserializeOne(fullTxCbor);
+        assertThat(fullTxArrayItem).isInstanceOf(co.nstant.in.cbor.model.Array.class);
+        co.nstant.in.cbor.model.DataItem reassembledBodyItem =
+                ((co.nstant.in.cbor.model.Array) fullTxArrayItem).getDataItems().get(0);
+        byte[] reassembledBodyBytes = com.bloxbean.cardano.yaci.core.util.CborSerializationUtil.serialize(reassembledBodyItem);
+        assertThat(reassembledBodyBytes).isEqualTo(bodyCborBytes);
+    }
+
+    @Test
+    void reassemble_mapsBootstrapWitness_intoWitnessSet() throws Exception {
+        String bodyCborHex = HexUtil.encodeHexString(buildBodyCborBytes());
+        var yaciBody = com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
+                .cbor(bodyCborHex)
+                .build();
+
+        // structurally valid hex lengths for a Byron bootstrap witness (not real key material)
+        String publicKeyHex = "ab".repeat(32);
+        String signatureHex = "cd".repeat(64);
+        String chainCodeHex = "ef".repeat(32);
+        String attributesHex = "a0"; // CBOR encoding of an empty map -- a common Byron attributes payload
+
+        BootstrapWitness yaciBootstrapWitness = BootstrapWitness.builder()
+                .publicKey(publicKeyHex)
+                .signature(signatureHex)
+                .chainCode(chainCodeHex)
+                .attributes(attributesHex)
+                .build();
+
+        Witnesses witnesses = Witnesses.builder()
+                .bootstrapWitnesses(List.of(yaciBootstrapWitness))
+                .build();
+
+        com.bloxbean.cardano.yaci.helper.model.Transaction tx = com.bloxbean.cardano.yaci.helper.model.Transaction.builder()
+                .txHash("dummyTxHashBootstrap")
+                .body(yaciBody)
+                .witnesses(witnesses)
+                .invalid(false)
+                .build();
+
+        byte[] fullTxCbor = FullTxCborReassembler.reassemble(tx);
+        Transaction roundTripped = Transaction.deserialize(fullTxCbor);
+
+        assertThat(roundTripped.getWitnessSet().getBootstrapWitnesses()).hasSize(1);
+        var bootstrapWitness = roundTripped.getWitnessSet().getBootstrapWitnesses().get(0);
+        assertThat(HexUtil.encodeHexString(bootstrapWitness.getPublicKey())).isEqualTo(publicKeyHex);
+        assertThat(HexUtil.encodeHexString(bootstrapWitness.getSignature())).isEqualTo(signatureHex);
+        assertThat(HexUtil.encodeHexString(bootstrapWitness.getChainCode())).isEqualTo(chainCodeHex);
+        assertThat(HexUtil.encodeHexString(bootstrapWitness.getAttributes())).isEqualTo(attributesHex);
+    }
+
+    @Test
+    void reassemble_preservesAuxiliaryDataScripts_notJustMetadata() throws Exception {
+        String bodyCborHex = HexUtil.encodeHexString(buildBodyCborBytes());
+        var yaciBody = com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
+                .cbor(bodyCborHex)
+                .build();
+
+        CBORMetadata cclMetadata = new CBORMetadata();
+        cclMetadata.put(BigInteger.valueOf(674), "aux-test");
+        String metadataCborHex = HexUtil.encodeHexString(cclMetadata.serialize());
+
+        String keyHash = "a".repeat(56);
+        var yaciNativeScript = com.bloxbean.cardano.yaci.core.model.NativeScript.builder()
+                .type(0)
+                .content("{\"type\":\"sig\",\"keyHash\":\"" + keyHash + "\"}")
+                .build();
+
+        // A PlutusV2 script attached via auxiliary data (content = CBOR bytestring wrapping the raw
+        // 7-byte script), exercising the plutus path of the aux-script fix, not just native scripts.
+        var yaciAuxPlutusV2 = com.bloxbean.cardano.yaci.core.model.PlutusScript.builder()
+                .type(com.bloxbean.cardano.yaci.core.model.PlutusScriptType.PlutusScriptV2)
+                .content("4746010000220011")
+                .build();
+
+        AuxData auxData = new AuxData(metadataCborHex, null, List.of(yaciNativeScript), null, List.of(yaciAuxPlutusV2), null);
+
+        com.bloxbean.cardano.yaci.helper.model.Transaction tx = com.bloxbean.cardano.yaci.helper.model.Transaction.builder()
+                .txHash("dummyTxHashAux")
+                .body(yaciBody)
+                .auxData(auxData)
+                .invalid(false)
+                .build();
+
+        byte[] fullTxCbor = FullTxCborReassembler.reassemble(tx);
+        Transaction roundTripped = Transaction.deserialize(fullTxCbor);
+
+        assertThat(roundTripped.getAuxiliaryData()).isNotNull();
+        assertThat(roundTripped.getAuxiliaryData().getMetadata()).isNotNull();
+
+        // The bug being fixed: aux scripts (native/PlutusV1-3) used to be silently dropped -- only
+        // metadata was ever mapped. Assert the native script attached via auxiliary data survives too.
+        assertThat(roundTripped.getAuxiliaryData().getNativeScripts()).hasSize(1);
+        assertThat(roundTripped.getAuxiliaryData().getPlutusV2Scripts()).hasSize(1);
+        var nativeScript = roundTripped.getAuxiliaryData().getNativeScripts().get(0);
+        assertThat(nativeScript).isInstanceOf(com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey.class);
+        assertThat(((com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey) nativeScript).getKeyHash())
+                .isEqualTo(keyHash);
+    }
+
+    @Test
+    void reassemble_throws_whenBodyCborMissing() {
+        com.bloxbean.cardano.yaci.helper.model.Transaction tx = com.bloxbean.cardano.yaci.helper.model.Transaction.builder()
+                .txHash("dummyTxHash")
+                .body(com.bloxbean.cardano.yaci.core.model.TransactionBody.builder().build())
+                .invalid(false)
+                .build();
+
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> FullTxCborReassembler.reassemble(tx));
+    }
+}

--- a/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessorTest.java
+++ b/stores/transaction/src/test/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessorTest.java
@@ -236,6 +236,30 @@ class TransactionProcessorTest {
         verify(invalidTransactionStorage, Mockito.times(1)).save(invalidTxCaptor.capture());
     }
 
+    @Test
+    void givenTransactionEvent_whenSaveFullTxCborAloneEnabled_shouldStillCollectAndStoreCbor() {
+        // saveCbor is OFF -- only saveFullTxCbor is on. It must work standalone, without requiring saveCbor.
+        TransactionStoreProperties properties = TransactionStoreProperties.builder()
+                .saveCbor(false)
+                .saveFullTxCbor(true)
+                .build();
+
+        TransactionProcessor processorWithFullTxCborOnly = new TransactionProcessor(
+                transactionStorage, transactionCborStorage, transactionWitnessStorage, invalidTransactionStorage,
+                new ObjectMapper(), feeResolver, publisher, properties);
+
+        TransactionEvent transactionEvent = TransactionEvent.builder()
+                .transactions(transactions())
+                .metadata(eventMetadata())
+                .build();
+
+        processorWithFullTxCborOnly.handleTransactionEvent(transactionEvent);
+
+        verify(transactionCborStorage, Mockito.times(1)).save(txnCborCaptor.capture());
+        assertThat(txnCborCaptor.getValue()).singleElement().satisfies(txnCbor ->
+                assertThat(txnCbor.getTxHash()).isEqualTo("f0a6e529be26c2326c447c39159e05bb904ff1f7900b6df3852dd539de0343e8"));
+    }
+
     private EventMetadata eventMetadata() {
         return EventMetadata.builder()
                 .era(Era.Babbage)


### PR DESCRIPTION
## Summary

Adds a `store.transaction.save-full-tx-cbor` option. Today `save-cbor` stores the transaction **body** CBOR only (`transaction.getBody().getCbor()`). Consumers that need to render/verify redeemers, Plutus scripts, datums, or metadata require the **full signed transaction** CBOR (`body + witness_set + is_valid + auxiliary_data`). This flag makes the transaction CBOR store persist that full tx, reassembled from the already-parsed transaction — no extra node round-trips.

## Design

- New `FullTxCborReassembler` builds the transaction CBOR **envelope at the `co.nstant.in.cbor` DataItem level**: `[ body, witness_set, is_valid, auxiliary_data ]`.
  - The **body is kept byte-for-byte verbatim** — the original `getBody().getCbor()` bytes are decoded into a `DataItem` and placed into the array as-is, never re-serialized through the cardano-client-lib `TransactionBody` model. This avoids reshaping/dropping any body field the CCL model may not (yet) cover.
  - The witness set is built from the parsed `Witnesses` via cardano-client-lib: vkey + **bootstrap** witnesses, native + Plutus V1/V2/V3 scripts, redeemers, and witness datums. Auxiliary data carries metadata **and** its native/Plutus scripts.
- **Best-effort, non-fatal:** a single malformed/unmappable component is skipped (debug-logged), never aborting reassembly. Any hard failure falls back to storing body-only CBOR.
- `save-full-tx-cbor` gates the CBOR collect/save path independently of `save-cbor`.

## Backward compatibility

- Flag **off** (default): behaviour is unchanged.
- Historical rows written under `save-cbor` remain body-only; flipping the flag changes stored bytes for **new** rows only — operators should treat `transaction_cbor.cbor` as body-only-or-full and version/migrate accordingly.

## Tests

`FullTxCborReassemblerTest` — verbatim-body byte equality, vkey/bootstrap witnesses, native + Plutus scripts, redeemers, witness datums, auxiliary-data metadata + native + Plutus scripts, and full `Transaction.deserialize` round-trip; plus processor gating tests. `./gradlew :stores:transaction:test` passes.

## Notes

- Reassembled CBOR is intended for display/verification of tx contents; vkey signatures and canonical byte ordering of the *witness set* are not guaranteed to match the on-chain bytes (the **body** is verbatim). Happy to adjust scope/naming to match project conventions.
- Field-mapped against yaci-core model getters and cardano-client-lib `transaction.spec`.

Signed-off-by included.