### PR TITLE
docs: add Nexus (A.D. Labs) to showcase page and Trusted By section

### DIFF
--- a/docs/app/docs/v2/showcase/projects-using-yaci-store/page.mdx
+++ b/docs/app/docs/v2/showcase/projects-using-yaci-store/page.mdx
@@ -60,6 +60,12 @@ A simple crawler app that stores relevant scoop transaction info and serves aggr
 ### [CBI Backend Service](https://github.com/Cardano-Fans/cbi-backend)
 **Cardano Fans (CRFA)**
 
+---
+
+### [Nexus](https://market.gerowallet.io)
+**[A.D. Labs](https://adlabs.dev)**
+Multi-chain blockchain data API. Nexus uses Yaci Store as its primary Cardano data provider - powering address, transaction, asset, pool, and DRep endpoints - behind a connection-pooled REST client with batched fan-out for high-concurrency queries. API available at https://nexus.gerowallet.io.
+
 ## Technical Integration Patterns
 
 These projects demonstrate various integration patterns with Yaci Store:
@@ -70,6 +76,7 @@ These projects demonstrate various integration patterns with Yaci Store:
 - **Microservices**: AdaHandle Resolver runs as a lightweight service with minimal stores enabled
 - **Governance Infrastructure**: Ballot and Reeve platforms utilize governance stores for on-chain voting
 - **Automation Workflows**: AdaMatic integrates multiple stores for complex blockchain interactions
+- **High-Concurrency Data API**: Nexus fronts Yaci Store as a multi-provider Cardano data API, batching per-tx/per-utxo fan-out behind a tuned HTTP pool
 
 ## Join the Community
 


### PR DESCRIPTION
Adds **Nexus** by [A.D. Labs](https://adlabs.dev) to the Yaci Store docs.

Nexus is a multi-chain blockchain data API that uses Yaci Store as its primary Cardano data provider - powering address, transaction, asset, pool, and DRep endpoints - behind a connection-pooled REST client with batched fan-out for high-concurrency queries.

- Product / Cardano market data: https://market.gerowallet.io
- API provider: https://nexus.gerowallet.io

## Changes

**`docs/app/docs/v2/showcase/projects-using-yaci-store/page.mdx`**
- New entry under *Community Projects*
- New bullet under *Technical Integration Patterns* (High-Concurrency Data API)

**`docs/app/page.jsx`** (homepage *Trusted By* grid)
- New project card for Nexus
- New `.project-icon img` CSS rule so an image icon renders at the same 3rem size as the existing emoji icons

**`docs/public/images/nexus.svg`**
- Nexus logo used as the card icon. Gradient mark with no black/white ink, so it reads on both light and dark themes.

## Verification

Ran the docs app locally (`next dev`) and confirmed the homepage renders the new card, the SVG loads (150x150 natural, 48x48 rendered - matching the emoji icons), and the link resolves.

Happy to switch the card icon back to an emoji if you'd prefer to keep that section emoji-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)