### PR TITLE
Fix: require SPO approval for bootstrap SECURITY param changes

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
@@ -40,13 +40,21 @@ public class ParameterChangeRatificationEvaluator implements RatificationEvaluat
         final boolean isPreviousActionAsExpected = GovernanceActionUtil.isPrevActionAsExpected(parameterChangeAction.getType(), parameterChangeAction.getGovActionId(), lastEnactedGovActionId);
         boolean isAccepted;
 
+        List<ProtocolParamGroup> ppGroupChangeList = ProtocolParamUtil.getGroupsWithNonNullField(parameterChangeAction.getProtocolParamUpdate());
+        boolean spoVotingRequired = ppGroupChangeList.contains(ProtocolParamGroup.SECURITY);
+
         if (context.isBootstrapPhase()) {
             isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD);
+            // during bootstrap, DRep thresholds are zeroed, but the SPO SECURITY-group threshold
+            // is unaffected, so SPO approval is still required for SECURITY-group changes.
+            if (spoVotingRequired) {
+                VotingStatus spoVotingResult = new SPOVotingEvaluator().evaluate(context.getVotingData(), votingEvaluationContext);
+                isAccepted = isAccepted && spoVotingResult.equals(VotingStatus.PASS_THRESHOLD);
+            }
         } else {
-            List<ProtocolParamGroup> ppGroupChangeList = ProtocolParamUtil.getGroupsWithNonNullField(parameterChangeAction.getProtocolParamUpdate());
             VotingStatus dRepVotingResult = new DRepVotingEvaluator().evaluate(context.getVotingData(), votingEvaluationContext);
 
-            if (ppGroupChangeList.contains(ProtocolParamGroup.SECURITY)) {
+            if (spoVotingRequired) {
                 VotingStatus spoVotingResult = new SPOVotingEvaluator().evaluate(context.getVotingData(), votingEvaluationContext);
                 if (ppGroupChangeList.size() == 1) {
                     isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD) && spoVotingResult.equals(VotingStatus.PASS_THRESHOLD);

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluatorTest.java
@@ -107,6 +107,135 @@ class ParameterChangeRatificationEvaluatorTest {
     }
 
     @Test
+    void evaluate_returnsContinue_whenBootstrap_securityParam_committeePasses_butSpoDoesNotSupport() {
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of(
+                                "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
+                                "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
+                        .build())
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .noVoteStake(BigInteger.ZERO)
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .abstainVoteStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.valueOf(1000))
+                        .totalStake(BigInteger.valueOf(1000))
+                        .build())
+                .build();
+
+        ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
+        when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
+        when(paramChange.getGovActionId()).thenReturn(null);
+        // minFeeA touches SECURITY group
+        when(paramChange.getProtocolParamUpdate()).thenReturn(ProtocolParamUpdate.builder().minFeeA(10).build());
+
+        GovernanceContext governanceContext = buildBootstrapGovernanceContext(
+                ConstitutionCommitteeState.NORMAL,
+                /* isDelayed= */ false,
+                /* currentEpoch= */ 5);
+
+        RatificationContext context = RatificationContext.builder()
+                .govAction(paramChange)
+                .votingData(votingData)
+                .governanceContext(governanceContext)
+                .maxAllowedVotingEpoch(8)
+                .build();
+
+        RatificationResult result = evaluator.evaluate(context);
+
+        // Committee passes, but SPO support is absent -> must not auto-accept during bootstrap.
+        assertThat(result).isEqualTo(RatificationResult.CONTINUE);
+    }
+
+    @Test
+    void evaluate_returnsAccept_whenBootstrap_securityParam_committeeAndSpoPass() {
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of(
+                                "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
+                                "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
+                        .build())
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .noVoteStake(BigInteger.ZERO)
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .spoVotes(VotingData.SPOVotes.builder()
+                        .yesVoteStake(BigInteger.valueOf(1000))
+                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
+                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
+                        .abstainVoteStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .totalStake(BigInteger.valueOf(1000))
+                        .build())
+                .build();
+
+        ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
+        when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
+        when(paramChange.getGovActionId()).thenReturn(null);
+        when(paramChange.getProtocolParamUpdate()).thenReturn(ProtocolParamUpdate.builder().minFeeA(10).build());
+
+        GovernanceContext governanceContext = buildBootstrapGovernanceContext(
+                ConstitutionCommitteeState.NORMAL,
+                /* isDelayed= */ false,
+                /* currentEpoch= */ 5);
+
+        RatificationContext context = RatificationContext.builder()
+                .govAction(paramChange)
+                .votingData(votingData)
+                .governanceContext(governanceContext)
+                .maxAllowedVotingEpoch(8)
+                .build();
+
+        assertThat(evaluator.evaluate(context)).isEqualTo(RatificationResult.ACCEPT);
+    }
+
+    @Test
+    void evaluate_returnsAccept_whenBootstrap_nonSecurityParam_committeePassesAlone() {
+        VotingData votingData = VotingData.builder()
+                .committeeVotes(VotingData.CommitteeVotes.builder()
+                        .votes(Map.of(
+                                "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
+                                "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
+                        .build())
+                .drepVotes(VotingData.DRepVotes.builder()
+                        .yesVoteStake(BigInteger.ZERO)
+                        .noVoteStake(BigInteger.ZERO)
+                        .noConfidenceStake(BigInteger.ZERO)
+                        .doNotVoteStake(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
+        when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
+        when(paramChange.getGovActionId()).thenReturn(null);
+        // nOpt touches TECHNICAL group only, not SECURITY
+        when(paramChange.getProtocolParamUpdate()).thenReturn(ProtocolParamUpdate.builder().nOpt(50).build());
+
+        GovernanceContext governanceContext = buildBootstrapGovernanceContext(
+                ConstitutionCommitteeState.NORMAL,
+                /* isDelayed= */ false,
+                /* currentEpoch= */ 5);
+
+        RatificationContext context = RatificationContext.builder()
+                .govAction(paramChange)
+                .votingData(votingData)
+                .governanceContext(governanceContext)
+                .maxAllowedVotingEpoch(8)
+                .build();
+
+        assertThat(evaluator.evaluate(context)).isEqualTo(RatificationResult.ACCEPT);
+    }
+
+    @Test
     void evaluate_returnsReject_whenOutOfLifecycle() {
         ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
         when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
@@ -184,6 +313,43 @@ class ParameterChangeRatificationEvaluatorTest {
                 .committee(committee)
                 .protocolParams(protocolParams)
                 .isInBootstrapPhase(false)
+                .isActionRatificationDelayed(isDelayed)
+                .treasury(BigInteger.ZERO)
+                .lastEnactedGovActionIds(Map.of())
+                .build();
+    }
+
+    private GovernanceContext buildBootstrapGovernanceContext(ConstitutionCommitteeState committeeState,
+                                                               boolean isDelayed,
+                                                               int currentEpoch) {
+        List<CommitteeMember> members = List.of(
+                CommitteeMember.builder().coldKey("cold1").hotKey("hot1").build(),
+                CommitteeMember.builder().coldKey("cold2").hotKey("hot2").build());
+
+        ConstitutionCommittee committee = ConstitutionCommittee.builder()
+                .state(committeeState)
+                .threshold(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .members(members)
+                .build();
+
+        // Bootstrap phase: DRep thresholds are zeroed, but the SPO
+        // security-group threshold is unaffected and still applies.
+        DrepVoteThresholds drepThresholds = DrepVoteThresholds.builder().build();
+
+        PoolVotingThresholds poolThresholds = PoolVotingThresholds.builder()
+                .pvtPPSecurityGroup(UnitIntervalUtil.decimalToUnitInterval(new BigDecimal("0.51")))
+                .build();
+
+        ProtocolParams protocolParams = ProtocolParams.builder()
+                .drepVotingThresholds(drepThresholds)
+                .poolVotingThresholds(poolThresholds)
+                .build();
+
+        return GovernanceContext.builder()
+                .currentEpoch(currentEpoch)
+                .committee(committee)
+                .protocolParams(protocolParams)
+                .isInBootstrapPhase(true)
                 .isActionRatificationDelayed(isDelayed)
                 .treasury(BigInteger.ZERO)
                 .lastEnactedGovActionIds(Map.of())


### PR DESCRIPTION
## Summary
  - During Conway bootstrap phase, DRep voting thresholds are zeroed, but the SPO SECURITY-group threshold (pvtPPSecurityGroup) is unaffected and still applies.
  - ParameterChangeRatificationEvaluator previously accepted a bootstrap ParameterChange on committee support alone, skipping the SPO check entirely — even when the change touched a SECURITY parameter (e.g. minFeeA).
  - Fix: compute affected PParam groups before branching on bootstrap phase, and require SPO PASS_THRESHOLD whenever SECURITY is affected, regardless of bootstrap phase. Non-SECURITY bootstrap changes keep
  committee-only acceptance (unchanged).

  ## Test plan
  - Added evaluate_returnsContinue_whenBootstrap_securityParam_committeePasses_butSpoDoesNotSupport — reproduces the bug
  - Added evaluate_returnsAccept_whenBootstrap_securityParam_committeeAndSpoPass
  - Added evaluate_returnsAccept_whenBootstrap_nonSecurityParam_committeePassesAlone — no regression
  - ./gradlew :aggregates:governance-rules:test passes
  
 Closes #1023 