### PR TITLE
feat: expose network identity and sync status

### DIFF
--- a/components/admin-ui/frontend/src/lib/api/client.ts
+++ b/components/admin-ui/frontend/src/lib/api/client.ts
@@ -9,6 +9,7 @@ export interface SyncStatus {
     syncPercentage: number;
     networkBlock: number;
     networkSlot: number;
+    networkTipAvailable: boolean;
     synced: boolean;
     protocolMagic: number;
 }

--- a/components/admin-ui/frontend/src/lib/components/dashboard/SyncProgress.svelte
+++ b/components/admin-ui/frontend/src/lib/components/dashboard/SyncProgress.svelte
@@ -3,6 +3,7 @@
     export let isSynced: boolean;
     export let currentBlock: number;
     export let networkBlock: number;
+    export let networkTipAvailable: boolean;
 
     $: progressPercentage = Math.min(100, Math.max(0, percentage));
 </script>
@@ -10,7 +11,11 @@
 <div class="stat-card">
     <div class="flex items-center justify-between mb-2">
         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">Sync Progress</h3>
-        {#if isSynced}
+        {#if !networkTipAvailable}
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                Tip unavailable
+            </span>
+        {:else if isSynced}
             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
                 Synced
             </span>
@@ -28,7 +33,7 @@
     </div>
     <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400">
         <span>Block {currentBlock.toLocaleString()}</span>
-        <span>{progressPercentage.toFixed(2)}%</span>
-        <span>Network {networkBlock.toLocaleString()}</span>
+        <span>{networkTipAvailable ? `${progressPercentage.toFixed(2)}%` : 'Unknown'}</span>
+        <span>{networkTipAvailable ? `Network ${networkBlock.toLocaleString()}` : 'Network unavailable'}</span>
     </div>
 </div>

--- a/components/admin-ui/frontend/src/routes/+page.svelte
+++ b/components/admin-ui/frontend/src/routes/+page.svelte
@@ -54,13 +54,13 @@
         <StatCard
             title="Current Block"
             value={syncStatus.block.toLocaleString()}
-            subtitle="Network: {syncStatus.networkBlock.toLocaleString()}"
+            subtitle={syncStatus.networkTipAvailable ? `Network: ${syncStatus.networkBlock.toLocaleString()}` : 'Network tip unavailable'}
             icon="block"
         />
         <StatCard
             title="Current Slot"
             value={syncStatus.slot.toLocaleString()}
-            subtitle="Network: {syncStatus.networkSlot.toLocaleString()}"
+            subtitle={syncStatus.networkTipAvailable ? `Network: ${syncStatus.networkSlot.toLocaleString()}` : 'Network tip unavailable'}
             icon="slot"
         />
         <StatCard
@@ -81,6 +81,7 @@
             isSynced={syncStatus.synced}
             currentBlock={syncStatus.block}
             networkBlock={syncStatus.networkBlock}
+            networkTipAvailable={syncStatus.networkTipAvailable}
         />
         <HealthBadge {health} />
     </div>

--- a/components/admin-ui/frontend/src/routes/sync/+page.svelte
+++ b/components/admin-ui/frontend/src/routes/sync/+page.svelte
@@ -65,6 +65,7 @@
             isSynced={syncStatus.synced}
             currentBlock={syncStatus.block}
             networkBlock={syncStatus.networkBlock}
+            networkTipAvailable={syncStatus.networkTipAvailable}
         />
 
         <SyncControls
@@ -84,7 +85,7 @@
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Network Block</p>
-                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.networkBlock.toLocaleString()}</p>
+                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.networkTipAvailable ? syncStatus.networkBlock.toLocaleString() : 'Unavailable'}</p>
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Current Slot</p>
@@ -92,7 +93,7 @@
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Network Slot</p>
-                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.networkSlot.toLocaleString()}</p>
+                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.networkTipAvailable ? syncStatus.networkSlot.toLocaleString() : 'Unavailable'}</p>
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Epoch</p>
@@ -104,7 +105,7 @@
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Sync Percentage</p>
-                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.syncPercentage.toFixed(4)}%</p>
+                <p class="text-lg font-semibold text-gray-900 dark:text-white">{syncStatus.networkTipAvailable ? `${syncStatus.syncPercentage.toFixed(4)}%` : 'Unknown'}</p>
             </div>
             <div>
                 <p class="text-xs text-gray-500 dark:text-gray-400">Block Hash</p>

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/SyncStatus.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/domain/SyncStatus.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.common.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 @Builder
@@ -15,4 +16,10 @@ public record SyncStatus(
         boolean synced,
         long protocolMagic
 ) {
+    public static final long UNKNOWN_NETWORK_TIP = -1L;
+
+    @JsonProperty
+    public boolean networkTipAvailable() {
+        return networkBlock != UNKNOWN_NETWORK_TIP && networkSlot != UNKNOWN_NETWORK_TIP;
+    }
 }

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ShelleyGenesis.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ShelleyGenesis.java
@@ -39,6 +39,9 @@ public class ShelleyGenesis extends GenesisFile {
     public static final String ATTR_EPOCH_LENGTH = "epochLength";
     public static final String ATTR_NETWORK_MAGIC = "networkMagic";
     public static final String SECURITY_PARAM = "securityParam";
+    public static final String ATTR_UPDATE_QUORUM = "updateQuorum";
+    public static final String ATTR_SLOTS_PER_KES_PERIOD = "slotsPerKESPeriod";
+    public static final String ATTR_MAX_KES_EVOLUTIONS = "maxKESEvolutions";
     public static final String MIN_FEE_A = "minFeeA";
     public static final String MIN_FEE_B = "minFeeB";
     public static final String MAX_BLOCK_BODY_SIZE = "maxBlockBodySize";
@@ -69,6 +72,9 @@ public class ShelleyGenesis extends GenesisFile {
     private long epochLength;
     private long networkMagic;
     private int securityParam;
+    private int updateQuorum;
+    private long slotsPerKesPeriod;
+    private int maxKesEvolutions;
 
     private List<GenesisBalance> initialFunds;
     private ProtocolParams protocolParams;
@@ -95,6 +101,13 @@ public class ShelleyGenesis extends GenesisFile {
         epochLength = genesisJson.get(ATTR_EPOCH_LENGTH).asLong();
         networkMagic = genesisJson.get(ATTR_NETWORK_MAGIC).asLong();
         securityParam = genesisJson.get(SECURITY_PARAM).asInt();
+        //Optional attributes for older/minimal custom genesis files
+        if (genesisJson.has(ATTR_UPDATE_QUORUM))
+            updateQuorum = genesisJson.get(ATTR_UPDATE_QUORUM).asInt();
+        if (genesisJson.has(ATTR_SLOTS_PER_KES_PERIOD))
+            slotsPerKesPeriod = genesisJson.get(ATTR_SLOTS_PER_KES_PERIOD).asLong();
+        if (genesisJson.has(ATTR_MAX_KES_EVOLUTIONS))
+            maxKesEvolutions = genesisJson.get(ATTR_MAX_KES_EVOLUTIONS).asInt();
 
         JsonNode initialFundJson = genesisJson.get("initialFunds");
         initialFunds = new ArrayList<>();

--- a/components/common/src/test/java/com/bloxbean/carano/yaci/store/common/genesis/ShelleyGenesisTest.java
+++ b/components/common/src/test/java/com/bloxbean/carano/yaci/store/common/genesis/ShelleyGenesisTest.java
@@ -10,8 +10,10 @@ import com.bloxbean.cardano.yaci.store.events.GenesisBalance;
 import com.bloxbean.cardano.yaci.store.events.GenesisStaking;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +34,10 @@ class ShelleyGenesisTest {
         assertThat(shelleyGenesis.getMaxLovelaceSupply()).isEqualTo(new BigInteger("45000000000000000"));
         assertThat(shelleyGenesis.getEpochLength()).isEqualTo(432000);
         assertThat(shelleyGenesis.getNetworkMagic()).isEqualTo(764824073L);
+        assertThat(shelleyGenesis.getSecurityParam()).isEqualTo(2160);
+        assertThat(shelleyGenesis.getUpdateQuorum()).isEqualTo(5);
+        assertThat(shelleyGenesis.getSlotsPerKesPeriod()).isEqualTo(129600);
+        assertThat(shelleyGenesis.getMaxKesEvolutions()).isEqualTo(62);
     }
 
     @Test
@@ -50,6 +56,10 @@ class ShelleyGenesisTest {
         assertThat(shelleyGenesis.getMaxLovelaceSupply()).isEqualTo(new BigInteger("20000000000000000"));
         assertThat(shelleyGenesis.getEpochLength()).isEqualTo(500);
         assertThat(shelleyGenesis.getNetworkMagic()).isEqualTo(42);
+        assertThat(shelleyGenesis.getSecurityParam()).isEqualTo(10);
+        assertThat(shelleyGenesis.getUpdateQuorum()).isEqualTo(2);
+        assertThat(shelleyGenesis.getSlotsPerKesPeriod()).isEqualTo(129600);
+        assertThat(shelleyGenesis.getMaxKesEvolutions()).isEqualTo(60);
 
         assertThat(shelleyGenesis.getInitialFunds()).containsAll(expectedInitialUtxos);
 
@@ -73,6 +83,28 @@ class ShelleyGenesisTest {
 
         assertThat(stake.getStakeKeyHash()).isEqualTo("295b987135610616f3c74e11c94d77b6ced5ccc93a7d719cfb135062");
         assertThat(stake.getPoolHash()).isEqualTo("7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57");
+    }
+
+    @Test
+    void parseShelleyGenesis_missingOptionalKesAttributes() {
+        String minimalGenesis = """
+                {
+                  "systemStart": "2022-09-15T04:09:11Z",
+                  "slotLength": 1,
+                  "activeSlotsCoeff": 1.0,
+                  "maxLovelaceSupply": 20000000000000000,
+                  "epochLength": 500,
+                  "networkMagic": 42,
+                  "securityParam": 10
+                }
+                """;
+
+        ShelleyGenesis shelleyGenesis = new ShelleyGenesis(new ByteArrayInputStream(minimalGenesis.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(shelleyGenesis.getSecurityParam()).isEqualTo(10);
+        assertThat(shelleyGenesis.getUpdateQuorum()).isZero();
+        assertThat(shelleyGenesis.getSlotsPerKesPeriod()).isZero();
+        assertThat(shelleyGenesis.getMaxKesEvolutions()).isZero();
     }
 
     @Test

--- a/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/domain/SyncStatusTest.java
+++ b/components/common/src/test/java/com/bloxbean/cardano/yaci/store/common/domain/SyncStatusTest.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.store.common.domain;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyncStatusTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesNetworkTipAvailabilityWithoutChangingRecordComponents() throws Exception {
+        SyncStatus syncStatus = SyncStatus.builder()
+                .networkBlock(SyncStatus.UNKNOWN_NETWORK_TIP)
+                .networkSlot(SyncStatus.UNKNOWN_NETWORK_TIP)
+                .build();
+
+        String json = objectMapper.writeValueAsString(syncStatus);
+
+        assertThat(json).contains("\"networkTipAvailable\":false");
+        assertThat(syncStatus.networkTipAvailable()).isFalse();
+    }
+}

--- a/components/core-api/build.gradle
+++ b/components/core-api/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    api project(':components:common')
+    api project(':components:core')
+
+    //Provided by the consuming web application; keeps the base starter usable in non-web apps
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yaci Store Core API'
+                description = 'Yaci Store Core API Module'
+            }
+        }
+    }
+}

--- a/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/CoreApiConfiguration.java
+++ b/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/CoreApiConfiguration.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.yaci.store.api.core;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnProperty(
+        name = {"store.core.enabled", "store.core.api-enabled"},
+        havingValue = "true",
+        matchIfMissing = true
+)
+@ComponentScan(basePackages = {"com.bloxbean.cardano.yaci.store.api.core"})
+public class CoreApiConfiguration {
+}

--- a/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/controller/GenesisController.java
+++ b/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/controller/GenesisController.java
@@ -1,0 +1,48 @@
+package com.bloxbean.cardano.yaci.store.api.core.controller;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.api.core.dto.GenesisDto;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("GenesisController")
+@RequestMapping("${apiPrefix:/api/v1}")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Network API", description = "APIs for Network information")
+@ConditionalOnExpression("${store.core.endpoints.genesis.enabled:true}")
+public class GenesisController {
+    private final GenesisConfig genesisConfig;
+    private final StoreProperties storeProperties;
+
+    @GetMapping("/genesis")
+    @Operation(description = "Get network genesis information (Blockfrost compatible shape). Use network_magic to verify which Cardano network this instance is serving.")
+    public GenesisDto getGenesisInfo() {
+        double slotDuration = genesisConfig.slotDuration(Era.Shelley);
+        // Blockfrost defines slot_length as an integer number of seconds. Round fractional
+        // devnet slot durations up so the response remains compatible with generated clients.
+        long slotLength = Math.max(1L, (long) Math.ceil(slotDuration));
+
+        return GenesisDto.builder()
+                .activeSlotsCoefficient(genesisConfig.getActiveSlotsCoeff())
+                .updateQuorum(genesisConfig.getUpdateQuorum())
+                .maxLovelaceSupply(genesisConfig.getMaxLovelaceSupply() != null ?
+                        genesisConfig.getMaxLovelaceSupply().toString() : null)
+                .networkMagic(storeProperties.getProtocolMagic())
+                .epochLength(genesisConfig.getEpochLength())
+                .systemStart(genesisConfig.getStartTime(storeProperties.getProtocolMagic()))
+                .slotsPerKesPeriod(genesisConfig.getSlotsPerKesPeriod())
+                .slotLength(slotLength)
+                .maxKesEvolutions(genesisConfig.getMaxKesEvolutions())
+                .securityParam(genesisConfig.getSecurityParam())
+                .build();
+    }
+}

--- a/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/controller/SyncController.java
+++ b/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/controller/SyncController.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.yaci.store.api.core.controller;
+
+import com.bloxbean.cardano.yaci.store.api.core.dto.SyncStatusDto;
+import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
+import com.bloxbean.cardano.yaci.store.core.service.SyncStatusService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("CoreSyncController")
+@RequestMapping("${apiPrefix:/api/v1}")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Network API", description = "APIs for Network information")
+@ReadOnly(false)
+@ConditionalOnExpression("${store.core.endpoints.sync.enabled:true}")
+public class SyncController {
+    private final SyncStatusService syncStatusService;
+
+    @GetMapping("/sync/status")
+    @Operation(description = "Get indexer sync status: store tip vs node tip. network_tip_available indicates whether lag_blocks, sync_percentage, and synced are based on a current node tip.")
+    public SyncStatusDto getSyncStatus() {
+        return SyncStatusDto.from(syncStatusService.getSyncStatus());
+    }
+}

--- a/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/dto/GenesisDto.java
+++ b/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/dto/GenesisDto.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yaci.store.api.core.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+/**
+ * Genesis information in Blockfrost compatible <code>/genesis</code> shape.
+ */
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GenesisDto(
+        double activeSlotsCoefficient,
+        int updateQuorum,
+        String maxLovelaceSupply,
+        long networkMagic,
+        long epochLength,
+        long systemStart,
+        long slotsPerKesPeriod,
+        long slotLength,
+        int maxKesEvolutions,
+        int securityParam
+) {
+}

--- a/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/dto/SyncStatusDto.java
+++ b/components/core-api/src/main/java/com/bloxbean/cardano/yaci/store/api/core/dto/SyncStatusDto.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yaci.store.api.core.dto;
+
+import com.bloxbean.cardano.yaci.store.common.domain.SyncStatus;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+/**
+ * Indexer sync status : store tip vs node tip.
+ */
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SyncStatusDto(
+        long block,
+        long slot,
+        int epoch,
+        String era,
+        String blockHash,
+        Double syncPercentage,
+        Long networkBlock,
+        Long networkSlot,
+        Long lagBlocks,
+        boolean networkTipAvailable,
+        boolean synced,
+        long protocolMagic
+) {
+    public static SyncStatusDto from(SyncStatus syncStatus) {
+        boolean networkTipAvailable = syncStatus.networkTipAvailable();
+
+        return SyncStatusDto.builder()
+                .block(syncStatus.block())
+                .slot(syncStatus.slot())
+                .epoch(syncStatus.epoch())
+                .era(syncStatus.era())
+                .blockHash(syncStatus.blockHash())
+                .syncPercentage(networkTipAvailable ? syncStatus.syncPercentage() : null)
+                .networkBlock(networkTipAvailable ? syncStatus.networkBlock() : null)
+                .networkSlot(networkTipAvailable ? syncStatus.networkSlot() : null)
+                .lagBlocks(networkTipAvailable ? Math.max(0, syncStatus.networkBlock() - syncStatus.block()) : null)
+                .networkTipAvailable(networkTipAvailable)
+                .synced(networkTipAvailable && syncStatus.synced())
+                .protocolMagic(syncStatus.protocolMagic())
+                .build();
+    }
+}

--- a/components/core-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/components/core-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.bloxbean.cardano.yaci.store.api.core.CoreApiConfiguration

--- a/components/core-api/src/test/java/com/bloxbean/cardano/yaci/store/api/core/controller/GenesisControllerTest.java
+++ b/components/core-api/src/test/java/com/bloxbean/cardano/yaci/store/api/core/controller/GenesisControllerTest.java
@@ -1,0 +1,94 @@
+package com.bloxbean.cardano.yaci.store.api.core.controller;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class GenesisControllerTest {
+
+    @Mock
+    private GenesisConfig genesisConfig;
+
+    @Mock
+    private StoreProperties storeProperties;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new GenesisController(genesisConfig, storeProperties))
+                .addPlaceholderValue("apiPrefix", "/api/v1")
+                .build();
+    }
+
+    private void mockMainnetGenesis() {
+        when(storeProperties.getProtocolMagic()).thenReturn(764824073L);
+        when(genesisConfig.getActiveSlotsCoeff()).thenReturn(0.05);
+        when(genesisConfig.getUpdateQuorum()).thenReturn(5);
+        when(genesisConfig.getMaxLovelaceSupply()).thenReturn(new BigInteger("45000000000000000"));
+        when(genesisConfig.getEpochLength()).thenReturn(432000L);
+        when(genesisConfig.getStartTime(764824073L)).thenReturn(1506203091L);
+        when(genesisConfig.getSlotsPerKesPeriod()).thenReturn(129600L);
+        when(genesisConfig.slotDuration(Era.Shelley)).thenReturn(1.0);
+        when(genesisConfig.getMaxKesEvolutions()).thenReturn(62);
+        when(genesisConfig.getSecurityParam()).thenReturn(2160);
+    }
+
+    @Test
+    void getGenesisInfo_returnsBlockfrostCompatibleShape() throws Exception {
+        mockMainnetGenesis();
+
+        mockMvc.perform(get("/api/v1/genesis"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.network_magic").value(764824073L))
+                .andExpect(jsonPath("$.system_start").value(1506203091L))
+                .andExpect(jsonPath("$.epoch_length").value(432000))
+                .andExpect(jsonPath("$.security_param").value(2160))
+                .andExpect(jsonPath("$.active_slots_coefficient").value(0.05))
+                .andExpect(jsonPath("$.update_quorum").value(5))
+                .andExpect(jsonPath("$.slots_per_kes_period").value(129600))
+                .andExpect(jsonPath("$.max_kes_evolutions").value(62))
+                .andExpect(jsonPath("$.max_lovelace_supply").value("45000000000000000"));
+    }
+
+    @Test
+    void getGenesisInfo_integralSlotLengthSerializedAsInteger() throws Exception {
+        mockMainnetGenesis();
+
+        String content = mockMvc.perform(get("/api/v1/genesis"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        //Blockfrost returns slot_length as integer, and max_lovelace_supply as string
+        assertThat(content).contains("\"slot_length\":1,");
+        assertThat(content).contains("\"max_lovelace_supply\":\"45000000000000000\"");
+    }
+
+    @Test
+    void getGenesisInfo_fractionalSlotLengthRoundedUpToBlockfrostInteger() throws Exception {
+        when(storeProperties.getProtocolMagic()).thenReturn(42L);
+        when(genesisConfig.slotDuration(Era.Shelley)).thenReturn(0.1);
+        when(genesisConfig.getMaxLovelaceSupply()).thenReturn(new BigInteger("20000000000000000"));
+
+        mockMvc.perform(get("/api/v1/genesis"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.network_magic").value(42))
+                .andExpect(jsonPath("$.slot_length").value(1));
+    }
+}

--- a/components/core-api/src/test/java/com/bloxbean/cardano/yaci/store/api/core/controller/SyncControllerTest.java
+++ b/components/core-api/src/test/java/com/bloxbean/cardano/yaci/store/api/core/controller/SyncControllerTest.java
@@ -1,0 +1,100 @@
+package com.bloxbean.cardano.yaci.store.api.core.controller;
+
+import com.bloxbean.cardano.yaci.store.common.domain.SyncStatus;
+import com.bloxbean.cardano.yaci.store.core.service.SyncStatusService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class SyncControllerTest {
+
+    @Mock
+    private SyncStatusService syncStatusService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new SyncController(syncStatusService))
+                .addPlaceholderValue("apiPrefix", "/api/v1")
+                .build();
+    }
+
+    @Test
+    void getSyncStatus_returnsLagBlocks() throws Exception {
+        when(syncStatusService.getSyncStatus()).thenReturn(SyncStatus.builder()
+                .block(11499000)
+                .slot(146000000)
+                .epoch(560)
+                .era("Conway")
+                .blockHash("d9e7e2c1a5b3f4e6d8c9b0a1f2e3d4c5b6a7f8e9d0c1b2a3f4e5d6c7b8a9f0e1")
+                .syncPercentage(99.99)
+                .networkBlock(11499100)
+                .networkSlot(146000200)
+                .synced(false)
+                .protocolMagic(764824073L)
+                .build());
+
+        mockMvc.perform(get("/api/v1/sync/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.block").value(11499000))
+                .andExpect(jsonPath("$.slot").value(146000000))
+                .andExpect(jsonPath("$.epoch").value(560))
+                .andExpect(jsonPath("$.era").value("Conway"))
+                .andExpect(jsonPath("$.block_hash").value("d9e7e2c1a5b3f4e6d8c9b0a1f2e3d4c5b6a7f8e9d0c1b2a3f4e5d6c7b8a9f0e1"))
+                .andExpect(jsonPath("$.sync_percentage").value(99.99))
+                .andExpect(jsonPath("$.network_block").value(11499100))
+                .andExpect(jsonPath("$.network_slot").value(146000200))
+                .andExpect(jsonPath("$.lag_blocks").value(100))
+                .andExpect(jsonPath("$.network_tip_available").value(true))
+                .andExpect(jsonPath("$.synced").value(false))
+                .andExpect(jsonPath("$.protocol_magic").value(764824073L));
+    }
+
+    @Test
+    void getSyncStatus_lagBlocksClampedToZeroWhenStoreAhead() throws Exception {
+        when(syncStatusService.getSyncStatus()).thenReturn(SyncStatus.builder()
+                .block(11499100)
+                .networkBlock(11499000)
+                .synced(true)
+                .protocolMagic(2L)
+                .build());
+
+        mockMvc.perform(get("/api/v1/sync/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lag_blocks").value(0))
+                .andExpect(jsonPath("$.synced").value(true))
+                .andExpect(jsonPath("$.protocol_magic").value(2));
+    }
+
+    @Test
+    void getSyncStatus_exposesUnknownTipWithoutClaimingSynced() throws Exception {
+        when(syncStatusService.getSyncStatus()).thenReturn(SyncStatus.builder()
+                .block(11499100)
+                .slot(146000000)
+                .networkBlock(SyncStatus.UNKNOWN_NETWORK_TIP)
+                .networkSlot(SyncStatus.UNKNOWN_NETWORK_TIP)
+                .synced(false)
+                .protocolMagic(2L)
+                .build());
+
+        mockMvc.perform(get("/api/v1/sync/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.network_tip_available").value(false))
+                .andExpect(jsonPath("$.network_block").doesNotExist())
+                .andExpect(jsonPath("$.network_slot").doesNotExist())
+                .andExpect(jsonPath("$.lag_blocks").doesNotExist())
+                .andExpect(jsonPath("$.sync_percentage").doesNotExist())
+                .andExpect(jsonPath("$.synced").value(false));
+    }
+}

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
@@ -48,6 +48,9 @@ public class GenesisConfig {
 
     private double activeSlotsCoeff;
     private int securityParam;
+    private int updateQuorum;
+    private long slotsPerKesPeriod;
+    private int maxKesEvolutions;
     private BigInteger maxLovelaceSupply = BigInteger.valueOf(45000000000000000L);
 
     public GenesisConfig(StoreProperties storeProperties, ObjectMapper objectMapper, ResourceLoader resourceLoader) {
@@ -186,6 +189,9 @@ public class GenesisConfig {
         shelleySlotLength = shelleyGenesis.getSlotLength();
         activeSlotsCoeff = shelleyGenesis.getActiveSlotsCoeff();
         securityParam = shelleyGenesis.getSecurityParam();
+        updateQuorum = shelleyGenesis.getUpdateQuorum();
+        slotsPerKesPeriod = shelleyGenesis.getSlotsPerKesPeriod();
+        maxKesEvolutions = shelleyGenesis.getMaxKesEvolutions();
         maxLovelaceSupply = shelleyGenesis.getMaxLovelaceSupply();
         epochLength = shelleyGenesis.getEpochLength();
 

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/SyncStatusService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/SyncStatusService.java
@@ -26,9 +26,11 @@ public class SyncStatusService {
 
     private volatile Tuple<Tip, Integer> cachedTipAndEpoch;
     private volatile long lastTipFetchTime = 0;
+    private volatile long lastTipFetchAttemptTime = 0;
 
     private static final long INITIAL_SYNC_REFRESH_INTERVAL = 15L * 60 * 1000; // 15 minutes
     private static final long SYNCED_REFRESH_INTERVAL = 3L * 60 * 1000;       // 3 minutes
+    private static final long FAILED_FETCH_RETRY_INTERVAL = 30L * 1000;       // 30 seconds
     private static final long SYNC_THRESHOLD_BLOCKS = 1000;                   // Consider syncing if > 1000 blocks behind
     private static final long SYNCED_BLOCK_TOLERANCE = 10;                    // Consider synced if within 10 blocks
 
@@ -59,10 +61,11 @@ public class SyncStatusService {
             }
         }
 
-        long networkBlock = currentBlock;
-        long networkSlot = currentSlot;
+        long networkBlock = SyncStatus.UNKNOWN_NETWORK_TIP;
+        long networkSlot = SyncStatus.UNKNOWN_NETWORK_TIP;
 
         Optional<Tuple<Tip, Integer>> tipAndEpoch = getCachedTipAndEpoch(currentBlock);
+        boolean networkTipAvailable = tipAndEpoch.isPresent();
         if (tipAndEpoch.isPresent()) {
             Tip tip = tipAndEpoch.get()._1;
             networkBlock = tip.getBlock();
@@ -75,7 +78,9 @@ public class SyncStatusService {
             syncPercentage = (double) currentBlock / finalNetworkBlock * 100.0;
         }
 
-        boolean isSynced = networkBlock > 0 && currentBlock >= networkBlock - SYNCED_BLOCK_TOLERANCE;
+        boolean isSynced = networkTipAvailable
+                && networkBlock > 0
+                && currentBlock >= networkBlock - SYNCED_BLOCK_TOLERANCE;
 
         return SyncStatus.builder()
                 .block(currentBlock)
@@ -91,13 +96,8 @@ public class SyncStatusService {
                 .build();
     }
 
-    private Optional<Tuple<Tip, Integer>> getCachedTipAndEpoch(long currentBlock) {
+    private synchronized Optional<Tuple<Tip, Integer>> getCachedTipAndEpoch(long currentBlock) {
         long now = System.currentTimeMillis();
-
-        // If cursor block is newer than cached tip, no need to fetch from node
-        if (cachedTipAndEpoch != null && currentBlock >= cachedTipAndEpoch._1.getBlock()) {
-            return Optional.of(cachedTipAndEpoch);
-        }
 
         // Determine refresh interval based on sync state
         long refreshInterval = INITIAL_SYNC_REFRESH_INTERVAL; // default: syncing
@@ -113,7 +113,14 @@ public class SyncStatusService {
             return Optional.of(cachedTipAndEpoch);
         }
 
+        // A failed node lookup can take up to the node-client timeout. Avoid making every
+        // status request immediately repeat that lookup while still reporting the tip as unknown.
+        if ((now - lastTipFetchAttemptTime) < FAILED_FETCH_RETRY_INTERVAL) {
+            return Optional.empty();
+        }
+
         // Fetch fresh tip from node
+        lastTipFetchAttemptTime = now;
         try {
             Optional<Tuple<Tip, Integer>> tipAndEpoch = chainTipService.getTipAndCurrentEpoch();
             if (tipAndEpoch.isPresent()) {
@@ -123,7 +130,7 @@ public class SyncStatusService {
             return tipAndEpoch;
         } catch (Exception e) {
             log.debug("Could not get network tip: {}", e.getMessage());
-            return Optional.ofNullable(cachedTipAndEpoch); // Return stale cache if available
+            return Optional.empty();
         }
     }
 }

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/SyncStatusServiceTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/SyncStatusServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -95,6 +96,7 @@ class SyncStatusServiceTest {
             SyncStatus status = syncStatusService.getSyncStatus();
 
             assertThat(status.syncPercentage()).isCloseTo(50.0, withinPercentage(1));
+            assertThat(status.networkTipAvailable()).isTrue();
             assertThat(status.synced()).isFalse();
         }
 
@@ -110,16 +112,17 @@ class SyncStatusServiceTest {
         }
 
         @Test
-        void fallsBackToCurrentBlockWhenTipUnavailable() {
+        void reportsUnknownNetworkTipWhenTipUnavailable() {
             withCursorAt(5000L, 100000L, Era.Babbage);
             when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.empty());
 
             SyncStatus status = syncStatusService.getSyncStatus();
 
-            assertThat(status.networkBlock()).isEqualTo(5000L);
-            assertThat(status.networkSlot()).isEqualTo(100000L);
-            assertThat(status.syncPercentage()).isCloseTo(100.0, withinPercentage(1));
-            assertThat(status.synced()).isTrue();
+            assertThat(status.networkTipAvailable()).isFalse();
+            assertThat(status.networkBlock()).isEqualTo(SyncStatus.UNKNOWN_NETWORK_TIP);
+            assertThat(status.networkSlot()).isEqualTo(SyncStatus.UNKNOWN_NETWORK_TIP);
+            assertThat(status.syncPercentage()).isZero();
+            assertThat(status.synced()).isFalse();
         }
 
         private org.assertj.core.data.Percentage withinPercentage(double pct) {
@@ -211,6 +214,46 @@ class SyncStatusServiceTest {
 
             verify(chainTipService, times(1)).getTipAndCurrentEpoch();
         }
+
+        @Test
+        void refreshesStaleTipEvenWhenCursorCaughtUp() {
+            withCursorAt(5000L, 100000L, Era.Babbage);
+            when(eraService.getEpochNo(any(), anyLong())).thenReturn(350);
+            withNetworkTipAt(10000L, 200000L);
+
+            syncStatusService.getSyncStatus();
+
+            // Cursor caught up past the cached tip, and the cache has gone stale
+            Cursor cursor2 = Cursor.builder()
+                    .block(10001L).slot(200001L).blockHash("def").era(Era.Babbage).build();
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursor2));
+            makeCachedTipStale();
+
+            syncStatusService.getSyncStatus();
+
+            verify(chainTipService, times(2)).getTipAndCurrentEpoch();
+        }
+
+        @Test
+        void reportsTipUnavailableAndBacksOffAfterFailedRefresh() {
+            withCursorAt(5000L, 100000L, Era.Babbage);
+            when(eraService.getEpochNo(any(), anyLong())).thenReturn(350);
+            withNetworkTipAt(10000L, 200000L);
+
+            syncStatusService.getSyncStatus();
+
+            makeCachedTipStale();
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.empty());
+
+            SyncStatus failedRefreshStatus = syncStatusService.getSyncStatus();
+            SyncStatus backedOffStatus = syncStatusService.getSyncStatus();
+
+            assertThat(failedRefreshStatus.networkTipAvailable()).isFalse();
+            assertThat(failedRefreshStatus.synced()).isFalse();
+            assertThat(backedOffStatus.networkTipAvailable()).isFalse();
+            assertThat(backedOffStatus.synced()).isFalse();
+            verify(chainTipService, times(2)).getTipAndCurrentEpoch();
+        }
     }
 
     // -- helpers --
@@ -225,5 +268,11 @@ class SyncStatusServiceTest {
     private void withNetworkTipAt(long block, long slot) {
         Tip tip = new Tip(new Point(slot, "tip_hash"), block);
         when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.of(new Tuple<>(tip, 400)));
+    }
+
+    private void makeCachedTipStale() {
+        long staleTimestamp = System.currentTimeMillis() - 20L * 60 * 1000;
+        ReflectionTestUtils.setField(syncStatusService, "lastTipFetchTime", staleTimestamp);
+        ReflectionTestUtils.setField(syncStatusService, "lastTipFetchAttemptTime", staleTimestamp);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include 'applications:admin'
 include 'applications:admin-cli'
 
 include 'components:core'
+include 'components:core-api'
 include 'components:events'
 include 'components:common'
 include 'components:client'

--- a/starters/spring-boot-starter/build.gradle
+++ b/starters/spring-boot-starter/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     api project(":components:common")
     api project(':components:core')
+    api project(':components:core-api')
     api project(":components:events")
     api project(":components:client")
 


### PR DESCRIPTION
## Summary

- add a Blockfrost-compatible `GET /api/v1/genesis` endpoint exposing protocol magic and genesis parameters
- add `GET /api/v1/sync/status` with store-vs-node tip details and explicit handling when the node tip is unavailable
- refresh stale cached tips, back off failed node-tip requests, and avoid false `synced`/zero-lag results
- keep `slot_length` integer-compatible with the Blockfrost schema, including fractional devnet configurations
- wire the new core API module into the Spring Boot starter and update the admin UI for unavailable-tip states

## Verification

- `./gradlew :components:common:test :components:core:test :components:core-api:test :components:admin-ui:buildFrontend --rerun-tasks`
- `./gradlew :applications:all:bootJar`
- `git diff --check`

Closes #1018