### PR TITLE
fix: make parameter change validation phase-aware

### DIFF
--- a/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
+++ b/aggregates/governance-rules/src/main/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluator.java
@@ -53,15 +53,13 @@ public class ParameterChangeRatificationEvaluator implements RatificationEvaluat
             }
         } else {
             VotingStatus dRepVotingResult = new DRepVotingEvaluator().evaluate(context.getVotingData(), votingEvaluationContext);
+            isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD)
+                    && dRepVotingResult.equals(VotingStatus.PASS_THRESHOLD);
 
             if (spoVotingRequired) {
                 VotingStatus spoVotingResult = new SPOVotingEvaluator().evaluate(context.getVotingData(), votingEvaluationContext);
-                if (ppGroupChangeList.size() == 1) {
-                    isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD) && spoVotingResult.equals(VotingStatus.PASS_THRESHOLD);
-                } else
-                    isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD) && spoVotingResult.equals(VotingStatus.PASS_THRESHOLD) && dRepVotingResult.equals(VotingStatus.PASS_THRESHOLD);
-            } else
-                isAccepted = committeeVotingResult.equals(VotingStatus.PASS_THRESHOLD) && dRepVotingResult.equals(VotingStatus.PASS_THRESHOLD);
+                isAccepted = isAccepted && spoVotingResult.equals(VotingStatus.PASS_THRESHOLD);
+            }
         }
 
         if (context.isLastRatificationOpportunity()) {
@@ -79,16 +77,15 @@ public class ParameterChangeRatificationEvaluator implements RatificationEvaluat
             throw new IllegalArgumentException("Committee votes are required for Parameter Change actions");
         }
 
-        if (context.isBootstrapPhase()) {
-            if (context.getVotingData().getDrepVotes() == null) {
-                throw new IllegalArgumentException("DRep votes are required for Parameter Change actions");
-            }
-            ParameterChangeAction parameterChangeAction = (ParameterChangeAction) context.getGovAction();
-            List<ProtocolParamGroup> ppGroupChangeList = ProtocolParamUtil.getGroupsWithNonNullField(parameterChangeAction.getProtocolParamUpdate());
+        if (!context.isBootstrapPhase() && context.getVotingData().getDrepVotes() == null) {
+            throw new IllegalArgumentException("DRep votes are required for Parameter Change actions");
+        }
 
-            if (ppGroupChangeList.contains(ProtocolParamGroup.SECURITY) && context.getVotingData().getSpoVotes() == null) {
-                throw new IllegalArgumentException("SPO votes are required for Parameter Change actions changing SECURITY parameters");
-            }
+        ParameterChangeAction parameterChangeAction = (ParameterChangeAction) context.getGovAction();
+        List<ProtocolParamGroup> ppGroupChangeList = ProtocolParamUtil.getGroupsWithNonNullField(parameterChangeAction.getProtocolParamUpdate());
+
+        if (ppGroupChangeList.contains(ProtocolParamGroup.SECURITY) && context.getVotingData().getSpoVotes() == null) {
+            throw new IllegalArgumentException("SPO votes are required for Parameter Change actions changing SECURITY parameters");
         }
     }
 

--- a/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluatorTest.java
+++ b/aggregates/governance-rules/src/test/java/com/bloxbean/cardano/yaci/store/governancerules/ratification/impl/ParameterChangeRatificationEvaluatorTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,12 +115,6 @@ class ParameterChangeRatificationEvaluatorTest {
                                 "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
                                 "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
                         .build())
-                .drepVotes(VotingData.DRepVotes.builder()
-                        .yesVoteStake(BigInteger.ZERO)
-                        .noVoteStake(BigInteger.ZERO)
-                        .noConfidenceStake(BigInteger.ZERO)
-                        .doNotVoteStake(BigInteger.ZERO)
-                        .build())
                 .spoVotes(VotingData.SPOVotes.builder()
                         .yesVoteStake(BigInteger.ZERO)
                         .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
@@ -156,27 +151,7 @@ class ParameterChangeRatificationEvaluatorTest {
 
     @Test
     void evaluate_returnsAccept_whenBootstrap_securityParam_committeeAndSpoPass() {
-        VotingData votingData = VotingData.builder()
-                .committeeVotes(VotingData.CommitteeVotes.builder()
-                        .votes(Map.of(
-                                "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
-                                "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
-                        .build())
-                .drepVotes(VotingData.DRepVotes.builder()
-                        .yesVoteStake(BigInteger.ZERO)
-                        .noVoteStake(BigInteger.ZERO)
-                        .noConfidenceStake(BigInteger.ZERO)
-                        .doNotVoteStake(BigInteger.ZERO)
-                        .build())
-                .spoVotes(VotingData.SPOVotes.builder()
-                        .yesVoteStake(BigInteger.valueOf(1000))
-                        .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
-                        .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
-                        .abstainVoteStake(BigInteger.ZERO)
-                        .doNotVoteStake(BigInteger.ZERO)
-                        .totalStake(BigInteger.valueOf(1000))
-                        .build())
-                .build();
+        VotingData votingData = buildPassingVotesWithCommitteeYes(false, true);
 
         ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
         when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
@@ -200,19 +175,7 @@ class ParameterChangeRatificationEvaluatorTest {
 
     @Test
     void evaluate_returnsAccept_whenBootstrap_nonSecurityParam_committeePassesAlone() {
-        VotingData votingData = VotingData.builder()
-                .committeeVotes(VotingData.CommitteeVotes.builder()
-                        .votes(Map.of(
-                                "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
-                                "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
-                        .build())
-                .drepVotes(VotingData.DRepVotes.builder()
-                        .yesVoteStake(BigInteger.ZERO)
-                        .noVoteStake(BigInteger.ZERO)
-                        .noConfidenceStake(BigInteger.ZERO)
-                        .doNotVoteStake(BigInteger.ZERO)
-                        .build())
-                .build();
+        VotingData votingData = buildPassingVotesWithCommitteeYes(false, false);
 
         ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
         when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
@@ -236,6 +199,64 @@ class ParameterChangeRatificationEvaluatorTest {
     }
 
     @Test
+    void evaluate_throwsWhenBootstrapSecurityParamIsMissingSpoVotes() {
+        RatificationContext context = buildRatificationContext(
+                ProtocolParamUpdate.builder().minFeeA(10).build(),
+                buildPassingVotesWithCommitteeYes(false, false),
+                true);
+
+        assertThatThrownBy(() -> evaluator.evaluate(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("SPO votes are required for Parameter Change actions changing SECURITY parameters");
+    }
+
+    @Test
+    void evaluate_throwsWhenPostBootstrapNonSecurityParamIsMissingDrepVotes() {
+        RatificationContext context = buildRatificationContext(
+                ProtocolParamUpdate.builder().nOpt(50).build(),
+                buildPassingVotesWithCommitteeYes(false, false),
+                false);
+
+        assertThatThrownBy(() -> evaluator.evaluate(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("DRep votes are required for Parameter Change actions");
+    }
+
+    @Test
+    void evaluate_returnsAccept_whenPostBootstrapNonSecurityParamHasNoSpoVotes() {
+        RatificationContext context = buildRatificationContext(
+                ProtocolParamUpdate.builder().nOpt(50).build(),
+                buildPassingVotesWithCommitteeYes(true, false),
+                false);
+
+        assertThat(evaluator.evaluate(context)).isEqualTo(RatificationResult.ACCEPT);
+    }
+
+    @Test
+    void evaluate_throwsWhenPostBootstrapSecurityParamIsMissingDrepVotes() {
+        RatificationContext context = buildRatificationContext(
+                ProtocolParamUpdate.builder().minFeeA(10).build(),
+                buildPassingVotesWithCommitteeYes(false, true),
+                false);
+
+        assertThatThrownBy(() -> evaluator.evaluate(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("DRep votes are required for Parameter Change actions");
+    }
+
+    @Test
+    void evaluate_throwsWhenPostBootstrapSecurityParamIsMissingSpoVotes() {
+        RatificationContext context = buildRatificationContext(
+                ProtocolParamUpdate.builder().minFeeA(10).build(),
+                buildPassingVotesWithCommitteeYes(true, false),
+                false);
+
+        assertThatThrownBy(() -> evaluator.evaluate(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("SPO votes are required for Parameter Change actions changing SECURITY parameters");
+    }
+
+    @Test
     void evaluate_returnsReject_whenOutOfLifecycle() {
         ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
         when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
@@ -256,26 +277,57 @@ class ParameterChangeRatificationEvaluatorTest {
     }
 
     private VotingData buildFullPassingVotesWithCommitteeYes() {
-        return VotingData.builder()
+        return buildPassingVotesWithCommitteeYes(true, true);
+    }
+
+    private VotingData buildPassingVotesWithCommitteeYes(boolean includeDrepVotes, boolean includeSpoVotes) {
+        var votingDataBuilder = VotingData.builder()
                 .committeeVotes(VotingData.CommitteeVotes.builder()
                         .votes(Map.of(
                                 "hot1", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES,
                                 "hot2", com.bloxbean.cardano.yaci.core.model.governance.Vote.YES))
-                        .build())
-                .drepVotes(VotingData.DRepVotes.builder()
+                        .build());
+
+        if (includeDrepVotes) {
+            votingDataBuilder.drepVotes(VotingData.DRepVotes.builder()
                         .yesVoteStake(BigInteger.valueOf(1000))
                         .noVoteStake(BigInteger.ZERO)
                         .noConfidenceStake(BigInteger.ZERO)
                         .doNotVoteStake(BigInteger.ZERO)
-                        .build())
-                .spoVotes(VotingData.SPOVotes.builder()
+                        .build());
+        }
+
+        if (includeSpoVotes) {
+            votingDataBuilder.spoVotes(VotingData.SPOVotes.builder()
                         .yesVoteStake(BigInteger.valueOf(1000))
                         .delegateToAutoAbstainDRepStake(BigInteger.ZERO)
                         .delegateToNoConfidenceDRepStake(BigInteger.ZERO)
                         .abstainVoteStake(BigInteger.ZERO)
                         .doNotVoteStake(BigInteger.ZERO)
                         .totalStake(BigInteger.valueOf(1000))
-                        .build())
+                        .build());
+        }
+
+        return votingDataBuilder.build();
+    }
+
+    private RatificationContext buildRatificationContext(ProtocolParamUpdate protocolParamUpdate,
+                                                          VotingData votingData,
+                                                          boolean isBootstrapPhase) {
+        ParameterChangeAction paramChange = mock(ParameterChangeAction.class);
+        when(paramChange.getType()).thenReturn(GovActionType.PARAMETER_CHANGE_ACTION);
+        when(paramChange.getGovActionId()).thenReturn(null);
+        when(paramChange.getProtocolParamUpdate()).thenReturn(protocolParamUpdate);
+
+        GovernanceContext governanceContext = isBootstrapPhase
+                ? buildBootstrapGovernanceContext(ConstitutionCommitteeState.NORMAL, false, 5)
+                : buildGovernanceContext(ConstitutionCommitteeState.NORMAL, false, 5);
+
+        return RatificationContext.builder()
+                .govAction(paramChange)
+                .votingData(votingData)
+                .governanceContext(governanceContext)
+                .maxAllowedVotingEpoch(8)
                 .build();
     }
 


### PR DESCRIPTION
## Summary

- Make `ParameterChange` voting-data validation phase-aware.
- Require DRep voting data only after the bootstrap phase.
- Require SPO voting data for SECURITY parameter changes in both phases.
- Remove the unreachable post-bootstrap SECURITY-only branch.
- Add regression coverage for missing voting data across bootstrap/post-bootstrap and SECURITY/non-SECURITY changes.

## Required voting data

| Phase | Non-SECURITY change | SECURITY change |
|---|---|---|
| Bootstrap | Committee | Committee + SPO |
| Post-bootstrap | Committee + DRep | Committee + DRep + SPO |

## Details

Previously, validation required DRep data during bootstrap even though DRep voting is not evaluated in that phase. Conversely, post-bootstrap evaluation used DRep data without validating its presence first, causing missing data to fall through as `INSUFFICIENT_DATA`.

The SECURITY-only branch was also removed. Every SECURITY parameter currently belongs to a DRep voting group as defined by the Cardano Ledger.

## Behavioral impact

Missing required voting data now fails through `validateRequiredData` with an `IllegalArgumentException` instead of silently producing `INSUFFICIENT_DATA` and returning `CONTINUE`.

The normal governance aggregation path already constructs the required voting-data components, so this primarily affects incomplete or malformed inputs.

## Verification

- `./gradlew :aggregates:governance-rules:test --tests com.bloxbean.cardano.yaci.store.governancerules.ratification.impl.ParameterChangeRatificationEvaluatorTest`
- `./gradlew :aggregates:governance-aggr:test`

Both completed successfully.

Fixes #1028

Related: #1025
