### PR TITLE
fix(governance): compare committee ratios exactly

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluator.java
@@ -8,7 +8,7 @@ import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingEvaluator;
 import com.bloxbean.cardano.yaci.store.governancerules.voting.VotingStatus;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.BigInteger;
 
 public class CommitteeVotingEvaluator implements VotingEvaluator<VotingData> {
 
@@ -33,8 +33,8 @@ public class CommitteeVotingEvaluator implements VotingEvaluator<VotingData> {
             return VotingStatus.NOT_PASS_THRESHOLD;
         }
 
-        var threshold = committee.getThreshold().safeRatio();
-        if (threshold.equals(BigDecimal.ZERO)) {
+        var threshold = committee.getThreshold();
+        if (threshold.safeRatio().compareTo(BigDecimal.ZERO) == 0) {
             return VotingStatus.PASS_THRESHOLD;
         }
 
@@ -49,11 +49,14 @@ public class CommitteeVotingEvaluator implements VotingEvaluator<VotingData> {
         if (totalExcludingAbstain == 0) {
             return VotingStatus.NOT_PASS_THRESHOLD;
         }
-        
-        BigDecimal acceptedRatio = BigDecimal.valueOf(yesVotes)
-                .divide(BigDecimal.valueOf(totalExcludingAbstain), 4, RoundingMode.HALF_UP);
 
-        return acceptedRatio.compareTo(threshold) >= 0 ?
+        // Compare yes/total >= thresholdNumerator/thresholdDenominator exactly by cross-multiplying.
+        BigInteger acceptedRatioSide = BigInteger.valueOf(yesVotes)
+                .multiply(threshold.getDenominator());
+        BigInteger thresholdSide = BigInteger.valueOf(totalExcludingAbstain)
+                .multiply(threshold.getNumerator());
+
+        return acceptedRatioSide.compareTo(thresholdSide) >= 0 ?
                 VotingStatus.PASS_THRESHOLD : VotingStatus.NOT_PASS_THRESHOLD;
     }
 }

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/committee/CommitteeVotingEvaluatorTest.java
@@ -87,6 +87,35 @@ class CommitteeVotingEvaluatorTest {
     }
 
     @Test
+    void evaluate_usesExactRationalComparisonAtThresholdBoundary() {
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(ConstitutionCommitteeState.NORMAL)
+                .threshold(new UnitInterval(BigInteger.valueOf(6667), BigInteger.valueOf(10000)))
+                .members(List.of(
+                        member("cold1", "hot1"),
+                        member("cold2", "hot2"),
+                        member("cold3", "hot3")))
+                .build();
+
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of(
+                                "hot1", Vote.YES,
+                                "hot2", Vote.YES,
+                                "hot3", Vote.NO))
+                        .build())
+                .build();
+
+        VotingEvaluationContext context = VotingEvaluationContext.builder()
+                .committee(committee)
+                .build();
+
+        VotingStatus result = evaluator.evaluate(votingData, context);
+
+        assertThat(result).isEqualTo(VotingStatus.NOT_PASS_THRESHOLD);
+    }
+
+    @Test
     void evaluate_returnsNotPassThreshold_whenCommitteeStateIsNormal_andMinorityVotesYes() {
         ConstitutionCommittee committee = ConstitutionCommittee.builder()
                 .state(ConstitutionCommitteeState.NORMAL)


### PR DESCRIPTION
#1013
## Summary

  - Replace committee accepted-ratio decimal rounding with exact rational comparison.
  - Compare `yesVotes / totalExcludingAbstain` against the committee threshold by cross-multiplying `BigInteger` values.
  - Add a regression test for the `2/3` vs `6667/10000` threshold boundary that previously rounded up and passed incorrectly.

  ## Why

  `cardano-ledger` compares committee voting ratios as exact rationals. The previous implementation rounded the accepted ratio to 4 decimal places before comparison, which could diverge from ledger behavior near
  threshold boundaries.

  ## Tests

  - `./gradlew :aggregates:governance-rules:test --tests '*CommitteeVotingEvaluatorTest.evaluate_usesExactRationalComparisonAtThresholdBoundary'`
  - `./gradlew :aggregates:governance-rules:test --tests '*CommitteeVotingEvaluatorTest'`
  - `./gradlew :aggregates:governance-rules:test`