### PR TITLE
fix: ignore stale DRep votes after unregistration

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
@@ -1,5 +1,7 @@
 package com.bloxbean.cardano.yaci.store.governanceaggr.service;
 
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.certs.StakeCredType;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
 import com.bloxbean.cardano.yaci.core.model.governance.Vote;
 import com.bloxbean.cardano.yaci.core.model.governance.VoterType;
@@ -20,6 +22,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.EPOCH_STAKE;
+import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.DREP_REGISTRATION;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.VOTING_PROCEDURE;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
 import static org.jooq.impl.DSL.*;
@@ -180,43 +183,77 @@ public class VotingAggrService {
                 .map(id -> row(id.getTransactionId(), id.getGov_action_index()))
                 .collect(Collectors.toList());
 
-        var cteQuery = select(
+        var dRepUnregistration = DREP_REGISTRATION.as("drep_unregistration");
+        var dRepCredentialType = decode()
+                .value(VOTING_PROCEDURE.VOTER_TYPE)
+                .when(VoterType.DREP_KEY_HASH.name(), StakeCredType.ADDR_KEYHASH.name())
+                .when(VoterType.DREP_SCRIPT_HASH.name(), StakeCredType.SCRIPTHASH.name());
+
+        // Unregistration clears every earlier vote; re-registration does not restore them.
+        var unregistrationAtOrAfterVote = dRepUnregistration.SLOT.gt(VOTING_PROCEDURE.SLOT)
+                .or(dRepUnregistration.SLOT.eq(VOTING_PROCEDURE.SLOT)
+                        .and(dRepUnregistration.TX_INDEX.gt(VOTING_PROCEDURE.TX_INDEX)))
+                .or(dRepUnregistration.SLOT.eq(VOTING_PROCEDURE.SLOT)
+                        .and(dRepUnregistration.TX_INDEX.eq(VOTING_PROCEDURE.TX_INDEX))
+                        .and(dRepUnregistration.CERT_INDEX.ge(VOTING_PROCEDURE.IDX)));
+
+        var rankedEffectiveVoteQuery = select(
+                VOTING_PROCEDURE.TX_HASH.as("tx_hash"),
                 VOTING_PROCEDURE.VOTER_HASH.as("voter_hash"),
                 VOTING_PROCEDURE.VOTER_TYPE.as("voter_type"),
                 VOTING_PROCEDURE.GOV_ACTION_TX_HASH.as("gov_action_tx_hash"),
                 VOTING_PROCEDURE.GOV_ACTION_INDEX.as("gov_action_index"),
-                max(VOTING_PROCEDURE.SLOT).as("max_slot")
+                rowNumber()
+                        .over(partitionBy(
+                                VOTING_PROCEDURE.VOTER_HASH,
+                                VOTING_PROCEDURE.VOTER_TYPE,
+                                VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
+                                VOTING_PROCEDURE.GOV_ACTION_INDEX
+                        ).orderBy(
+                                VOTING_PROCEDURE.SLOT.desc(),
+                                VOTING_PROCEDURE.TX_INDEX.desc(),
+                                VOTING_PROCEDURE.IDX.desc()
+                        ))
+                        .as("vote_rank")
         )
                 .from(VOTING_PROCEDURE)
                 .where(VOTING_PROCEDURE.EPOCH.le(epoch))
                 .and(row(VOTING_PROCEDURE.GOV_ACTION_TX_HASH, VOTING_PROCEDURE.GOV_ACTION_INDEX).in(govActionPairs))
                 .and(VOTING_PROCEDURE.VOTER_TYPE.in("DREP_KEY_HASH", "DREP_SCRIPT_HASH"))
-                .groupBy(
-                        VOTING_PROCEDURE.VOTER_HASH,
-                        VOTING_PROCEDURE.VOTER_TYPE,
-                        VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
-                        VOTING_PROCEDURE.GOV_ACTION_INDEX
+                .andNotExists(
+                        selectOne()
+                                .from(dRepUnregistration)
+                                .where(dRepUnregistration.DREP_HASH.eq(VOTING_PROCEDURE.VOTER_HASH))
+                                .and(dRepUnregistration.CRED_TYPE.eq(dRepCredentialType))
+                                .and(dRepUnregistration.TYPE.eq(CertificateType.UNREG_DREP_CERT.name()))
+                                .and(dRepUnregistration.EPOCH.le(epoch))
+                                .and(unregistrationAtOrAfterVote)
                 );
 
-        var voteWithMaxSlot = table(name("vote_with_max_slot"));
+        var rankedEffectiveVote = table(name("ranked_effective_vote"));
 
-        var vVoterHash = field(name("vote_with_max_slot", "voter_hash"), String.class);
-        var vGovActionTxHash = field(name("vote_with_max_slot", "gov_action_tx_hash"), String.class);
-        var vGovActionIndex = field(name("vote_with_max_slot", "gov_action_index"), Integer.class);
-        var vMaxSlot = field(name("vote_with_max_slot", "max_slot"), Long.class);
+        var vTxHash = field(name("ranked_effective_vote", "tx_hash"), String.class);
+        var vVoterHash = field(name("ranked_effective_vote", "voter_hash"), String.class);
+        var vVoterType = field(name("ranked_effective_vote", "voter_type"), String.class);
+        var vGovActionTxHash = field(name("ranked_effective_vote", "gov_action_tx_hash"), String.class);
+        var vGovActionIndex = field(name("ranked_effective_vote", "gov_action_index"), Integer.class);
+        var vVoteRank = field(name("ranked_effective_vote", "vote_rank"), Integer.class);
 
-        Result<Record> result = dsl.with("vote_with_max_slot").as(cteQuery)
+        Result<Record> result = dsl.with("ranked_effective_vote").as(rankedEffectiveVoteQuery)
                 .select(VOTING_PROCEDURE.fields())
                 .from(VOTING_PROCEDURE)
-                .join(voteWithMaxSlot)
-                .on(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash)
+                .join(rankedEffectiveVote)
+                .on(VOTING_PROCEDURE.TX_HASH.eq(vTxHash)
+                        .and(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash))
+                        .and(VOTING_PROCEDURE.VOTER_TYPE.eq(vVoterType))
                         .and(VOTING_PROCEDURE.GOV_ACTION_TX_HASH.eq(vGovActionTxHash))
                         .and(VOTING_PROCEDURE.GOV_ACTION_INDEX.eq(vGovActionIndex))
-                        .and(VOTING_PROCEDURE.SLOT.eq(vMaxSlot)))
+                        .and(vVoteRank.eq(1)))
                 .andExists(
                         selectOne()
                                 .from(DREP_DIST)
                                 .where(DREP_DIST.DREP_HASH.eq(VOTING_PROCEDURE.VOTER_HASH))
+                                .and(DREP_DIST.DREP_TYPE.eq(dRepCredentialType))
                                 .and(DREP_DIST.EPOCH.eq(epoch + 1))
                 )
                 .fetch();

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
@@ -1,0 +1,180 @@
+package com.bloxbean.cardano.yaci.store.governanceaggr.service;
+
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.certs.StakeCredType;
+import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
+import com.bloxbean.cardano.yaci.core.model.governance.Vote;
+import com.bloxbean.cardano.yaci.core.model.governance.VoterType;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.RenderQuotedNames;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.DREP_REGISTRATION;
+import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.VOTING_PROCEDURE;
+import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VotingAggrServiceTest {
+    private static final int SNAPSHOT_EPOCH = 10;
+    private static final String DREP_HASH = "11111111111111111111111111111111111111111111111111111111";
+    private static final String GOV_ACTION_TX_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private DSLContext dsl;
+    private VotingAggrService votingAggrService;
+
+    @BeforeEach
+    void setUp() {
+        var dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:" + UUID.randomUUID() + ";MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1");
+
+        dsl = DSL.using(dataSource, SQLDialect.H2, new Settings().withRenderQuotedNames(RenderQuotedNames.NEVER));
+        votingAggrService = new VotingAggrService(dsl, null, null);
+        createSchema();
+        insertDRepDistribution(SNAPSHOT_EPOCH + 1);
+    }
+
+    @Test
+    void getVotesByDRep_doesNotReviveVoteFromBeforeReregistration() {
+        insertVote("old-vote", Vote.YES, 8, 100, 1, 0);
+        insertRegistration("unregister", CertificateType.UNREG_DREP_CERT, 9, 100, 2, 0);
+        insertRegistration("reregister", CertificateType.REG_DREP_CERT, 9, 100, 3, 0);
+
+        assertThat(getVotes()).isEmpty();
+    }
+
+    @Test
+    void getVotesByDRep_returnsNewVoteCastAfterReregistration() {
+        insertVote("old-vote", Vote.YES, 8, 100, 1, 0);
+        insertRegistration("unregister", CertificateType.UNREG_DREP_CERT, 9, 100, 2, 0);
+        insertRegistration("reregister", CertificateType.REG_DREP_CERT, 9, 100, 3, 0);
+        insertVote("new-vote", Vote.NO, 9, 100, 4, 0);
+
+        assertThat(getVotes()).singleElement().satisfies(vote -> {
+            assertThat(vote.getTxHash()).isEqualTo("new-vote");
+            assertThat(vote.getVote()).isEqualTo(Vote.NO);
+        });
+    }
+
+    @Test
+    void getVotesByDRep_ignoresUnregistrationAfterSnapshotEpoch() {
+        insertVote("historical-vote", Vote.YES, SNAPSHOT_EPOCH, 100, 1, 0);
+        insertRegistration("future-unregister", CertificateType.UNREG_DREP_CERT, SNAPSHOT_EPOCH + 1, 101, 0, 0);
+
+        assertThat(getVotes()).singleElement().satisfies(vote -> {
+            assertThat(vote.getTxHash()).isEqualTo("historical-vote");
+            assertThat(vote.getVote()).isEqualTo(Vote.YES);
+        });
+    }
+
+    private List<com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure> getVotes() {
+        var govActionId = GovActionId.builder()
+                .transactionId(GOV_ACTION_TX_HASH)
+                .gov_action_index(0)
+                .build();
+        return votingAggrService.getVotesByDRep(SNAPSHOT_EPOCH, List.of(govActionId));
+    }
+
+    private void insertVote(String txHash, Vote vote, int epoch, long slot, int txIndex, int index) {
+        dsl.insertInto(VOTING_PROCEDURE)
+                .set(VOTING_PROCEDURE.ID, UUID.randomUUID())
+                .set(VOTING_PROCEDURE.TX_HASH, txHash)
+                .set(VOTING_PROCEDURE.IDX, index)
+                .set(VOTING_PROCEDURE.TX_INDEX, txIndex)
+                .set(VOTING_PROCEDURE.VOTER_TYPE, VoterType.DREP_KEY_HASH.name())
+                .set(VOTING_PROCEDURE.VOTER_HASH, DREP_HASH)
+                .set(VOTING_PROCEDURE.GOV_ACTION_TX_HASH, GOV_ACTION_TX_HASH)
+                .set(VOTING_PROCEDURE.GOV_ACTION_INDEX, 0)
+                .set(VOTING_PROCEDURE.VOTE, vote.name())
+                .set(VOTING_PROCEDURE.EPOCH, epoch)
+                .set(VOTING_PROCEDURE.SLOT, slot)
+                .execute();
+    }
+
+    private void insertRegistration(String txHash, CertificateType type, int epoch, long slot, int txIndex, int certIndex) {
+        dsl.insertInto(DREP_REGISTRATION)
+                .set(DREP_REGISTRATION.TX_HASH, txHash)
+                .set(DREP_REGISTRATION.CERT_INDEX, certIndex)
+                .set(DREP_REGISTRATION.TX_INDEX, txIndex)
+                .set(DREP_REGISTRATION.TYPE, type.name())
+                .set(DREP_REGISTRATION.DREP_HASH, DREP_HASH)
+                .set(DREP_REGISTRATION.CRED_TYPE, StakeCredType.ADDR_KEYHASH.name())
+                .set(DREP_REGISTRATION.EPOCH, epoch)
+                .set(DREP_REGISTRATION.SLOT, slot)
+                .execute();
+    }
+
+    private void insertDRepDistribution(int epoch) {
+        dsl.insertInto(DREP_DIST)
+                .set(DREP_DIST.DREP_HASH, DREP_HASH)
+                .set(DREP_DIST.DREP_TYPE, StakeCredType.ADDR_KEYHASH.name())
+                .set(DREP_DIST.AMOUNT, 1_000L)
+                .set(DREP_DIST.EPOCH, epoch)
+                .execute();
+    }
+
+    private void createSchema() {
+        dsl.execute("""
+                CREATE TABLE voting_procedure (
+                    id uuid not null,
+                    tx_hash varchar(64) not null,
+                    idx int not null,
+                    tx_index int not null,
+                    voter_type varchar(50),
+                    voter_hash varchar(56),
+                    gov_action_tx_hash varchar(64),
+                    gov_action_index int,
+                    vote varchar(10),
+                    anchor_url varchar,
+                    anchor_hash varchar(64),
+                    epoch int,
+                    slot bigint,
+                    block bigint,
+                    block_time bigint,
+                    update_datetime timestamp,
+                    primary key (tx_hash, voter_hash, voter_type, gov_action_tx_hash, gov_action_index)
+                )
+                """);
+        dsl.execute("""
+                CREATE TABLE drep_registration (
+                    tx_hash varchar(64) not null,
+                    cert_index int not null,
+                    tx_index int not null,
+                    type varchar(50),
+                    deposit bigint,
+                    drep_hash varchar(56),
+                    drep_id varchar(255),
+                    anchor_url varchar,
+                    anchor_hash varchar(64),
+                    cred_type varchar(40),
+                    epoch int,
+                    slot bigint,
+                    block bigint,
+                    block_time bigint,
+                    update_datetime timestamp,
+                    primary key (tx_hash, cert_index)
+                )
+                """);
+        dsl.execute("""
+                CREATE TABLE drep_dist (
+                    drep_hash varchar(56),
+                    drep_type varchar(40),
+                    drep_id varchar(255),
+                    amount bigint,
+                    epoch int,
+                    active_until int,
+                    expiry int,
+                    update_datetime timestamp,
+                    primary key (drep_hash, drep_type, epoch)
+                )
+                """);
+    }
+}

--- a/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
+++ b/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
@@ -114,11 +114,11 @@ Covers post-bootstrap qualifier gates where votes would otherwise be sufficient:
 
 ### `dRepReregistration_shouldNotReviveStaleVoteAndShouldAcceptNewVote`
 
-- A DRep with dominant stake votes `YES`, unregisters, and re-registers the
-  same credential without casting a new vote for the proposal.
+- A DRep with dominant stake votes `YES`, unregisters, re-registers the same
+  credential, and restores its delegation without casting a new vote for the proposal.
 - A smaller DRep votes `NO`.
-- Re-registration restores the DRep's voting power but does not restore the
-  cleared `YES` vote, so the proposal expires.
+- Re-registration plus a new delegation restores the DRep's voting power but
+  does not restore the cleared `YES` vote, so the proposal expires.
 - A control proposal verifies that a new `NO` vote cast after re-registration
   is counted while the earlier `YES` vote remains cleared.
 - The test asserts effective voting stats and DB-vs-ledger outcome, not deletion of raw historical vote rows.

--- a/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
+++ b/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
@@ -18,7 +18,7 @@ API status translation is intentionally separate from rule parity tests.
 | `GovernanceProposalApiStatusIT` | 1 | Public API status mapping from stored proposal status rows |
 | `GovernanceProposalOutcomeIT` | 2 | Post-bootstrap action outcome and ratification-gate parity |
 | `GovernanceDRepVoteTallyIT` | 2 | DRep vote aggregation, replacement, and accepted-ratio parity |
-| `GovernanceDRepLifecycleVoteTallyIT` | 1 | DRep registration lifecycle effect on active proposal tallies |
+| `GovernanceDRepLifecycleVoteTallyIT` | 1 | DRep unregister/re-registration lifecycle effect on active proposal tallies |
 | `GovernanceSPOVoteTallyIT` | 2 | SPO stake distribution and mixed voting-group parity |
 | `GovernanceCommitteeVoteTallyIT` | 1 | Committee size and quorum parity |
 | `GovernanceRuleEdgeIT` | 5 active, 1 disabled | Default-vote reshaping and voter eligibility edges |
@@ -112,11 +112,15 @@ Covers post-bootstrap qualifier gates where votes would otherwise be sufficient:
 
 ## `GovernanceDRepLifecycleVoteTallyIT`
 
-### `dRepDeregistration_shouldClearEffectiveVoteForProposal`
+### `dRepReregistration_shouldNotReviveStaleVoteAndShouldAcceptNewVote`
 
-- A DRep with dominant stake votes `YES` for a proposal, then deregisters before ratification.
+- A DRep with dominant stake votes `YES`, unregisters, and re-registers the
+  same credential without casting a new vote for the proposal.
 - A smaller DRep votes `NO`.
-- If the deregistered DRep remained effective, the DRep ratio would pass; after ledger cleanup, the proposal expires.
+- Re-registration restores the DRep's voting power but does not restore the
+  cleared `YES` vote, so the proposal expires.
+- A control proposal verifies that a new `NO` vote cast after re-registration
+  is counted while the earlier `YES` vote remains cleared.
 - The test asserts effective voting stats and DB-vs-ledger outcome, not deletion of raw historical vote rows.
 
 ## `GovernanceSPOVoteTallyIT`

--- a/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
+++ b/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.account.Account;
 import com.bloxbean.cardano.client.transaction.spec.governance.Vote;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
+import com.bloxbean.cardano.yaci.store.test.e2e.common.GovernanceTxHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
 
     /**
-     * A DRep deregistration removes that DRep's effective votes from active proposals.
+     * Re-registering a DRep does not restore votes cleared by its earlier deregistration.
      */
     @Test
-    void dRepDeregistration_shouldClearEffectiveVoteForProposal() {
+    void dRepReregistration_shouldNotReviveStaleVoteAndShouldAcceptNewVote() {
         ensureDRepUnregisterFixture();
 
         Account removedYesDRep = accountAt(5);
@@ -34,7 +35,7 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
         BigInteger remainingNoStake = ledgerDRepStake(com.bloxbean.cardano.client.governance.GovId.toDrep(remainingNoDRep.drepId()));
 
         assertProposalScenario(
-                "DRep deregistration clears an earlier YES vote before ratification",
+                "DRep re-registration does not revive an earlier YES vote",
                 GovActionType.NEW_CONSTITUTION,
                 this::newConstitutionAction,
                 proposal -> {
@@ -44,6 +45,7 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                     governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.YES);
                     governanceTxHelper.castDRepVote(account0, remainingNoDRep, proposal.storeGovActionId(), Vote.NO);
                     governanceTxHelper.unregisterDRep(account0, removedYesDRep);
+                    governanceTxHelper.registerDRep(account0, removedYesDRep, GovernanceTxHelper.defaultAnchor());
                     castCommitteeYesVotes(proposal, committeeAccounts.size());
                 },
                 GovActionStatus.EXPIRED,
@@ -51,6 +53,24 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                     assertThat(removedYesStake).as("removed DRep fixture stake").isPositive();
                     assertStake("deregistered DRep YES stake", stats.getDrepYesVoteStake(), BigInteger.ZERO);
                     assertStake("remaining DRep NO stake", stats.getDrepNoVoteStake(), remainingNoStake);
+                    assertThat(nz(stats.getDrepApprovalRatio())).isZero();
+                });
+
+        assertProposalScenario(
+                "DRep vote after re-registration replaces the cleared vote",
+                GovActionType.NEW_CONSTITUTION,
+                this::newConstitutionAction,
+                proposal -> {
+                    governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.YES);
+                    governanceTxHelper.unregisterDRep(account0, removedYesDRep);
+                    governanceTxHelper.registerDRep(account0, removedYesDRep, GovernanceTxHelper.defaultAnchor());
+                    governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.NO);
+                    castCommitteeYesVotes(proposal, committeeAccounts.size());
+                },
+                GovActionStatus.EXPIRED,
+                stats -> {
+                    assertStake("cleared DRep YES stake", stats.getDrepYesVoteStake(), BigInteger.ZERO);
+                    assertStake("post-registration DRep NO stake", stats.getDrepNoVoteStake(), removedYesStake);
                     assertThat(nz(stats.getDrepApprovalRatio())).isZero();
                 });
     }

--- a/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
+++ b/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
@@ -39,13 +39,13 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                 GovActionType.NEW_CONSTITUTION,
                 this::newConstitutionAction,
                 proposal -> {
-                    // Re-registering the same credential restores its voting power, but must not restore
-                    // the cleared YES vote. Otherwise, YES/(YES+NO) would be roughly
+                    // Re-registering the same credential and restoring its delegation returns its voting
+                    // power, but must not restore the cleared YES vote. Otherwise, YES/(YES+NO) would be roughly
                     // 910,000 / 1,020,000 ~= 0.89 and incorrectly clear the NewConstitution threshold.
                     governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.YES);
                     governanceTxHelper.castDRepVote(account0, remainingNoDRep, proposal.storeGovActionId(), Vote.NO);
                     governanceTxHelper.unregisterDRep(account0, removedYesDRep);
-                    governanceTxHelper.registerDRep(account0, removedYesDRep, GovernanceTxHelper.defaultAnchor());
+                    registerDRepAndRestoreDelegation(removedYesDRep);
                     castCommitteeYesVotes(proposal, committeeAccounts.size());
                 },
                 GovActionStatus.EXPIRED,
@@ -63,7 +63,7 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                 proposal -> {
                     governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.YES);
                     governanceTxHelper.unregisterDRep(account0, removedYesDRep);
-                    governanceTxHelper.registerDRep(account0, removedYesDRep, GovernanceTxHelper.defaultAnchor());
+                    registerDRepAndRestoreDelegation(removedYesDRep);
                     governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.NO);
                     castCommitteeYesVotes(proposal, committeeAccounts.size());
                 },
@@ -73,5 +73,13 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                     assertStake("post-registration DRep NO stake", stats.getDrepNoVoteStake(), removedYesStake);
                     assertThat(nz(stats.getDrepApprovalRatio())).isZero();
                 });
+    }
+
+    private void registerDRepAndRestoreDelegation(Account drepAccount) {
+        governanceTxHelper.registerDRep(account0, drepAccount, GovernanceTxHelper.defaultAnchor());
+        governanceTxHelper.delegateVotingPowerToDRep(
+                account0,
+                drepAccount,
+                com.bloxbean.cardano.client.governance.GovId.toDrep(drepAccount.drepId()));
     }
 }

--- a/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
+++ b/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
@@ -39,9 +39,9 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                 GovActionType.NEW_CONSTITUTION,
                 this::newConstitutionAction,
                 proposal -> {
-                    // If the YES DRep stayed registered, YES/(YES+NO) would be roughly
-                    // 910,000 / 1,020,000 ~= 0.89 and clear the NewConstitution DRep threshold.
-                    // The unregister transaction must remove that YES vote from effective ledger state.
+                    // Re-registering the same credential restores its voting power, but must not restore
+                    // the cleared YES vote. Otherwise, YES/(YES+NO) would be roughly
+                    // 910,000 / 1,020,000 ~= 0.89 and incorrectly clear the NewConstitution threshold.
                     governanceTxHelper.castDRepVote(account0, removedYesDRep, proposal.storeGovActionId(), Vote.YES);
                     governanceTxHelper.castDRepVote(account0, remainingNoDRep, proposal.storeGovActionId(), Vote.NO);
                     governanceTxHelper.unregisterDRep(account0, removedYesDRep);


### PR DESCRIPTION
 ## Summary

  Fix DRep vote tallying so votes cast before a DRep unregistration are not revived when the same DRep credential is registered again.

  Fixes #1048.

  ## Root cause

  Cardano ledger state clears a DRep's votes when the DRep unregisters. Re-registering the same credential does not restore those votes.

  Yaci Store previously selected the latest stored vote and only checked whether the DRep existed in the snapshot distribution. Once the DRep registered again, this eligibility check passed and the stale pre-
  unregistration vote was incorrectly included in governance voting statistics, causing mismatches with AdaStat and ledger state.

  ## Changes

  - Exclude DRep votes invalidated by an unregistration at or before the requested snapshot epoch.
  - Preserve votes cast after the DRep registers again.
  - Select the latest effective vote deterministically using slot, transaction index, and vote index.
  - Match DRep credential types when checking registration and distribution records.
  - Add unit coverage for:
    - stale votes after unregister/re-register;
    - new votes cast after re-registration;
    - unregistrations occurring after the requested snapshot epoch.
  - Extend the DevKit E2E lifecycle test to:
    - re-register and restore the DRep delegation;
    - verify that the old vote remains cleared;
    - verify that a new post-registration vote is counted.
  - Update the governance E2E test-case documentation.

  Raw historical vote rows remain unchanged; lifecycle filtering is applied when determining effective votes. No database migration is required.

  ## Testing

  - [x] `./gradlew :aggregates:governance-aggr:test --tests com.bloxbean.cardano.yaci.store.governanceaggr.service.VotingAggrServiceTest --console=plain`
  - [x] `./gradlew :e2e-tests:compileTestJava`
  - [x] `./gradlew :e2e-tests:test --tests com.bloxbean.cardano.yaci.store.test.e2e.gov.GovernanceDRepLifecycleVoteTallyIT --console=plain`
    - 1 test, 0 failures, 0 errors