### PR TITLE
fix(core): bulk (set-based) cursor deletes to prevent cursor cleanup OOM

### DIFF
--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
@@ -3,6 +3,9 @@ package com.bloxbean.cardano.yaci.store.core.storage.impl;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.model.CursorEntity;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.model.CursorId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,8 +18,19 @@ public interface CursorRepository extends JpaRepository<CursorEntity, CursorId> 
 
     Optional<CursorEntity> findByIdAndBlockHash(Long id, String blockHash);
 
-    int deleteByIdAndSlotGreaterThan(Long id, Long slot);
+    // Set-based (bulk) deletes. These were Spring Data DERIVED deletes, which Spring implements by
+    // SELECTing every matching row into the persistence context and removing them one entity at a
+    // time -- so memory scales with the number of rows deleted. When cursor_ is large (e.g. the
+    // cleanup below has never completed since genesis) a single run loads millions of CursorEntity
+    // objects and throws OutOfMemoryError; the cursor then never prunes, so the failure is permanent
+    // and self-reinforcing. A @Modifying @Query issues one SQL DELETE with memory independent of the
+    // number of rows removed.
+    @Modifying
+    @Query("delete from CursorEntity c where c.id = :id and c.slot > :slot")
+    int deleteByIdAndSlotGreaterThan(@Param("id") Long id, @Param("slot") Long slot);
 
     //Required for history cleanup
-    int deleteByIdAndBlockLessThan(Long id, Long block);
+    @Modifying
+    @Query("delete from CursorEntity c where c.id = :id and c.block < :block")
+    int deleteByIdAndBlockLessThan(@Param("id") Long id, @Param("block") Long block);
 }


### PR DESCRIPTION
## Problem
`CursorCleanupScheduler.scheduleCursorCleanup()` → `CursorStorageImpl.deleteCursorBefore()` → `CursorRepository.deleteByIdAndBlockLessThan(id, block)`.

`deleteByIdAndBlockLessThan` (and its sibling `deleteByIdAndSlotGreaterThan`) are Spring Data **derived deletes**. Spring implements a derived delete by **SELECTing every matching row into the persistence context and removing them one entity at a time** (so lifecycle callbacks can fire). Memory therefore scales with the number of rows being deleted.

When `cursor_` is large this OOMs. Concretely: on a full sync the table accumulates one row per block; if a cleanup run ever faces a large backlog (e.g. the first cleanup during/after a long initial sync, or any deployment where cleanup hasn't kept up), it loads millions of `CursorEntity` instances and throws `java.lang.OutOfMemoryError: Java heap space`. Because the delete never commits, the cursor is never pruned, so **every subsequent hourly run faces at least as many rows — the failure is permanent and self-reinforcing**, and at smaller heaps the OOM/GC-thrash wedges the whole sync.

We hit this on a downstream deployment where `cursor_` had grown to ~13.7M rows (~2.7 GB); every hourly `scheduleCursorCleanup` OOMed until the table was purged by hand with a plain SQL `DELETE`.

## Fix
Make both cursor deletes `@Modifying @Query` bulk deletes — a single SQL `DELETE` whose memory cost is independent of the number of rows removed. Behavior is otherwise identical (same rows removed).

```java
@Modifying
@Query("delete from CursorEntity c where c.id = :id and c.slot > :slot")
int deleteByIdAndSlotGreaterThan(@Param("id") Long id, @Param("slot") Long slot);

@Modifying
@Query("delete from CursorEntity c where c.id = :id and c.block < :block")
int deleteByIdAndBlockLessThan(@Param("id") Long id, @Param("block") Long block);
```

## Notes / compatibility
- Both methods are already invoked inside a transaction (`CursorCleanupScheduler` is `@Transactional`; the rollback path that uses `deleteByIdAndSlotGreaterThan` runs transactionally too), which `@Modifying` requires — no caller change needed.
- I left `clearAutomatically`/`flushAutomatically` at defaults to keep the change minimal; happy to set `clearAutomatically = true` if you'd prefer to guard against stale first-level-cache reads after the delete.
- Verified the derived-delete form is present unchanged on `v2.0.0-beta5`, `v2.0.2.1`, `v3.0.0-beta3`, and `main`.

## Tests
I didn't add a test because the existing `*StorageImplTest`s in this module mock the repository (so they wouldn't exercise the query), and I didn't want to guess at the JPA slice/DB harness for a real integration test. Glad to add a `@DataJpaTest` that inserts N cursor rows and asserts `deleteCursorBefore` prunes correctly if you can point me at the preferred test DB setup for `components/core`.