### PR TITLE
[Blockfrost API] Optimize Blockfrost transaction input lookup

### DIFF
--- a/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/storage/impl/BFTransactionStorageReaderImpl.java
+++ b/extensions/blockfrost/transaction/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/transaction/storage/impl/BFTransactionStorageReaderImpl.java
@@ -86,7 +86,9 @@ public class BFTransactionStorageReaderImpl implements BFTransactionStorageReade
                 .asField("asset_mint_count");
 
         Field<Integer> inputCount = DSL.selectCount()
-                .from(TX_INPUT).where(TX_INPUT.SPENT_TX_HASH.eq(txHash))
+                .from(TX_INPUT)
+                .where(TX_INPUT.SPENT_AT_BLOCK.eq(TRANSACTION.BLOCK))
+                .and(TX_INPUT.SPENT_TX_HASH.eq(txHash))
                 .asField("input_count");
 
         Field<Integer> outputCount = DSL.selectCount()
@@ -178,7 +180,8 @@ public class BFTransactionStorageReaderImpl implements BFTransactionStorageReade
                 .join(TX_INPUT)
                 .on(TX_INPUT.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
                 .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
-                .where(TX_INPUT.SPENT_TX_HASH.eq(txHash))
+                .where(TX_INPUT.SPENT_AT_BLOCK.eq(txn.getBlockNumber()))
+                .and(TX_INPUT.SPENT_TX_HASH.eq(txHash))
                 .fetch(record -> TxInputRaw.builder()
                         .txHash(record.get(ADDRESS_UTXO.TX_HASH))
                         .outputIndex(record.get(ADDRESS_UTXO.OUTPUT_INDEX))


### PR DESCRIPTION

## Summary

Improves the performance of the Blockfrost-compatible transaction endpoints by constraining `tx_input` lookups with both the consuming block number and transaction hash.

This allows the queries to use the existing `tx_input (spent_at_block, spent_tx_hash)` index efficiently, without adding another index or changing the database schema.

Related to #1049 .

## Problem

`GET /api/v1/blockfrost/txs/{hash}` calculated the input count using only `spent_tx_hash`:

```sql
WHERE tx_input.spent_tx_hash = ?
```

On a mainnet database with more than 341 million `tx_input` rows, PostgreSQL had to perform an index skip scan over many `spent_at_block` values because `spent_tx_hash` is the second column of the existing composite index.

The same lookup pattern was also used when loading inputs for `GET /api/v1/blockfrost/txs/{hash}/utxos`.

## Changes

- Correlate the transaction input count with `transaction.block`:

```sql
WHERE tx_input.spent_at_block = transaction.block
  AND tx_input.spent_tx_hash = ?
```

- Use the transaction's block number when loading its consumed inputs for the UTXO endpoint:

```sql
WHERE tx_input.spent_at_block = ?
  AND tx_input.spent_tx_hash = ?
```

No Flyway migration or additional database index is required.

## Correctness

All inputs consumed by a transaction are recorded with the block in which that transaction was included. Therefore, adding `spent_at_block` narrows the search to the correct index range without changing the selected inputs.

This also preserves invalid-transaction behavior. For an invalid transaction, `tx_input` contains the collateral inputs that were consumed instead of the regular transaction inputs. Those collateral inputs are consumed in the invalid transaction's block, so the same block predicate applies.

For valid transactions, regular consumed inputs continue to come from `tx_input`; collateral and reference inputs continue to be handled by the existing separate branches.

## Verification

### Database query plan

Verified with `EXPLAIN (ANALYZE, BUFFERS)` against a PostgreSQL mainnet database:

| Query | Before | After |
|---|---:|---:|
| Isolated `tx_input` count | ~12.65 s | ~0.126 ms |
| Full transaction aggregate after the rewrite | N/A | ~64.5 ms |

The rewritten count query used the existing composite index with a single targeted index search instead of skip-scanning across block values.

### Deployed API

Verified using Docker image `bloxbean/yaci-store:fix-1049` and a different mainnet transaction:

```text
ee578fba7424bee97b4ad49f52b0480c8fd0f238c26278cf0c94a4d446a26b4a
```

| Endpoint | First request | 10-request average | Min | Max | Result |
|---|---:|---:|---:|---:|---|
| `/api/v1/blockfrost/txs/{hash}` | 77.7 ms | 26.5 ms | 19.2 ms | 41.6 ms | HTTP 200 |
| `/api/v1/blockfrost/txs/{hash}/utxos` | 74.6 ms | 21.3 ms | 16.3 ms | 26.9 ms | HTTP 200 |

The transaction response matched the requested hash and returned block height `13748070`, `valid_contract: true`, and `utxo_count: 5`. The UTXO response returned the expected regular, collateral, and reference input classifications together with the transaction outputs.

### Build

```bash
./gradlew :extensions:blockfrost:blockfrost-transaction:compileJava
```

Result: `BUILD SUCCESSFUL` with Java 21.

## Database impact

- No new index
- No schema migration
- No data migration
- No changes to stored transaction data
