### PR TITLE
Use a hash index for address_utxo.owner_addr_full in blockfrost-index.yml

### DIFF
--- a/components/dbutils/src/main/resources/blockfrost-index.yml
+++ b/components/dbutils/src/main/resources/blockfrost-index.yml
@@ -1,8 +1,13 @@
 - table: address_utxo
   indexes:
+    # btree is impossible on mainnet for this column: at least one Byron-era
+    # address exceeds the btree row limit ("index row requires 10520 bytes,
+    # maximum size is 8191"). The BF address endpoints look this column up by
+    # equality only, which a hash index serves without any key-size limit.
     - name: idx_address_utxo_owner_addr_full
       columns:
         - owner_addr_full
+      type: hash
     - name: idx_address_utxo_block
       columns:
         - block_hash


### PR DESCRIPTION
## Problem

The shipped `blockfrost-index.yml` btree definition for `address_utxo.owner_addr_full` cannot be created on mainnet:

```
ERROR:  index row requires 10520 bytes, maximum size is 8191
```

At least one Byron-era-class mainnet address exceeds the btree row-size limit. Reproduced independently on two mainnet deployments (our validation instance, and @satran004 saw the same in his deployment and thought it was instance-specific).

Related observation, reported in the Discord thread: `apply-optional-indexes` exits 0 when an index in the set fails, surfacing only a WARN plus a summary line, so exit-code-based automation misses the failure. Happy to send a separate PR for that if wanted.

## Fix

Config-only: `type: hash` on the existing entry (name unchanged). The Blockfrost address endpoints look this column up by equality only, which a hash index serves with no key-size limit, and `IndexService` already supports the yml `type` field (`USING <type>`).

## Validation (full mainnet instance, epoch 647, PG 18.4)

- Build: **8m23s** at the standard `maintenance_work_mem=1GB` (16 vCPU / 64 GB / pd-ssd), comparable to the btree builds in the same set
- Size: **10 GB**; `pg_index.indisvalid = t`
- Planner evidence, equality lookup:

```
Index Scan using idx_address_utxo_owner_addr_full_hash on address_utxo
  (cost=0.00..8.02 rows=1 width=2314) (actual time=1.201..1.202 rows=1.00 loops=1)
```

Requested by @huyle28 in the thread after we hit the failure during the beta3 mainnet validation run.