### PR TITLE
Fix full table scan in findLatestBlock

### DIFF
--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
@@ -41,8 +41,8 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
         var nextBlockField = nextBlockField(block);
         var confirmationsField = confirmationsField(block);
 
-        return blockBaseSelect(block, nextBlockField, confirmationsField, DSL.trueCondition())
-                .orderBy(block.NUMBER.desc().nullsLast())
+        return blockBaseSelect(block, nextBlockField, confirmationsField, block.NUMBER.isNotNull())
+                .orderBy(block.NUMBER.desc())
                 .limit(1)
                 .fetchOptional(record -> toBlockRow(record, block, nextBlockField, confirmationsField));
     }


### PR DESCRIPTION
## Summary
- `findLatestBlock()` ordered by `block.number.desc().nullsLast()` with no `WHERE` filter. Since `number` is nullable, a backward index scan on `idx_block_number` naturally yields `NULLS FIRST`, which can't satisfy an explicit `NULLS LAST`, forcing a full sequential scan + sort on large tables.
- Fix: filter `block.NUMBER.isNotNull()` and order by a plain `.desc()` so Postgres can reuse the existing index via a backward index scan.

Fixes #1041

## Test plan
Verified with `EXPLAIN (ANALYZE, BUFFERS)` against a synced mainnet DB (13.7M blocks):
- Before: `Parallel Seq Scan` + Sort, ~5.9s, ~1.59M buffer pages read
- After: `Index Scan Backward` on `idx_block_number`, ~0.07ms, 4 buffer pages read

Also verified end-to-end on the live `/api/v1/blockfrost/blocks/latest` endpoint on the same mainnet node:
- Before: ~7.4-7.5s response time
- After: ~6ms response time (steady state)