### PR TITLE
fix(blockfrost): Include deposit in DRep updates response

### DIFF
--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/dto/BFDRepUpdateDto.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/dto/BFDRepUpdateDto.java
@@ -19,4 +19,6 @@ public class BFDRepUpdateDto {
     private Integer certIndex;
     /** Values: "registered", "deregistered", "updated" */
     private String action;
+    /** Lovelace deposit paid at registration. Null on "deregistered" and "updated". */
+    private String deposit;
 }

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/mapper/BFDRepMapper.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/mapper/BFDRepMapper.java
@@ -51,6 +51,7 @@ public interface BFDRepMapper {
     @Mapping(target = "txHash", source = "txHash")
     @Mapping(target = "certIndex", expression = "java((int) registration.getCertIndex())")
     @Mapping(target = "action", expression = "java(certTypeStringToAction(registration.getType() != null ? registration.getType().name() : null))")
+    @Mapping(target = "deposit", expression = "java(registrationDeposit(registration))")
     BFDRepUpdateDto toUpdateDto(DRepRegistration registration);
 
     // ── DRep vote ─────────────────────────────────────────────────────────
@@ -89,6 +90,17 @@ public interface BFDRepMapper {
             case "UPDATE_DREP_CERT" -> "updated";
             default -> typeName.toLowerCase();
         };
+    }
+
+    /**
+     * Deposit is only meaningful on a registration. The store persists the refund amount on
+     * UNREG_DREP_CERT rows, but Blockfrost reports deposit as null for deregistered and
+     * updated actions, so only REG_DREP_CERT surfaces a value.
+     */
+    default String registrationDeposit(DRepRegistration registration) {
+        if (registration == null || registration.getDeposit() == null) return null;
+        return registration.getType() == com.bloxbean.cardano.yaci.core.model.certs.CertificateType.REG_DREP_CERT
+                ? registration.getDeposit().toString() : null;
     }
 
     @Named("voteToLowerCase")

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/mapper/BFDRepMapper.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/mapper/BFDRepMapper.java
@@ -1,5 +1,8 @@
 package com.bloxbean.cardano.yaci.store.blockfrost.governance.mapper;
 
+import com.bloxbean.cardano.client.crypto.Bech32;
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.governance.Vote;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.dto.BFDRepDelegatorDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.dto.BFDRepDto;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.dto.BFDRepListItemDto;
@@ -99,12 +102,12 @@ public interface BFDRepMapper {
      */
     default String registrationDeposit(DRepRegistration registration) {
         if (registration == null || registration.getDeposit() == null) return null;
-        return registration.getType() == com.bloxbean.cardano.yaci.core.model.certs.CertificateType.REG_DREP_CERT
+        return registration.getType() == CertificateType.REG_DREP_CERT
                 ? registration.getDeposit().toString() : null;
     }
 
     @Named("voteToLowerCase")
-    default String voteToLowerCase(com.bloxbean.cardano.yaci.core.model.governance.Vote vote) {
+    default String voteToLowerCase(Vote vote) {
         return vote != null ? vote.name().toLowerCase() : null;
     }
 
@@ -135,8 +138,7 @@ public interface BFDRepMapper {
         if (rawHash == null) return null;
         if (drepId == null) return "22" + rawHash;
         try {
-            com.bloxbean.cardano.client.crypto.Bech32.Bech32Data decoded =
-                    com.bloxbean.cardano.client.crypto.Bech32.decode(drepId);
+            Bech32.Bech32Data decoded = Bech32.decode(drepId);
             byte[] data = decoded.data;
             if (data.length == 29) {
                 // First byte is the CIP-129 header (0x22 or 0x23)

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -237,6 +237,8 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .drepId(r.get(DREP_REGISTRATION.DREP_ID))
                 .anchorUrl(r.get(DREP_REGISTRATION.ANCHOR_URL))
                 .anchorHash(r.get(DREP_REGISTRATION.ANCHOR_HASH))
+                .deposit(r.get(DREP_REGISTRATION.DEPOSIT) != null
+                        ? java.math.BigInteger.valueOf(r.get(DREP_REGISTRATION.DEPOSIT)) : null)
                 .slot(r.get(DREP_REGISTRATION.SLOT))
                 .epoch(r.get(DREP_REGISTRATION.EPOCH))
                 .build();

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -2,6 +2,9 @@ package com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.impl;
 
 import com.bloxbean.cardano.client.crypto.Bech32;
 import com.bloxbean.cardano.client.util.HexUtil;
+import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
+import com.bloxbean.cardano.yaci.core.model.governance.Vote;
+import com.bloxbean.cardano.yaci.core.model.governance.VoterType;
 import com.bloxbean.cardano.yaci.store.blockfrost.common.util.BlockfrostDialectUtil;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.BFGovernanceStorageReader;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.impl.model.BFDRepDelegator;
@@ -18,11 +21,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.jooq.JSON;
+import org.jooq.Record;
 import org.jooq.SortField;
 import org.jooq.SortOrder;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Component;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -195,7 +200,7 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
         }
     }
 
-    private BFProposal toProposalRow(org.jooq.Record r, int govActionLifetime) {
+    private BFProposal toProposalRow(Record r, int govActionLifetime) {
         String txHash = r.get(GOV_ACTION_PROPOSAL.TX_HASH);
         int idx = r.get(GOV_ACTION_PROPOSAL.IDX);
         Integer proposalEpoch = r.get(GOV_ACTION_PROPOSAL.EPOCH);
@@ -217,13 +222,13 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .build();
     }
 
-    private DRepRegistration toDRepRegistrationDomain(org.jooq.Record r) {
+    private DRepRegistration toDRepRegistrationDomain(Record r) {
         // Map the String type from DB to CertificateType enum
         String typeStr = r.get(DREP_REGISTRATION.TYPE);
-        com.bloxbean.cardano.yaci.core.model.certs.CertificateType certType = null;
+        CertificateType certType = null;
         if (typeStr != null) {
             try {
-                certType = com.bloxbean.cardano.yaci.core.model.certs.CertificateType.valueOf(typeStr);
+                certType = CertificateType.valueOf(typeStr);
             } catch (IllegalArgumentException e) {
                 log.debug("Unknown DRep registration type: {}", typeStr);
             }
@@ -238,23 +243,23 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .anchorUrl(r.get(DREP_REGISTRATION.ANCHOR_URL))
                 .anchorHash(r.get(DREP_REGISTRATION.ANCHOR_HASH))
                 .deposit(r.get(DREP_REGISTRATION.DEPOSIT) != null
-                        ? java.math.BigInteger.valueOf(r.get(DREP_REGISTRATION.DEPOSIT)) : null)
+                        ? BigInteger.valueOf(r.get(DREP_REGISTRATION.DEPOSIT)) : null)
                 .slot(r.get(DREP_REGISTRATION.SLOT))
                 .epoch(r.get(DREP_REGISTRATION.EPOCH))
                 .build();
     }
 
-    private VotingProcedure toVotingProcedureDomain(org.jooq.Record r) {
+    private VotingProcedure toVotingProcedureDomain(Record r) {
         String voterTypeStr = r.get(VOTING_PROCEDURE.VOTER_TYPE);
-        com.bloxbean.cardano.yaci.core.model.governance.VoterType voterType = null;
+        VoterType voterType = null;
         if (voterTypeStr != null) {
-            try { voterType = com.bloxbean.cardano.yaci.core.model.governance.VoterType.valueOf(voterTypeStr); }
+            try { voterType = VoterType.valueOf(voterTypeStr); }
             catch (IllegalArgumentException ignored) {}
         }
         String voteStr = r.get(VOTING_PROCEDURE.VOTE);
-        com.bloxbean.cardano.yaci.core.model.governance.Vote vote = null;
+        Vote vote = null;
         if (voteStr != null) {
-            try { vote = com.bloxbean.cardano.yaci.core.model.governance.Vote.valueOf(voteStr); }
+            try { vote = Vote.valueOf(voteStr); }
             catch (IllegalArgumentException ignored) {}
         }
         return VotingProcedure.builder()


### PR DESCRIPTION
## Summary

Adds the missing `deposit` field to the Blockfrost-compatible `GET /api/v1/blockfrost/governance/dreps/{drep_id}/updates` endpoint. The field is a lovelace string on `registered` rows and `null` on `deregistered` and `updated` rows, matching the live Blockfrost API.

Fixes #1062.

This PR targets `issue-864`, the source branch of #865.

## Problem

The Blockfrost `drep_updates` schema lists `deposit` as a required, nullable property:

> Deposit in Lovelaces paid at this registration. `null` on `deregistered` and `updated` rows.

The endpoint omitted the key entirely. Three separate gaps contributed:

1. `BFDRepUpdateDto` had no `deposit` property.
2. `BFGovernanceStorageReaderImpl.toDRepRegistrationDomain` did not copy the `drep_registration.deposit` column into the `DRepRegistration` domain object, so the value was dropped before mapping.
3. `BFDRepMapper.toUpdateDto` had no mapping for the field.

Passing the stored column straight through would not have been correct either. `DRepRegistrationProcessor` persists the certificate coin for both registration and deregistration:

```java
case REG_DREP_CERT   -> buildDRepRegistration(..., regDrepCert.getCoin(), ...);
case UNREG_DREP_CERT -> buildDRepRegistration(..., unregDrepCert.getCoin(), ...);
case UPDATE_DREP_CERT -> buildDRepRegistration(..., null, ...);
```

On a deregistration that coin is the refund rather than a deposit paid, so `UNREG_DREP_CERT` rows hold a non-null value where Blockfrost reports `null`. The deposit is therefore derived from the certificate type rather than read directly from the column.

## Changes

- Add the `deposit` property to `BFDRepUpdateDto`. No `NON_NULL` inclusion is applied, so the key is always present and serializes as `null` where required.
- Populate `deposit` in `BFGovernanceStorageReaderImpl.toDRepRegistrationDomain`, converting the jOOQ `BIGINT` column to the domain's `BigInteger`.
- Map the field in `BFDRepMapper` through a `registrationDeposit` helper that surfaces a value only for `REG_DREP_CERT`, so deregistration refunds and updates report `null`.

## Verification

### Blockfrost compatibility

Verified against the live Blockfrost API on mainnet and preprod. The full normalized JSON payloads matched:

| Network | DReps compared | Exact matches | Differences | Rows covered |
|---|---|---|---|---|
| Mainnet | 101 | 101 | 0 | 370 (139 registered, 73 deregistered, 158 updated) |
| Preprod | 40 | 40 | 0 | 80 (55 registered, 17 deregistered, 8 updated) |

All three actions are represented on both networks, including the `UNREG_DREP_CERT` rows that carry a stored refund amount and must report `null`.

The DRep reported in #1062 is byte-identical to the live Blockfrost response:

```json
[{"tx_hash":"07ad909f…64b2","cert_index":0,"action":"registered","deposit":"500000000"},
 {"tx_hash":"c981bd0c…2838","cert_index":0,"action":"deregistered","deposit":null},
 {"tx_hash":"51760d47…5de4","cert_index":0,"action":"registered","deposit":"500000000"}]
```

## Database impact

- No schema migration
- No data migration
- No database writes
