### PR TITLE
fix(blockfrost): deterministic ordering for epoch stakes, metadata by label, and scripts list endpoints

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/EpochStakeStorageReaderImpl.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/storage/impl/EpochStakeStorageReaderImpl.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yaci.store.adapot.storage.impl.repository.EpochStake
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -15,6 +16,11 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 public class EpochStakeStorageReaderImpl implements EpochStakeStorageReader {
+    //Paged reads need a stable order, otherwise rows can be dropped or repeated across pages.
+    //(epoch, address) is the primary key of epoch_stake, so address alone is unique within an
+    //epoch and the sort is served by the primary key index without an extra sort step.
+    private static final Sort ADDRESS_SORT = Sort.by(Sort.Direction.ASC, "address");
+
     private final EpochStakeRepository stakeSnapshotRepository;
     private final Mapper mapper;
 
@@ -36,7 +42,7 @@ public class EpochStakeStorageReaderImpl implements EpochStakeStorageReader {
 
     @Override
     public List<EpochStake> getAllActiveStakesByEpoch(Integer epoch, int page, int count) {
-        Pageable pageable = PageRequest.of(page, count);
+        Pageable pageable = PageRequest.of(page, count, ADDRESS_SORT);
 
         return stakeSnapshotRepository.getAllActiveStakesByEpoch(epoch, pageable)
                 .stream().map(mapper::toEpochStake).toList();
@@ -44,7 +50,7 @@ public class EpochStakeStorageReaderImpl implements EpochStakeStorageReader {
 
     @Override
     public List<EpochStake> getAllActiveStakesByEpochAndPool(Integer epoch, String poolId, int page, int count) {
-        Pageable pageable = PageRequest.of(page, count);
+        Pageable pageable = PageRequest.of(page, count, ADDRESS_SORT);
 
         return stakeSnapshotRepository.getAllByActiveEpochAndPool(epoch, poolId, pageable)
                 .stream().map(mapper::toEpochStake).toList();

--- a/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/storage/impl/BFScriptsStorageReaderImpl.java
+++ b/extensions/blockfrost/scripts/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/scripts/storage/impl/BFScriptsStorageReaderImpl.java
@@ -38,10 +38,15 @@ public class BFScriptsStorageReaderImpl implements BFScriptsStorageReader {
         SortField<?> sortField = order == Order.desc
                 ? SCRIPT.SLOT.desc().nullsLast()
                 : SCRIPT.SLOT.asc().nullsFirst();
+        // Many scripts share a slot, so slot alone is not a stable paging order. script_hash is the
+        // primary key, so it makes the order total and pages cannot drop or repeat rows.
+        SortField<?> tieBreaker = order == Order.desc
+                ? SCRIPT.SCRIPT_HASH.desc()
+                : SCRIPT.SCRIPT_HASH.asc();
 
         return dsl.select(SCRIPT.SCRIPT_HASH)
                 .from(SCRIPT)
-                .orderBy(sortField)
+                .orderBy(sortField, tieBreaker)
                 .limit(count)
                 .offset(offset)
                 .fetch(r -> new BFScriptListItem(r.get(SCRIPT.SCRIPT_HASH)));
@@ -65,6 +70,19 @@ public class BFScriptsStorageReaderImpl implements BFScriptsStorageReader {
         SortField<?> sortField = order == Order.desc
                 ? TRANSACTION_SCRIPTS.SLOT.desc().nullsLast()
                 : TRANSACTION_SCRIPTS.SLOT.asc().nullsLast();
+        // A slot holds many transactions and a transaction can hold several redeemers for the same
+        // script, so slot alone is not a stable paging order. tx_hash, redeemer_index and purpose
+        // identify the redeemer within the slot: a tx can carry the same redeemer_index under two
+        // purposes (for example Cert and Reward), which are distinct rows in the response.
+        List<SortField<?>> orderBy = order == Order.desc
+                ? List.of(sortField,
+                          TRANSACTION_SCRIPTS.TX_HASH.desc(),
+                          TRANSACTION_SCRIPTS.REDEEMER_INDEX.desc(),
+                          TRANSACTION_SCRIPTS.PURPOSE.desc())
+                : List.of(sortField,
+                          TRANSACTION_SCRIPTS.TX_HASH.asc(),
+                          TRANSACTION_SCRIPTS.REDEEMER_INDEX.asc(),
+                          TRANSACTION_SCRIPTS.PURPOSE.asc());
 
         // Fetch execution unit prices once for the entire page — more efficient than per-row
         ExecUnitPrices prices = fetchExecUnitPrices();
@@ -81,7 +99,7 @@ public class BFScriptsStorageReaderImpl implements BFScriptsStorageReader {
                 .from(TRANSACTION_SCRIPTS)
                 .where(TRANSACTION_SCRIPTS.SCRIPT_HASH.eq(scriptHash))
                 .and(TRANSACTION_SCRIPTS.PURPOSE.isNotNull())
-                .orderBy(sortField)
+                .orderBy(orderBy)
                 .limit(count)
                 .offset(offset)
                 .fetch(r -> {

--- a/stores/metadata/src/main/java/com/bloxbean/cardano/yaci/store/metadata/storage/impl/TxMetadataStorageReaderImpl.java
+++ b/stores/metadata/src/main/java/com/bloxbean/cardano/yaci/store/metadata/storage/impl/TxMetadataStorageReaderImpl.java
@@ -14,6 +14,11 @@ import java.util.List;
 
 @RequiredArgsConstructor
 public class TxMetadataStorageReaderImpl implements TxMetadataStorageReader {
+    //A slot holds many transactions, so slot alone is not a stable paging order and rows can be
+    //dropped or repeated across pages. txHash breaks the tie: a transaction carries at most one
+    //metadata entry per label, so (slot, txHash) identifies the row for a given label.
+    private static final String[] SORT_PROPERTIES = {"slot", "txHash"};
+
     private final TxMetadataLabelRepository txMetadataLabelReadRepository;
     private final MetadataMapper metadataMapper;
 
@@ -28,7 +33,7 @@ public class TxMetadataStorageReaderImpl implements TxMetadataStorageReader {
     @Override
     public List<TxMetadataLabel> findByLabel(String label, int page, int count) {
         Pageable sortedBySlot =
-                PageRequest.of(page, count, Sort.by("slot").descending());
+                PageRequest.of(page, count, Sort.by(SORT_PROPERTIES).descending());
 
         return txMetadataLabelReadRepository.findByLabel(label, sortedBySlot)
                 .stream()
@@ -39,8 +44,8 @@ public class TxMetadataStorageReaderImpl implements TxMetadataStorageReader {
     @Override
     public List<TxMetadataLabel> findByLabel(String label, int page, int count, Order order) {
         Sort sort = (order == Order.asc)
-                ? Sort.by("slot").ascending()
-                : Sort.by("slot").descending();
+                ? Sort.by(SORT_PROPERTIES).ascending()
+                : Sort.by(SORT_PROPERTIES).descending();
         Pageable pageable = PageRequest.of(page, count, sort);
 
         return txMetadataLabelReadRepository.findByLabel(label, pageable)


### PR DESCRIPTION
## Problem

Three paged read paths behind Blockfrost API endpoints have no total order:

| endpoint | ordering today |
|---|---|
| `/epochs/{n}/stakes`, `/epochs/{n}/stakes/{pool_id}` | no `ORDER BY` at all (unsorted `Pageable`) |
| `/metadata/txs/labels/{label}`, `/metadata/txs/labels/{label}/cbor` | `slot` only |
| `/scripts` | `slot` only |
| `/scripts/{script_hash}/redeemers` | `slot` only |

When the sort key is not unique, the order of rows inside a tie group is whatever the
executor happens to produce, and that can differ between two runs of the same query.
Two consequences:

1. Two identical calls can return different orders.
2. Pagination can drop and duplicate rows, because page N and page N+1 are separate
   queries whose tie groups may be broken differently.

The second one is reproducible on mainnet data today. Scripts `fda1b6b4..` and
`eb188aca..` share slot `39917515`. Paging `/scripts` with `count=4`:

```
page 1 (limit 4 offset 0)                page 2 (limit 4 offset 4)
39917226|cc788885..                      39917515|fda1b6b4..   <- repeated from page 1
39917226|4f590a3d..                      39917606|e265b741..
39917427|f3232d8f..                      39917752|7f356ce7..
39917515|fda1b6b4..                      39920450|7bd7bbd9..
```

`fda1b6b4..` is returned twice and `eb188aca..` is never returned. Reading the same
range as one page (`limit 8 offset 0`) contains both rows exactly once. No data changed
between the calls: the small `LIMIT` uses a top-N heapsort and the larger one sorts
differently, so the slot tie is broken the other way round.

## Change

Tie-breaks only. No refactoring, no change to `NULLS` handling on the existing sort
fields, no behaviour change other than the order becoming total.

| site | before | after |
|---|---|---|
| `EpochStakeStorageReaderImpl.getAllActiveStakesByEpoch` | `PageRequest.of(page, count)` | `PageRequest.of(page, count, ADDRESS_SORT)` |
| `EpochStakeStorageReaderImpl.getAllActiveStakesByEpochAndPool` | `PageRequest.of(page, count)` | `PageRequest.of(page, count, ADDRESS_SORT)` |
| `TxMetadataStorageReaderImpl.findByLabel` (both overloads) | `Sort.by("slot")` | `Sort.by("slot", "txHash")` |
| `BFScriptsStorageReaderImpl.getScripts` | `SCRIPT.SLOT` | `SCRIPT.SLOT`, `SCRIPT.SCRIPT_HASH` |
| `BFScriptsStorageReaderImpl.getScriptRedeemers` | `TRANSACTION_SCRIPTS.SLOT` | `+ TX_HASH`, `REDEEMER_INDEX`, `PURPOSE` |

Each tie-break follows the direction of the primary sort, so `?order=desc` stays
consistent.

Notes on the individual choices:

- **epoch stakes**: `address` is unique within an epoch because `(epoch, address)` is the
  primary key of `epoch_stake`, so the sort needs no sort node and is served straight
  from the primary key index. The sort is applied at the caller because the two
  `@Query` methods share it. `getAllActiveStakesByEpochAndPool(epoch, poolId)` pages
  through the same query in a loop accumulating every page, so it was the most exposed
  to the missing order.
- **metadata**: a transaction carries at most one metadata entry per label, so
  `(slot, txHash)` identifies the row for a given label.
- **script redeemers**: `purpose` is included because one transaction can carry the same
  `redeemer_index` under two purposes. On mainnet there are rows with an identical
  `(script_hash, slot, tx_hash, redeemer_index)` differing only in `purpose`
  (`Cert` and `Reward`), and those are distinct rows in the response.

## Ordering key for `/epochs/{n}/stakes`

This endpoint had no order at all, so there was no existing behaviour to preserve and a
key had to be chosen. I tried to derive the hosted Blockfrost key empirically first,
against `/epochs/647/stakes` on mainnet.

Hosted Blockfrost is self-consistent: `page=1&count=100` fetched twice returned identical
responses, and `count=50` pages 1+2 equal `count=100` page 1 (same for pages 3+4 against
page 2). `count=200` is rejected with HTTP 400, so 100 is the maximum page size.

But none of the exposed fields reproduces the order. Over the 200-row concatenation of
pages 1 and 2:

```
amount (int)                  asc=False  desc=False
stake_address (bech32 string) asc=False  desc=False
pool_id (bech32 string)       asc=False  desc=False
raw stake address bytes       asc=False  desc=True
(pool_id, stake_address)      asc=False
```

Raw address bytes descending holds inside a page, but not globally. Sampling pages
across the whole epoch:

```
page   first raw address     last raw address      descending within page
1      e1005155af58108ba8e7  e1004c4f047f69cad40e  True
2      e1004c4e38d9880d2162  e1004757a21920d5dd4e  True
50     e100ea94de04f0ce584e  e100e54eca6e9d2dbfd3  True
500    e1094d59bf0a63962f8c  e10948b7584d797a1464  True
5000   e160c00b0f572cc9630b  e160bab21e3ec2b66569  True
12000  e1e8fda4684d9d9a4bba  e1e8f90c0b3c50442e1f  True
13000  e1fc7c77ec7fe658bf86  e1fc770d3e4e886f3375  True
```

Every page is internally descending, and the run continues across the page 1 to page 2
boundary, so the runs are longer than one page. But the page starts rise with the page
number, and a globally descending key would have started page 1 at the maximum
(`e1ff..`) rather than at `e10051`. So the order is long descending runs by address
bytes with upward jumps between runs and an upward global drift, which is the shape of
an internal row identifier assigned during a chunked bulk load, not a value ordering.

**I could not identify the hosted ordering key, and no `ORDER BY` over the exposed
columns reproduces it.** So this PR picks `address` ascending as a deterministic
canonical order rather than claiming Blockfrost parity. If you would prefer a different
canonical key, it is a one line change. `address` was chosen because it is the only
candidate that needs no sort node, see the measurements below.

## Verification

No rebuild was available on the instance holding the data, so this was verified at the
SQL level by running the exact new `ORDER BY` clauses. Environment: mainnet yaci-store
instance, PostgreSQL, `epoch_stake` epoch 645 with 1,346,824 rows, `script` 152,364 rows,
`transaction_metadata` label `674` with 20,715,154 rows, `transaction_scripts` for
script `a65ca58a..` with 5,088,446 redeemers.

Each query was run twice at `count=50 offset=0` and compared, then page 1 plus page 2 at
`count=50` was compared against page 1 at `count=100`.

| query | repeat run identical | p1+p2 (n=50) == p1 (n=100) | distinct rows |
|---|---|---|---|
| epoch stakes, `order by address` | yes | yes | 100 of 100 |
| epoch stakes by pool, `order by address` | yes | yes | 100 of 100 |
| metadata by label, `slot desc, tx_hash desc` | yes | yes | 100 of 100 |
| metadata by label, `slot asc, tx_hash asc` | yes | yes | 100 of 100 |
| scripts, `slot asc nulls first, script_hash asc` | yes | yes | 100 of 100 |
| scripts, `slot desc nulls last, script_hash desc` | yes | yes | 100 of 100 |
| redeemers, four keys asc | yes | yes | 100 of 100 |
| redeemers, four keys desc | yes | yes | 100 of 100 |

Query plans, before and after, same session and warm cache, `limit 100 offset 0`:

| query | before | after |
|---|---|---|
| `/epochs/645/stakes` | Seq Scan, 0.060 ms | Index Scan on `epoch_stake_p645_pkey`, 0.085 ms |
| `/metadata/txs/labels/674` | Index Scan Backward on `idx_txn_metadata_slot`, 0.191 ms | same scan plus Incremental Sort, 0.237 ms |
| `/scripts` | Gather Merge, top-N heapsort, 35.403 ms | same plan shape, 35.013 ms |
| `/scripts/{h}/redeemers` | Index Scan on `idx_txn_scripts_slot`, 885.916 ms | same scan plus Incremental Sort, 869.708 ms |

The tie-breaks add an Incremental Sort over an already presorted leading key. No query
gained a full sort and no scan changed. For the deeper pages of `/epochs/{n}/stakes`,
`limit 100 offset 500000` on epoch 647 measured 198.777 ms with `order by address`
against 709.184 ms with `order by pool_id, address`, which is why `address` alone was
chosen over a composite key.

## Tests

There are no existing tests for `EpochStakeStorageReaderImpl`,
`TxMetadataStorageReaderImpl` or `BFScriptsStorageReaderImpl`, so nothing needed
updating. The three modules compile clean:

```
./gradlew :aggregates:adapot:compileJava :stores:metadata:compileJava \
          :extensions:blockfrost:blockfrost-scripts:compileJava
```

Happy to add regression tests if you would like them, for example asserting that
concatenated pages equal the equivalent single wider page against an in-memory or
Testcontainers fixture that seeds several rows sharing a slot. Let me know the style you
prefer and I will add them to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
