### PR TITLE
[Backport to main] Backport JVM DNS TTL defaults for Yaci 0.4.4 to main

### DIFF
--- a/bin/start.bat
+++ b/bin/start.bat
@@ -9,6 +9,9 @@ REM ------------------------------------------------------------
 REM Save the current working directory
 SET CURRENT_DIR=%CD%
 
+REM Lower JVM DNS cache TTLs to avoid stale DNS cache.
+SET "JAVA_OPTS=-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10 %JAVA_OPTS%"
+
 REM Uncomment the following line to enable polyglot (Python, JS) plugins support.
 :: set "JAVA_OPTS=%JAVA_OPTS% -Dloader.path=plugins,plugins/lib,plugins/ext-jars"
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Lower JVM DNS cache TTLs to avoid stale DNS cache.
+JAVA_OPTS="-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10 $JAVA_OPTS"
+
 # Uncomment the following line to enable polyglot (Python, JS) plugins support.
 #JAVA_OPTS="$JAVA_OPTS -Dloader.path=plugins,plugins/lib,plugins/ext-jars"
 

--- a/docker/config/env
+++ b/docker/config/env
@@ -1,6 +1,9 @@
 # Common env file
 
-# Java Options
+# Lower JVM DNS cache TTLs to avoid stale DNS cache.
+JAVA_TOOL_OPTIONS=-Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=10
+
+# JVM options (heap, GC, etc.).
 # JDK_JAVA_OPTIONS=-Xms4G -Xmx12G
 
 ## Enable Ledger State profile
@@ -19,5 +22,5 @@
 #SPRING_PROFILES_ACTIVE=ledger-state,analytics,blockfrost
 
 ## Enable polyglot plugins (Python, JS) support.
-# JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+# LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
 

--- a/docs/app/docs/v2/plugins/write-first-plugin/page.mdx
+++ b/docs/app/docs/v2/plugins/write-first-plugin/page.mdx
@@ -22,7 +22,7 @@ First, unzip your yaci-store docker distribution and navigate to the directory.
 Edit the `config/env` file to enable plugin support by uncommenting the following line:
 
 ```bash
-JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
 ```
 
 ### 2. Understanding the Plugin Directory Structure

--- a/docs/app/docs/v2/tutorials/tracking-address-utxos/page.mdx
+++ b/docs/app/docs/v2/tutorials/tracking-address-utxos/page.mdx
@@ -203,7 +203,7 @@ Yaci Store uses a plugin system to extend its functionality. Let's enable it.
    Find and uncomment (remove the `#` at the beginning) this line:
 
    ```bash
-   JDK_JAVA_OPTIONS=${JDK_JAVA_OPTIONS} -Dloader.path=plugins,plugins/lib,plugins/ext-jars
+   LOADER_PATH=plugins,plugins/lib,plugins/ext-jars
    ```
 
    This tells Yaci Store to load plugins from the `plugins` directory.


### PR DESCRIPTION

## Summary

Backports the JVM DNS cache TTL defaults from `release/2.0.x` to `main`.

`main` already uses `yaci:0.4.4`, but it is missing the JVM-level DNS TTL settings that were added on `release/2.0.x` to support the Yaci 0.4.4 stale-DNS-cache fix.

## Backported commit

| Source PR | Original commit | Change |
|---|---:|---|
| #960 | `d26bc87b8` | Set JVM DNS cache TTL defaults for Yaci 0.4.4 |

## Details

This change adds the JVM DNS cache TTL defaults required by the Yaci 0.4.4 DNS re-resolution behavior:

- `-Dsun.net.inetaddr.ttl=60`
- `-Dsun.net.inetaddr.negative.ttl=10`

It applies the defaults in:

- `bin/start.sh`
- `bin/start.bat`
- `docker/config/env`

It also updates plugin/tutorial docs to use the `LOADER_PATH` docker env pattern.

Note: the Yaci version bump from #960 is not included because `main` already uses `yaci:0.4.4`.
