### PR TITLE
Add tx_input(spent_tx_hash) to blockfrost-index.yml (fixes #1075)

### DIFF
--- a/components/dbutils/src/main/resources/blockfrost-index.yml
+++ b/components/dbutils/src/main/resources/blockfrost-index.yml
@@ -39,6 +39,12 @@
     - name: idx_tx_input_tx_hash
       columns:
         - tx_hash
+    # /txs/{hash} computes count(*) where spent_tx_hash = ?; without a
+    # leading spent_tx_hash index that is a ~10s range walk on mainnet
+    # (see issue #1075). 14m21s to build, 13 GB, endpoint drops to ~0.2s.
+    - name: idx_tx_input_spent_tx_hash
+      columns:
+        - spent_tx_hash
 
 - table: block
   indexes:


### PR DESCRIPTION
Fixes #1075.

One-entry addition to `blockfrost-index.yml`: an index on `tx_input (spent_tx_hash)`.

`GET /txs/{tx_hash}` computes `count(*) from tx_input where spent_tx_hash = ?` among its eight correlated sub-selects; the other seven are sub-millisecond, this one is **9.7s** on mainnet because no index leads with `spent_tx_hash` (the composite `(spent_at_block, spent_tx_hash)` has it second).

Verified on our mainnet validation instance before opening this PR:

| | before | after |
|---|---|---|
| the subquery | 9723 ms | 1.4 ms |
| `GET /txs/{hash}` | ~10 s | 0.16-0.20 s |
| `GET /txs/{hash}/utxos` | ~9.9 s | 0.009-0.015 s |
| build cost | | 14m21s concurrent, 13 GB |

Note: this file is also touched by #1060 (different table block); the hunks don't overlap, whichever merges second rebases trivially.