### PR TITLE
test(governance): preserve HFI tally behavior across phases

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculator.java
@@ -77,6 +77,10 @@ public final class VoteTallyCalculator {
         BigInteger totalYesStake = yesVote;
         BigInteger totalAbstainStake = abstainVote;
 
+        /*
+            Match spoAcceptedRatio in cardano-ledger's Ratify.hs: handle HardForkInitiation
+            before the bootstrap rule, then apply default delegation only post-bootstrap.
+         */
         if (type != GovActionType.HARD_FORK_INITIATION_ACTION) {
             if (isInBootstrapPhase) {
                 totalAbstainStake = totalAbstainStake

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/voting/VoteTallyCalculatorTest.java
@@ -113,6 +113,24 @@ class VoteTallyCalculatorTest {
     }
 
     @Test
+    void computeSPOTallies_postBootstrapPhase_hardForkInitiation_doesNotAddNonVotingDefaultStakeToAbstain() {
+        VotingData.SPOVotes votes = VotingData.SPOVotes.builder()
+                .yesVoteStake(BigInteger.valueOf(100))
+                .delegateToAutoAbstainDRepStake(BigInteger.valueOf(30))
+                .delegateToNoConfidenceDRepStake(BigInteger.valueOf(40))
+                .abstainVoteStake(BigInteger.valueOf(10))
+                .doNotVoteStake(BigInteger.valueOf(20))
+                .totalStake(BigInteger.valueOf(200))
+                .build();
+
+        VoteTallies.SPOTallies tallies = VoteTallyCalculator.computeSPOTallies(votes, GovActionType.HARD_FORK_INITIATION_ACTION, false);
+
+        assertEquals(BigInteger.valueOf(100), tallies.getTotalYesStake());
+        assertEquals(BigInteger.valueOf(10), tallies.getTotalAbstainStake());
+        assertEquals(BigInteger.valueOf(90), tallies.getTotalNoStake());
+    }
+
+    @Test
     void computeSPOTallies_postBootstrapPhase_noConfidence_addsNoConfidenceDelegationToYes() {
         VotingData.SPOVotes votes = VotingData.SPOVotes.builder()
                 .yesVoteStake(BigInteger.valueOf(100))


### PR DESCRIPTION
 ## Summary

  This is a follow-up to #1020, which fixed SPO tally handling for non-voters during the Conway bootstrap phase.

  This PR:

  - Restores dedicated post-bootstrap coverage for `HardForkInitiation`.
  - Documents the SPO non-voter guard order implemented by `computeSPOTallies`.

  This PR does not change tally behavior.

  ## Details

  PR #1020 changed the existing `HardForkInitiation` test from post-bootstrap to bootstrap coverage. Although the implementation intentionally handles `HardForkInitiation` identically in both phases, the post-bootstrap
  combination no longer had a dedicated regression test.

  This change adds a post-bootstrap test confirming that non-voting SPO stake, including stake delegated to `AlwaysAbstain` and `AlwaysNoConfidence`, is still treated as `No` for `HardForkInitiation`.

  It also adds a short comment documenting the ledger-compatible guard order:

  1. Handle `HardForkInitiation` first.
  2. Apply the bootstrap non-voter rule.
  3. Apply delegation-specific defaults post-bootstrap.

  The ordering follows `spoAcceptedRatio` in cardano-ledger's `Ratify.hs`.

  ## Out of scope

  The review also identified a pre-existing issue where non-voting SPO default delegation is derived from votes across all proposals in an evaluation batch rather than independently for each proposal.

  This behavior was not introduced by #1020 and is outside the scope of this PR. It is tracked by #1030 and will be addressed in a separate PR.

  ## Verification

  ```bash
  ./gradlew :aggregates:governance-rules:test

  Result: BUILD SUCCESSFUL