### PR TITLE
Set requiredSigners on Txn during transaction processing (fixes #1061)

### DIFF
--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
@@ -40,7 +40,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -104,6 +106,12 @@ public class TransactionProcessor {
 
             BigInteger fee = feeResolver.resolveFee(transaction);
 
+            Set<String> requiredSigners = null;
+            if (transaction.getBody().getRequiredSigners() != null
+                    && !transaction.getBody().getRequiredSigners().isEmpty()) {
+                requiredSigners = new HashSet<>(transaction.getBody().getRequiredSigners());
+            }
+
             Txn txn = Txn.builder()
                     .txHash(transaction.getTxHash())
                     .blockHash(event.getMetadata().getBlockHash())
@@ -120,6 +128,7 @@ public class TransactionProcessor {
                     .validityIntervalStart(transaction.getBody().getValidityIntervalStart())
                     .scriptDataHash(transaction.getBody().getScriptDataHash())
                     .collateralInputs(collateralInputs)
+                    .requiredSigners(requiredSigners)
                     .collateralReturnJson(convertOutput(transaction.getBody().getCollateralReturn()))
                     .netowrkId(transaction.getBody().getNetowrkId())
                     .totalCollateral(transaction.getBody().getTotalCollateral())

--- a/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
+++ b/stores/transaction/src/main/java/com/bloxbean/cardano/yaci/store/transaction/processor/TransactionProcessor.java
@@ -40,9 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -106,12 +104,6 @@ public class TransactionProcessor {
 
             BigInteger fee = feeResolver.resolveFee(transaction);
 
-            Set<String> requiredSigners = null;
-            if (transaction.getBody().getRequiredSigners() != null
-                    && !transaction.getBody().getRequiredSigners().isEmpty()) {
-                requiredSigners = new HashSet<>(transaction.getBody().getRequiredSigners());
-            }
-
             Txn txn = Txn.builder()
                     .txHash(transaction.getTxHash())
                     .blockHash(event.getMetadata().getBlockHash())
@@ -128,7 +120,7 @@ public class TransactionProcessor {
                     .validityIntervalStart(transaction.getBody().getValidityIntervalStart())
                     .scriptDataHash(transaction.getBody().getScriptDataHash())
                     .collateralInputs(collateralInputs)
-                    .requiredSigners(requiredSigners)
+                    .requiredSigners(transaction.getBody().getRequiredSigners())
                     .collateralReturnJson(convertOutput(transaction.getBody().getCollateralReturn()))
                     .netowrkId(transaction.getBody().getNetowrkId())
                     .totalCollateral(transaction.getBody().getTotalCollateral())


### PR DESCRIPTION
Fixes #1061.

## Problem

`transaction.required_signers` is declared in the schema (`V0_300_1__init.sql`, jsonb), mapped on `TxnEntity`, present on the `Txn` and `TransactionDetails` domain objects, and read by both `TransactionService` and `BFTransactionService`. But `TransactionProcessor` never set it, so the column was always null.

Visible effect: `GET /txs/{tx_hash}/required_signers` returns `[]` for every transaction, including ones that genuinely have required signers. Found while comparing against Blockfrost on a mainnet instance; @satran004 diagnosed the cause on the issue.

## Change

Populate `requiredSigners` from `transaction.getBody().getRequiredSigners()` in the `Txn.builder()` chain, null when the body has none, matching how `collateralInputs` and `referenceInputs` are handled a few lines above.

## Verification

- `:stores:transaction:compileJava` clean.
- Reference case from #1061: tx `a08eb1513c64588ee8f44a9b52395f28948399ada4112ece3f0054a505cb7b81` on mainnet, where Blockfrost returns witness hash `0b46751422f2357dd4ecee5a84b288b982b20375a0503cc7ecdda5aa` and yaci-store currently returns `[]`.

## Note for existing deployments

This populates rows indexed **after** the change. Transactions already stored keep `required_signers = null` until their blocks are re-processed, so a rollback + re-sync (or a targeted backfill) is needed to correct historical data. Happy to add a backfill note to the docs if you want one.