### PR TITLE
fix(epoch-aggr): update total fees for existing epochs

### DIFF
--- a/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/storage/impl/mapper/EpochMapper.java
+++ b/aggregates/epoch-aggr/src/main/java/com/bloxbean/cardano/yaci/store/epochaggr/storage/impl/mapper/EpochMapper.java
@@ -11,6 +11,7 @@ public abstract class EpochMapper {
 
     public EpochEntity updateEntity(Epoch epoch, EpochEntity targetEntity) {
         targetEntity.setTotalOutput(epoch.getTotalOutput());
+        targetEntity.setTotalFees(epoch.getTotalFees());
         targetEntity.setTransactionCount(epoch.getTransactionCount());
         targetEntity.setBlockCount(epoch.getBlockCount());
         targetEntity.setStartTime(epoch.getStartTime());


### PR DESCRIPTION
## Summary

- Persist the recalculated `totalFees` value when updating an existing epoch.
- Fix incorrect `fees` values returned for the in-progress epoch.

Fixes #1064

## Root cause

`EpochService` correctly recalculates the total fees from all blocks in an epoch. However, `EpochMapper.updateEntity()` did not copy `totalFees` to an existing `EpochEntity`.

The initial insert mapped every field, so an epoch created when its first block arrived stored that block's fee. Later aggregation runs calculated the correct accumulated fees but left the stored value unchanged.

## Changes

Update `EpochMapper.updateEntity()` to set `totalFees` together with the other recalculated epoch fields.

## Verification

- Confirmed against the mainnet database that the stored fee matched the first block's fee while the block-derived epoch total was significantly higher.
- Ran `./gradlew :aggregates:epoch-aggr:compileJava` successfully.
- Ran the `epoch-aggr` and Blockfrost epoch module checks successfully.

## Notes

- No database schema changes are required.
- The current epoch will be corrected by the next scheduled aggregation after deployment.
- Previously affected closed epochs require a separate one-time data backfill.
