### PR TITLE
Fix full table scan in block addresses endpoint

### DIFF
--- a/components/dbutils/src/main/resources/blockfrost-index.yml
+++ b/components/dbutils/src/main/resources/blockfrost-index.yml
@@ -3,9 +3,9 @@
     - name: idx_address_utxo_owner_addr_full
       columns:
         - owner_addr_full
-    - name: idx_address_utxo_block
+    - name: idx_address_utxo_block_number
       columns:
-        - block_hash
+        - block
 
 - table: assets
   indexes:

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/service/BFBlockService.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/service/BFBlockService.java
@@ -117,7 +117,7 @@ public class BFBlockService {
         long blockNumber = requireBlockNumber(block);
 
         List<BFBlockAddressTxRow> rows =
-                bfBlocksStorageReader.findBlockAddressTransactions(blockNumber, block.hash(), page, count);
+                bfBlocksStorageReader.findBlockAddressTransactions(blockNumber, page, count);
 
         Map<String, LinkedHashMap<String, BFBlockAddressTxDTO>> addresses = new LinkedHashMap<>();
         for (BFBlockAddressTxRow row : rows) {

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/service/BFBlockService.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/service/BFBlockService.java
@@ -116,7 +116,8 @@ public class BFBlockService {
         BFBlockRow block = requireBlock(hashOrNumber);
         long blockNumber = requireBlockNumber(block);
 
-        List<BFBlockAddressTxRow> rows = bfBlocksStorageReader.findBlockAddressTransactions(blockNumber, page, count);
+        List<BFBlockAddressTxRow> rows =
+                bfBlocksStorageReader.findBlockAddressTransactions(blockNumber, block.hash(), page, count);
 
         Map<String, LinkedHashMap<String, BFBlockAddressTxDTO>> addresses = new LinkedHashMap<>();
         for (BFBlockAddressTxRow row : rows) {

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/BFBlocksStorageReader.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/BFBlocksStorageReader.java
@@ -27,5 +27,5 @@ public interface BFBlocksStorageReader {
 
     List<BFBlockTxCborRow> findBlockTxCbor(long blockNumber, int page, int count, Order order);
 
-    List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, String blockHash, int page, int count);
+    List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, int page, int count);
 }

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/BFBlocksStorageReader.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/BFBlocksStorageReader.java
@@ -27,5 +27,5 @@ public interface BFBlocksStorageReader {
 
     List<BFBlockTxCborRow> findBlockTxCbor(long blockNumber, int page, int count, Order order);
 
-    List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, int page, int count);
+    List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, String blockHash, int page, int count);
 }

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
@@ -189,7 +189,7 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
     }
 
     @Override
-    public List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, String blockHash, int page, int count) {
+    public List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, int page, int count) {
         int offset = Math.max(page, 0) * count;
 
         var outputUtxo = ADDRESS_UTXO.as("output_utxo");
@@ -198,7 +198,7 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
 
         var outputsSelect = dsl.select(outputAddressField, outputUtxo.TX_HASH.as("tx_hash"))
                 .from(outputUtxo)
-                .where(outputUtxo.BLOCK_HASH.eq(blockHash))
+                .where(outputUtxo.BLOCK.eq(blockNumber))
                 .and(outputAddressExpr.isNotNull());
 
         var spentInput = TX_INPUT.as("spent_input");

--- a/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
+++ b/extensions/blockfrost/block/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/block/storage/impl/BFBlocksStorageReaderImpl.java
@@ -189,7 +189,7 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
     }
 
     @Override
-    public List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, int page, int count) {
+    public List<BFBlockAddressTxRow> findBlockAddressTransactions(long blockNumber, String blockHash, int page, int count) {
         int offset = Math.max(page, 0) * count;
 
         var outputUtxo = ADDRESS_UTXO.as("output_utxo");
@@ -198,7 +198,7 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
 
         var outputsSelect = dsl.select(outputAddressField, outputUtxo.TX_HASH.as("tx_hash"))
                 .from(outputUtxo)
-                .where(outputUtxo.BLOCK.eq(blockNumber))
+                .where(outputUtxo.BLOCK_HASH.eq(blockHash))
                 .and(outputAddressExpr.isNotNull());
 
         var spentInput = TX_INPUT.as("spent_input");
@@ -215,13 +215,10 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
                 .and(spentInput.SPENT_TX_HASH.isNotNull())
                 .and(spentAddressExpr.isNotNull());
 
-        Table<?> affected = outputsSelect.unionAll(spentSelect).asTable("affected");
-        Field<String> affectedAddressField = affected.field("address", String.class);
-        Field<String> affectedTxHashField = affected.field("tx_hash", String.class);
-
-        if (affectedAddressField == null || affectedTxHashField == null) {
-            return List.of();
-        }
+        var affectedCte = DSL.name("affected").as(outputsSelect.unionAll(spentSelect));
+        Table<?> affected = DSL.table(DSL.name("affected"));
+        Field<String> affectedAddressField = DSL.field(DSL.name("affected", "address"), String.class);
+        Field<String> affectedTxHashField = DSL.field(DSL.name("affected", "tx_hash"), String.class);
 
         Table<?> pagedAddresses = dsl.selectDistinct(affectedAddressField.as("address"))
                 .from(affected)
@@ -231,15 +228,13 @@ public class BFBlocksStorageReaderImpl implements BFBlocksStorageReader {
                 .offset(offset)
                 .asTable("paged_addresses");
 
-        Field<String> pagedAddressField = pagedAddresses.field("address", String.class);
-        if (pagedAddressField == null) {
-            return List.of();
-        }
+        Field<String> pagedAddressField = DSL.field(DSL.name("paged_addresses", "address"), String.class);
 
         var transaction = TRANSACTION.as("tx");
         Field<Integer> txIndexField = DSL.min(transaction.TX_INDEX).as("tx_index");
 
-        return dsl.select(
+        return dsl.with(affectedCte)
+                .select(
                         pagedAddressField.as("address"),
                         affectedTxHashField.as("tx_hash"),
                         txIndexField


### PR DESCRIPTION
## Summary

`findBlockAddressTransactions()` filters `address_utxo` on the numeric `block` column, which had no index. The blockfrost index named `idx_address_utxo_block` is actually defined on `block_hash`, so the predicate degraded to a parallel sequential scan over the whole 352M-row / 244GB table.

The output/spent `unionAll` was also declared as a derived table and referenced twice (once in `paged_addresses`, again in the outer join), so Postgres inlined it at each reference and ran that sequential scan twice.

Following review, the fix is:
- **`blockfrost-index.yml`**: replace `idx_address_utxo_block` (on `block_hash`) with `idx_address_utxo_block_number` (on `block`), so the index matches the query the code has issued since #811. The unused `block_hash` index is dropped in favour of one that is actually reachable.
- **Move the union into a CTE** so it is evaluated once instead of twice.

The query itself is unchanged from `main`: no `blockHash` parameter, no signature change.

Removal of the now-obsolete `idx_address_utxo_block` on existing installations is not handled here; see discussion.

Fixes #1044

## Test plan

Verified against a synced mainnet DB (`address_utxo` 352,801,888 rows / 244GB heap, 396GB total), on the 57-transaction block 13749038, with `idx_address_utxo_block_number` built via `CREATE INDEX CONCURRENTLY`.

`EXPLAIN (ANALYZE, BUFFERS)`:
- Before: `Parallel Seq Scan on address_utxo`, `Filter: (block = ...)`, planner cost 67,736,241 — appearing **twice** in the plan (`address_utxo o` and `o_1`)
- After: `Index Scan using idx_address_utxo_block_number`, `Index Cond: (block = 13749038)`, planner cost 77,804, that node at 0.064ms
- The CTE is materialized once (`Storage: Memory, Maximum Storage: 134kB`) and scanned twice

Query time: **197ms cold, then 8.5ms / 8.5ms / 8.5ms warm.**

Row equivalence: filtering by `block = 13749038` and by the corresponding `block_hash` both return 67 rows, symmetric difference 0.

Index size on mainnet, measured after the build:
- `idx_address_utxo_block` (`block_hash`, current) — 3263 MB
- `idx_address_utxo_block_number` (`block`, new) — **2497 MB**

Endpoint timing before the fix, measured on the live mainnet node: **246.90s** for `/api/v1/blockfrost/blocks/13749038/addresses?count=100&page=1`.
