### PR TITLE
Fix(blockfrost): drep delegators performance

### DIFF
--- a/extensions/blockfrost/governance/build.gradle
+++ b/extensions/blockfrost/governance/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api project(":stores:governance")
     api project(":stores-api:governance-api")
     api project(":aggregates:governance-aggr")
+    api project(":aggregates:account")
     api project(":stores:utxo")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/extensions/blockfrost/governance/build.gradle
+++ b/extensions/blockfrost/governance/build.gradle
@@ -7,10 +7,15 @@ dependencies {
     api project(":stores-api:governance-api")
     api project(":aggregates:governance-aggr")
     api project(":aggregates:account")
+    api project(":aggregates:adapot")
+    api project(":stores:staking")
+    api project(":stores:transaction")
     api project(":stores:utxo")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.jooq:jooq'
+
+    testImplementation 'com.h2database:h2'
 }
 
 publishing {

--- a/extensions/blockfrost/governance/build.gradle
+++ b/extensions/blockfrost/governance/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.jooq:jooq'
 
-    testImplementation 'com.h2database:h2'
 }
 
 publishing {

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -2,7 +2,6 @@ package com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.impl;
 
 import com.bloxbean.cardano.client.crypto.Bech32;
 import com.bloxbean.cardano.client.util.HexUtil;
-import com.bloxbean.cardano.yaci.store.blockfrost.common.util.BlockfrostDialectUtil;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.BFGovernanceStorageReader;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.impl.model.BFDRepDelegator;
 import com.bloxbean.cardano.yaci.store.blockfrost.governance.storage.impl.model.BFDRep;
@@ -18,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.jooq.JSON;
+import org.jooq.Select;
 import org.jooq.SortField;
 import org.jooq.SortOrder;
 import org.jooq.impl.DSL;
@@ -30,12 +30,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.STAKE_ADDRESS_BALANCE;
 import static com.bloxbean.cardano.yaci.store.epoch.jooq.Tables.EPOCH_PARAM;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.*;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.GOV_ACTION_PROPOSAL_STATUS;
-import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.ADDRESS_UTXO;
-import static com.bloxbean.cardano.yaci.store.utxo.jooq.Tables.TX_INPUT;
 
 @Slf4j
 @Component
@@ -397,83 +396,49 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
 
     @Override
     public List<BFDRepDelegator> findDRepDelegators(String drepHex, int page, int count, Order order) {
-        if (BlockfrostDialectUtil.isPostgres(dsl)) {
-            // Subquery: latest delegation row per address using window function
-            var latestDelegation = dsl.select(
-                            DELEGATION_VOTE.ADDRESS,
-                            DELEGATION_VOTE.DREP_HASH,
-                            DSL.rowNumber()
-                                    .over(DSL.partitionBy(DELEGATION_VOTE.ADDRESS).orderBy(DELEGATION_VOTE.SLOT.desc()))
-                                    .as("rn"),
-                            DELEGATION_VOTE.SLOT.as("max_slot")
-                    )
-                    .from(DELEGATION_VOTE)
-                    .asTable("latest_del");
-
-            return dsl.select(
-                            latestDelegation.field("address", String.class).as("address"),
-                            DSL.coalesce(
-                                    DSL.sum(ADDRESS_UTXO.LOVELACE_AMOUNT).cast(Long.class),
-                                    DSL.inline(0L)
-                            ).as("amount")
-                    )
-                    .from(latestDelegation)
-                    .leftJoin(ADDRESS_UTXO)
-                    .on(ADDRESS_UTXO.OWNER_STAKE_ADDR.eq(latestDelegation.field("address", String.class)))
-                    .and(DSL.notExists(
-                            dsl.selectOne()
-                                    .from(TX_INPUT)
-                                    .where(TX_INPUT.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
-                                    .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
-                    ))
-                    .where(latestDelegation.field("rn", Integer.class).eq(1))
-                    .and(latestDelegation.field("drep_hash", String.class).eq(drepHex))
-                    .groupBy(latestDelegation.field("address", String.class), latestDelegation.field("max_slot", Long.class))
-                    .orderBy(latestDelegation.field("max_slot", Long.class).sort(order == Order.desc ? SortOrder.DESC : SortOrder.ASC))
-                    .limit(count)
-                    .offset(offset(page, count))
-                    .fetch()
-                    .map(r -> BFDRepDelegator.builder()
-                            .address(r.get("address", String.class))
-                            .amount(r.get("amount", Long.class))
-                            .build());
-        } else {
-            // SQLite/H2 fallback: fetch addresses whose latest delegation is to this DRep
-            List<String> addresses = dsl.select(DELEGATION_VOTE.ADDRESS)
-                    .from(DELEGATION_VOTE)
-                    .where(DELEGATION_VOTE.DREP_HASH.eq(drepHex))
-                    .and(DSL.notExists(
-                            dsl.selectOne()
-                                    .from(DELEGATION_VOTE.as("newer"))
-                                    .where(DELEGATION_VOTE.as("newer").field(DELEGATION_VOTE.ADDRESS).eq(DELEGATION_VOTE.ADDRESS))
-                                    .and(DELEGATION_VOTE.as("newer").field(DELEGATION_VOTE.SLOT).gt(DELEGATION_VOTE.SLOT))
-                    ))
-                    .orderBy(order == Order.desc ? DELEGATION_VOTE.SLOT.desc() : DELEGATION_VOTE.SLOT.asc())
-                    .limit(count)
-                    .offset(offset(page, count))
-                    .fetch(DELEGATION_VOTE.ADDRESS);
-            List<BFDRepDelegator> result = new ArrayList<>();
-            for (String address : addresses) {
-                Long sum = dsl.select(DSL.coalesce(
-                                DSL.sum(ADDRESS_UTXO.LOVELACE_AMOUNT).cast(Long.class),
-                                DSL.inline(0L)
-                        ).as("total"))
-                        .from(ADDRESS_UTXO)
-                        .where(ADDRESS_UTXO.OWNER_STAKE_ADDR.eq(address))
-                        .and(DSL.notExists(
-                                dsl.selectOne()
-                                        .from(TX_INPUT)
-                                        .where(TX_INPUT.TX_HASH.eq(ADDRESS_UTXO.TX_HASH))
-                                        .and(TX_INPUT.OUTPUT_INDEX.eq(ADDRESS_UTXO.OUTPUT_INDEX))
-                        ))
-                        .fetchOne(0, Long.class);
-                result.add(BFDRepDelegator.builder()
-                        .address(address)
-                        .amount(sum != null ? sum : 0L)
+        return buildDRepDelegatorsQuery(drepHex, page, count, order)
+                .fetch()
+                .map(r -> BFDRepDelegator.builder()
+                        .address(r.get("address", String.class))
+                        .amount(r.get("amount", Long.class))
                         .build());
-            }
-            return result;
-        }
+    }
+
+    Select<?> buildDRepDelegatorsQuery(String drepHex, int page, int count, Order order) {
+        SortOrder sortOrder = order == Order.desc ? SortOrder.DESC : SortOrder.ASC;
+        var newerDelegation = DELEGATION_VOTE.as("newer");
+        var pagedDelegators = dsl.select(
+                        DELEGATION_VOTE.ADDRESS.as("address"),
+                        DELEGATION_VOTE.SLOT.as("max_slot")
+                )
+                .from(DELEGATION_VOTE)
+                .where(DELEGATION_VOTE.DREP_HASH.eq(drepHex))
+                .and(DSL.notExists(
+                        dsl.selectOne()
+                                .from(newerDelegation)
+                                .where(newerDelegation.ADDRESS.eq(DELEGATION_VOTE.ADDRESS))
+                                .and(newerDelegation.SLOT.gt(DELEGATION_VOTE.SLOT))
+                ))
+                .orderBy(DELEGATION_VOTE.SLOT.sort(sortOrder))
+                .limit(count)
+                .offset(offset(page, count))
+                .asTable("paged_del");
+
+        var address = pagedDelegators.field("address", String.class);
+        var maxSlot = pagedDelegators.field("max_slot", Long.class);
+        var latestBalance = dsl.select(STAKE_ADDRESS_BALANCE.QUANTITY.cast(Long.class))
+                .from(STAKE_ADDRESS_BALANCE)
+                .where(STAKE_ADDRESS_BALANCE.ADDRESS.eq(address))
+                .orderBy(STAKE_ADDRESS_BALANCE.SLOT.desc())
+                .limit(1)
+                .asField();
+
+        return dsl.select(
+                        address.as("address"),
+                        DSL.coalesce(latestBalance, DSL.inline(0L)).as("amount")
+                )
+                .from(pagedDelegators)
+                .orderBy(maxSlot.sort(sortOrder));
     }
 
     @Override

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -30,10 +30,17 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.bloxbean.cardano.yaci.store.account.jooq.Tables.STAKE_ADDRESS_BALANCE;
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.ADAPOT_JOBS;
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.EPOCH_STAKE;
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.INSTANT_REWARD;
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.REWARD;
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.REWARD_REST;
 import static com.bloxbean.cardano.yaci.store.epoch.jooq.Tables.EPOCH_PARAM;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.*;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.GOV_ACTION_PROPOSAL_STATUS;
+import static com.bloxbean.cardano.yaci.store.staking.jooq.Tables.STAKE_REGISTRATION;
+import static com.bloxbean.cardano.yaci.store.transaction.jooq.Tables.WITHDRAWAL;
 
 @Slf4j
 @Component
@@ -394,49 +401,240 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
 
     @Override
     public List<BFDRepDelegator> findDRepDelegators(String drepHex, int page, int count, Order order) {
-        return buildDRepDelegatorsQuery(drepHex, page, count, order)
-                .fetch()
-                .map(r -> BFDRepDelegator.builder()
-                        .address(r.get("address", String.class))
-                        .amount(r.get("amount", Long.class))
-                        .build());
+        Integer snapshotEpoch = findLatestStakeSnapshotEpoch();
+        var delegators = buildDRepDelegatorsQuery(drepHex, page, count, order, snapshotEpoch).fetch();
+        if (delegators.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> checkpointAddresses = delegators.stream()
+                .filter(r -> r.get("checkpoint_amount", Long.class) != null)
+                .map(r -> r.get("address", String.class))
+                .toList();
+        List<String> addressesWithoutCheckpoint = delegators.stream()
+                .filter(r -> r.get("checkpoint_amount", Long.class) == null)
+                .map(r -> r.get("address", String.class))
+                .toList();
+
+        Map<String, Long> rewardChanges = new HashMap<>();
+        fetchRewardChanges(rewardChanges, checkpointAddresses, snapshotEpoch);
+        fetchRewardChanges(rewardChanges, addressesWithoutCheckpoint, null);
+
+        return delegators
+                .map(r -> {
+                    String address = r.get("address", String.class);
+                    long currentBalance = r.get("amount", Long.class);
+                    Long checkpointAmount = r.get("checkpoint_amount", Long.class);
+                    long snapshotBalance = Optional.ofNullable(r.get("snapshot_balance", Long.class)).orElse(0L);
+                    // epoch_stake stores controlled amount. Subtract its UTxO component to recover
+                    // the reward balance at the checkpoint, then apply only later reward changes.
+                    long checkpointReward = checkpointAmount == null ? 0L : checkpointAmount - snapshotBalance;
+                    long withdrawableReward = Math.max(
+                            checkpointReward + rewardChanges.getOrDefault(address, 0L),
+                            0L
+                    );
+                    return BFDRepDelegator.builder()
+                            .address(address)
+                            .amount(currentBalance + withdrawableReward)
+                            .build();
+                });
     }
 
-    Select<?> buildDRepDelegatorsQuery(String drepHex, int page, int count, Order order) {
+    private Integer findLatestStakeSnapshotEpoch() {
+        Integer completedJobEpoch = dsl.select(ADAPOT_JOBS.EPOCH)
+                .from(ADAPOT_JOBS)
+                .where(ADAPOT_JOBS.TYPE.eq("REWARD_CALC"))
+                .and(ADAPOT_JOBS.STATUS.eq("COMPLETED"))
+                .orderBy(ADAPOT_JOBS.EPOCH.desc())
+                .limit(1)
+                .fetchOne(ADAPOT_JOBS.EPOCH);
+        // Reward calculation for job epoch N materializes the epoch_stake snapshot for N - 1.
+        return completedJobEpoch == null ? null : completedJobEpoch - 1;
+    }
+
+    private void fetchRewardChanges(Map<String, Long> rewardChanges,
+                                    List<String> addresses,
+                                    Integer snapshotEpoch) {
+        if (addresses.isEmpty()) {
+            return;
+        }
+
+        buildRewardBalanceQuery(addresses, snapshotEpoch).fetch().forEach(r -> rewardChanges.put(
+                r.get("address", String.class),
+                r.get("amount", Long.class)
+        ));
+    }
+
+    Select<?> buildDRepDelegatorsQuery(String drepHex, int page, int count, Order order, Integer snapshotEpoch) {
         SortOrder sortOrder = order == Order.desc ? SortOrder.DESC : SortOrder.ASC;
         var newerDelegation = DELEGATION_VOTE.as("newer");
+        var newerStakeRegistration = STAKE_REGISTRATION.as("newer_stake_reg");
+
+        // Chain order includes transaction and certificate positions because multiple delegation
+        // certificates can share a slot. Resolve current delegators before pagination so balance
+        // lookups stay bounded to the requested page.
+        var newerInChainOrder = newerDelegation.SLOT.gt(DELEGATION_VOTE.SLOT)
+                .or(newerDelegation.SLOT.eq(DELEGATION_VOTE.SLOT)
+                        .and(newerDelegation.TX_INDEX.gt(DELEGATION_VOTE.TX_INDEX)))
+                .or(newerDelegation.SLOT.eq(DELEGATION_VOTE.SLOT)
+                        .and(newerDelegation.TX_INDEX.eq(DELEGATION_VOTE.TX_INDEX))
+                        .and(newerDelegation.CERT_INDEX.gt(DELEGATION_VOTE.CERT_INDEX)));
+        var newerStakeRegistrationInChainOrder = newerStakeRegistration.SLOT.gt(STAKE_REGISTRATION.SLOT)
+                .or(newerStakeRegistration.SLOT.eq(STAKE_REGISTRATION.SLOT)
+                        .and(newerStakeRegistration.TX_INDEX.gt(STAKE_REGISTRATION.TX_INDEX)))
+                .or(newerStakeRegistration.SLOT.eq(STAKE_REGISTRATION.SLOT)
+                        .and(newerStakeRegistration.TX_INDEX.eq(STAKE_REGISTRATION.TX_INDEX))
+                        .and(newerStakeRegistration.CERT_INDEX.gt(STAKE_REGISTRATION.CERT_INDEX)));
+        var delegationAtOrAfterCurrentRegistration = DELEGATION_VOTE.SLOT.gt(STAKE_REGISTRATION.SLOT)
+                .or(DELEGATION_VOTE.SLOT.eq(STAKE_REGISTRATION.SLOT)
+                        .and(DELEGATION_VOTE.TX_INDEX.gt(STAKE_REGISTRATION.TX_INDEX)))
+                .or(DELEGATION_VOTE.SLOT.eq(STAKE_REGISTRATION.SLOT)
+                        .and(DELEGATION_VOTE.TX_INDEX.eq(STAKE_REGISTRATION.TX_INDEX))
+                        .and(DELEGATION_VOTE.CERT_INDEX.ge(STAKE_REGISTRATION.CERT_INDEX)));
+
+        // Deregistration clears vote delegation. Require the latest stake-registration event to
+        // be a registration, and ignore a delegation left over from an earlier registration cycle.
+        var hasActiveRegistrationForDelegation = DSL.exists(
+                dsl.selectOne()
+                        .from(STAKE_REGISTRATION)
+                        .where(STAKE_REGISTRATION.ADDRESS.eq(DELEGATION_VOTE.ADDRESS))
+                        .and(STAKE_REGISTRATION.TYPE.eq("STAKE_REGISTRATION"))
+                        .and(delegationAtOrAfterCurrentRegistration)
+                        .andNotExists(
+                                dsl.selectOne()
+                                        .from(newerStakeRegistration)
+                                        .where(newerStakeRegistration.ADDRESS.eq(STAKE_REGISTRATION.ADDRESS))
+                                        .and(newerStakeRegistrationInChainOrder)
+                        )
+        );
         var pagedDelegators = dsl.select(
                         DELEGATION_VOTE.ADDRESS.as("address"),
-                        DELEGATION_VOTE.SLOT.as("max_slot")
+                        DELEGATION_VOTE.SLOT.as("max_slot"),
+                        DELEGATION_VOTE.TX_INDEX.as("max_tx_index"),
+                        DELEGATION_VOTE.CERT_INDEX.as("max_cert_index")
                 )
                 .from(DELEGATION_VOTE)
                 .where(DELEGATION_VOTE.DREP_HASH.eq(drepHex))
+                .and(hasActiveRegistrationForDelegation)
                 .and(DSL.notExists(
                         dsl.selectOne()
                                 .from(newerDelegation)
                                 .where(newerDelegation.ADDRESS.eq(DELEGATION_VOTE.ADDRESS))
-                                .and(newerDelegation.SLOT.gt(DELEGATION_VOTE.SLOT))
+                                .and(newerInChainOrder)
                 ))
-                .orderBy(DELEGATION_VOTE.SLOT.sort(sortOrder))
+                .orderBy(
+                        DELEGATION_VOTE.SLOT.sort(sortOrder),
+                        DELEGATION_VOTE.TX_INDEX.sort(sortOrder),
+                        DELEGATION_VOTE.CERT_INDEX.sort(sortOrder)
+                )
                 .limit(count)
                 .offset(offset(page, count))
                 .asTable("paged_del");
 
         var address = pagedDelegators.field("address", String.class);
         var maxSlot = pagedDelegators.field("max_slot", Long.class);
+        var maxTxIndex = pagedDelegators.field("max_tx_index", Integer.class);
+        var maxCertIndex = pagedDelegators.field("max_cert_index", Integer.class);
+
+        // Balance snapshots are keyed by address and slot, so this lookup can fetch the latest
+        // balance for each paged delegator without rebuilding it from historical UTxOs.
         var latestBalance = dsl.select(STAKE_ADDRESS_BALANCE.QUANTITY.cast(Long.class))
                 .from(STAKE_ADDRESS_BALANCE)
                 .where(STAKE_ADDRESS_BALANCE.ADDRESS.eq(address))
                 .orderBy(STAKE_ADDRESS_BALANCE.SLOT.desc())
                 .limit(1)
                 .asField();
+        var checkpointAmount = snapshotEpoch == null
+                ? DSL.val((Long) null)
+                : dsl.select(EPOCH_STAKE.AMOUNT.cast(Long.class))
+                .from(EPOCH_STAKE)
+                .where(EPOCH_STAKE.EPOCH.eq(snapshotEpoch))
+                .and(EPOCH_STAKE.ADDRESS.eq(address))
+                .asField();
+        var balanceAtSnapshot = snapshotEpoch == null
+                ? DSL.val((Long) null)
+                : dsl.select(STAKE_ADDRESS_BALANCE.QUANTITY.cast(Long.class))
+                .from(STAKE_ADDRESS_BALANCE)
+                .where(STAKE_ADDRESS_BALANCE.ADDRESS.eq(address))
+                .and(STAKE_ADDRESS_BALANCE.EPOCH.le(snapshotEpoch))
+                .orderBy(STAKE_ADDRESS_BALANCE.SLOT.desc())
+                .limit(1)
+                .asField();
 
         return dsl.select(
                         address.as("address"),
-                        DSL.coalesce(latestBalance, DSL.inline(0L)).as("amount")
+                        DSL.coalesce(latestBalance, DSL.inline(0L)).as("amount"),
+                        checkpointAmount.as("checkpoint_amount"),
+                        balanceAtSnapshot.as("snapshot_balance")
                 )
                 .from(pagedDelegators)
-                .orderBy(maxSlot.sort(sortOrder));
+                .orderBy(
+                        maxSlot.sort(sortOrder),
+                        maxTxIndex.sort(sortOrder),
+                        maxCertIndex.sort(sortOrder)
+                );
+    }
+
+    Select<?> buildRewardBalanceQuery(List<String> addresses, Integer snapshotEpoch) {
+        var rewardCondition = REWARD.ADDRESS.in(addresses);
+        var rewardRestCondition = REWARD_REST.ADDRESS.in(addresses);
+        var instantRewardCondition = INSTANT_REWARD.ADDRESS.in(addresses);
+        var withdrawalCondition = WITHDRAWAL.ADDRESS.in(addresses);
+
+        if (snapshotEpoch != null) {
+            // The static partition-key lower bound is essential: PostgreSQL can prune all reward
+            // partitions already represented by the epoch stake checkpoint.
+            // Regular pool rewards earned through snapshot epoch E are already in epoch_stake(E),
+            // including rewards that first become spendable in E + 1. Refunds are included only
+            // when spendable, so their cutoff remains E. Instant rewards use the same E + 1
+            // spendable boundary as the snapshot calculation.
+            rewardCondition = rewardCondition
+                    .and(REWARD.SPENDABLE_EPOCH.gt(snapshotEpoch))
+                    .and(REWARD.TYPE.eq("refund")
+                            .or(REWARD.TYPE.in("member", "leader")
+                                    .and(REWARD.EARNED_EPOCH.gt(snapshotEpoch)
+                                            .or(REWARD.SPENDABLE_EPOCH.gt(snapshotEpoch + 1)))));
+            rewardRestCondition = rewardRestCondition
+                    .and(REWARD_REST.SPENDABLE_EPOCH.gt(snapshotEpoch));
+            instantRewardCondition = instantRewardCondition
+                    .and(INSTANT_REWARD.SPENDABLE_EPOCH.gt(snapshotEpoch + 1));
+            withdrawalCondition = withdrawalCondition
+                    .and(WITHDRAWAL.EPOCH.gt(snapshotEpoch));
+        }
+
+        // Blockfrost's controlled amount includes unclaimed rewards. Aggregate changes for the
+        // whole page in one query; addresses without a checkpoint fall back to their full history.
+        var rewardChanges = dsl.select(
+                        REWARD.ADDRESS.as("address"),
+                        REWARD.AMOUNT.cast(Long.class).as("amount")
+                )
+                .from(REWARD)
+                .where(rewardCondition)
+                .unionAll(dsl.select(
+                                REWARD_REST.ADDRESS.as("address"),
+                                REWARD_REST.AMOUNT.cast(Long.class).as("amount")
+                        )
+                        .from(REWARD_REST)
+                        .where(rewardRestCondition))
+                .unionAll(dsl.select(
+                                INSTANT_REWARD.ADDRESS.as("address"),
+                                INSTANT_REWARD.AMOUNT.cast(Long.class).as("amount")
+                        )
+                        .from(INSTANT_REWARD)
+                        .where(instantRewardCondition))
+                .unionAll(dsl.select(
+                                WITHDRAWAL.ADDRESS.as("address"),
+                                WITHDRAWAL.AMOUNT.neg().cast(Long.class).as("amount")
+                        )
+                        .from(WITHDRAWAL)
+                        .where(withdrawalCondition))
+                .asTable("reward_changes");
+
+        var address = rewardChanges.field("address", String.class);
+        var amount = rewardChanges.field("amount", Long.class);
+        return dsl.select(address.as("address"), DSL.sum(amount).cast(Long.class).as("amount"))
+                .from(rewardChanges)
+                .groupBy(address);
     }
 
     @Override

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -482,6 +482,7 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
         SortOrder sortOrder = order == Order.desc ? SortOrder.DESC : SortOrder.ASC;
         var newerDelegation = DELEGATION_VOTE.as("newer");
         var newerStakeRegistration = STAKE_REGISTRATION.as("newer_stake_reg");
+        var newerDRepLifecycleEvent = DREP_REGISTRATION.as("newer_drep_lifecycle");
 
         // Chain order includes transaction and certificate positions because multiple delegation
         // certificates can share a slot. Resolve current delegators before pagination so balance
@@ -504,6 +505,18 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .or(DELEGATION_VOTE.SLOT.eq(STAKE_REGISTRATION.SLOT)
                         .and(DELEGATION_VOTE.TX_INDEX.eq(STAKE_REGISTRATION.TX_INDEX))
                         .and(DELEGATION_VOTE.CERT_INDEX.ge(STAKE_REGISTRATION.CERT_INDEX)));
+        var newerDRepLifecycleEventInChainOrder = newerDRepLifecycleEvent.SLOT.gt(DREP_REGISTRATION.SLOT)
+                .or(newerDRepLifecycleEvent.SLOT.eq(DREP_REGISTRATION.SLOT)
+                        .and(newerDRepLifecycleEvent.TX_INDEX.gt(DREP_REGISTRATION.TX_INDEX)))
+                .or(newerDRepLifecycleEvent.SLOT.eq(DREP_REGISTRATION.SLOT)
+                        .and(newerDRepLifecycleEvent.TX_INDEX.eq(DREP_REGISTRATION.TX_INDEX))
+                        .and(newerDRepLifecycleEvent.CERT_INDEX.gt(DREP_REGISTRATION.CERT_INDEX)));
+        var delegationAtOrAfterCurrentDRepRegistration = DELEGATION_VOTE.SLOT.gt(DREP_REGISTRATION.SLOT)
+                .or(DELEGATION_VOTE.SLOT.eq(DREP_REGISTRATION.SLOT)
+                        .and(DELEGATION_VOTE.TX_INDEX.gt(DREP_REGISTRATION.TX_INDEX)))
+                .or(DELEGATION_VOTE.SLOT.eq(DREP_REGISTRATION.SLOT)
+                        .and(DELEGATION_VOTE.TX_INDEX.eq(DREP_REGISTRATION.TX_INDEX))
+                        .and(DELEGATION_VOTE.CERT_INDEX.ge(DREP_REGISTRATION.CERT_INDEX)));
 
         // Deregistration clears vote delegation. Require the latest stake-registration event to
         // be a registration, and ignore a delegation left over from an earlier registration cycle.
@@ -520,6 +533,23 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                                         .and(newerStakeRegistrationInChainOrder)
                         )
         );
+        // Unregistering a DRep clears all delegations in ledger state. Updates do not start a new
+        // lifecycle, so only registration and unregistration certificates delimit the cycle.
+        // A later registration starts empty and requires stake accounts to delegate again.
+        var hasActiveDRepRegistrationForDelegation = DSL.exists(
+                dsl.selectOne()
+                        .from(DREP_REGISTRATION)
+                        .where(DREP_REGISTRATION.DREP_HASH.eq(drepHex))
+                        .and(DREP_REGISTRATION.TYPE.eq("REG_DREP_CERT"))
+                        .and(delegationAtOrAfterCurrentDRepRegistration)
+                        .andNotExists(
+                                dsl.selectOne()
+                                        .from(newerDRepLifecycleEvent)
+                                        .where(newerDRepLifecycleEvent.DREP_HASH.eq(DREP_REGISTRATION.DREP_HASH))
+                                        .and(newerDRepLifecycleEvent.TYPE.in("REG_DREP_CERT", "UNREG_DREP_CERT"))
+                                        .and(newerDRepLifecycleEventInChainOrder)
+                        )
+        );
         var pagedDelegators = dsl.select(
                         DELEGATION_VOTE.ADDRESS.as("address"),
                         DELEGATION_VOTE.SLOT.as("max_slot"),
@@ -529,6 +559,7 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .from(DELEGATION_VOTE)
                 .where(DELEGATION_VOTE.DREP_HASH.eq(drepHex))
                 .and(hasActiveRegistrationForDelegation)
+                .and(hasActiveDRepRegistrationForDelegation)
                 .and(DSL.notExists(
                         dsl.selectOne()
                                 .from(newerDelegation)

--- a/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
+++ b/extensions/blockfrost/governance/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/governance/storage/impl/BFGovernanceStorageReaderImpl.java
@@ -401,12 +401,18 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
 
     @Override
     public List<BFDRepDelegator> findDRepDelegators(String drepHex, int page, int count, Order order) {
+        // The latest completed AdaPot reward calculation provides a stable epoch_stake baseline.
+        // This lets the endpoint read only reward changes after that epoch instead of full history.
         Integer snapshotEpoch = findLatestStakeSnapshotEpoch();
+
+        // Resolve active delegators and pagination first, then load balance data only for this page.
         var delegators = buildDRepDelegatorsQuery(drepHex, page, count, order, snapshotEpoch).fetch();
         if (delegators.isEmpty()) {
             return List.of();
         }
 
+        // Addresses with an epoch_stake row can start from the checkpoint. Missing rows fall back
+        // to full reward history so an incomplete snapshot does not omit their reward balance.
         List<String> checkpointAddresses = delegators.stream()
                 .filter(r -> r.get("checkpoint_amount", Long.class) != null)
                 .map(r -> r.get("address", String.class))
@@ -416,6 +422,8 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
                 .map(r -> r.get("address", String.class))
                 .toList();
 
+        // Both calls are batched by address group and populate the same map: post-checkpoint
+        // changes for checkpointed addresses, and lifetime changes for fallback addresses.
         Map<String, Long> rewardChanges = new HashMap<>();
         fetchRewardChanges(rewardChanges, checkpointAddresses, snapshotEpoch);
         fetchRewardChanges(rewardChanges, addressesWithoutCheckpoint, null);
@@ -423,16 +431,21 @@ public class BFGovernanceStorageReaderImpl implements BFGovernanceStorageReader 
         return delegators
                 .map(r -> {
                     String address = r.get("address", String.class);
+                    // stake_address_balance supplies the current UTxO component.
                     long currentBalance = r.get("amount", Long.class);
                     Long checkpointAmount = r.get("checkpoint_amount", Long.class);
                     long snapshotBalance = Optional.ofNullable(r.get("snapshot_balance", Long.class)).orElse(0L);
                     // epoch_stake stores controlled amount. Subtract its UTxO component to recover
                     // the reward balance at the checkpoint, then apply only later reward changes.
+                    // For fallback addresses checkpointReward is zero and rewardChanges contains
+                    // their complete reward and withdrawal history.
                     long checkpointReward = checkpointAmount == null ? 0L : checkpointAmount - snapshotBalance;
+                    // Unclaimed rewards cannot be negative; withdrawals can reduce them only to zero.
                     long withdrawableReward = Math.max(
                             checkpointReward + rewardChanges.getOrDefault(address, 0L),
                             0L
                     );
+                    // Blockfrost amount is controlled stake: current UTxO plus unclaimed rewards.
                     return BFDRepDelegator.builder()
                             .address(address)
                             .amount(currentBalance + withdrawableReward)


### PR DESCRIPTION
## Summary

Optimizes the Blockfrost-compatible endpoint:

```http
GET /api/v1/blockfrost/governance/dreps/{drep_id}/delegators
```

The endpoint now resolves and paginates current delegators before loading balances, uses `stake_address_balance` instead of reconstructing UTxOs from full history, and calculates Blockfrost-compatible controlled amounts from an AdaPot checkpoint plus subsequent reward changes.

The change also aligns stake-address and DRep registration lifecycle handling with ledger behavior, including deregistration, re-registration, DRep unregistration, and DRep re-registration.

Closes #1081.

Related: #1067, #865.

## Problem

The previous implementation performed expensive work before pagination:

1. Rank the full `delegation_vote` history to resolve the latest delegation per address.
2. Join delegators to historical `address_utxo` rows.
3. Anti-join those outputs with `tx_input` to remove spent outputs.
4. Aggregate balances for all matching delegators.
5. Apply `LIMIT` and `OFFSET` only after the balance reconstruction.

On the mainnet database used for verification, `address_utxo` contained approximately 353 million rows and `tx_input` approximately 342 million rows. A request for only 100 delegators still read about 413,778 historical outputs, more than 99% of which were later discarded as spent.

The old implementation also had correctness gaps:

- Ordering only by `slot` could select the wrong certificate when several transactions or certificates shared a slot.
- Stake deregistration did not clear historical vote delegations from the result.
- Re-registering a stake address could incorrectly revive a delegation from its previous registration cycle.
- DRep unregistration and re-registration cycles were not considered.
- The returned `amount` represented only the current UTxO balance, while Blockfrost returns the controlled amount, including rewards not yet withdrawn.

## Changes

### Resolve and paginate current delegators first

- Select only delegations whose stake address is currently registered.
- Require the delegation to belong to the stake address's current registration cycle.
- Require the target DRep to be currently registered and the delegation to belong to its current registration cycle.
- Treat only `REG_DREP_CERT` and `UNREG_DREP_CERT` as DRep lifecycle boundaries; `UPDATE_DREP_CERT` does not start a new cycle.
- Resolve chain order with `(slot, tx_index, cert_index)`.
- Exclude a delegation when the same address has a newer delegation to any DRep.
- Apply ordering and pagination before any balance lookup, bounding the remaining work to at most the requested page size.

### Use current balance snapshots

The endpoint now reads the latest `stake_address_balance.quantity` for each paged delegator instead of rebuilding current UTxOs from `address_utxo` and `tx_input` history.

### Calculate the amount reported by Blockfrost

Blockfrost reports the delegator's controlled amount, not only the ADA currently held by its UTxOs:

```text
amount = current UTxO balance + rewards not yet withdrawn
```

Replaying the complete reward history for every address would make the endpoint slow. Instead, the endpoint starts from the latest completed AdaPot stake snapshot and applies only the changes that are not already represented by that snapshot.

If the latest completed `REWARD_CALC` job is for epoch `N`, AdaPot has materialized `epoch_stake` for epoch `E = N - 1`. For each delegator on the requested page, the calculation is:

1. Read `epoch_stake(E).amount`, which already contains the address's UTxO balance and rewards not yet withdrawn at the checkpoint.
2. Subtract the address's UTxO balance at `E` to recover the reward balance already included in the checkpoint.
3. Add rewards not represented by the checkpoint and subtract withdrawals made after it.
4. Add the reward balance remaining after withdrawals to the current UTxO balance.

```text
reward_at_checkpoint = epoch_stake(E).amount - utxo_balance_at_E

current_reward = max(
    reward_at_checkpoint
    + rewards_not_in_checkpoint
    - withdrawals_not_in_checkpoint,
    0
)

response.amount = current_utxo_balance + current_reward
```

For example:

```text
epoch_stake(E).amount       = 1,100 ADA
utxo_balance_at_E           = 1,000 ADA
reward_at_checkpoint        =   100 ADA
later rewards               =    20 ADA
later withdrawals           =    30 ADA
rewards not yet withdrawn   =    90 ADA
current UTxO balance        = 1,250 ADA
response.amount             = 1,340 ADA
```

If the address has no `epoch_stake(E)` row, the endpoint cannot use the checkpoint. It therefore calculates the reward balance from the address's complete reward, reward-rest, instant-reward, and withdrawal history. This fallback preserves correctness for addresses omitted from the snapshot, such as a still-active DRep delegator whose stake pool has retired.

<details>
<summary>Reward boundaries used after checkpoint E</summary>

The delta query mirrors the rules used to build `epoch_stake(E)` so that a reward is neither skipped nor counted twice:

| Change type | Included in the delta when |
|---|---|
| Member or leader reward | `spendable_epoch > E` and either `earned_epoch > E` or `spendable_epoch > E + 1` |
| Refund | `spendable_epoch > E` |
| Reward rest | `spendable_epoch > E` |
| Instant reward | `spendable_epoch > E + 1` |
| Withdrawal | `epoch > E`, subtracted from the reward balance |

The static `spendable_epoch` lower bounds also allow PostgreSQL to prune reward partitions that are already represented by the checkpoint.

</details>

### Module dependencies

The governance extension now declares direct dependencies on the account, AdaPot, staking, and transaction modules that own the tables used by the query. 

No database index, schema migration, or stored-data migration is required.

## Ledger lifecycle behavior

The implementation follows the Conway ledger behavior in which:

- Stake credential deregistration clears its vote delegation.
- Re-registering the stake credential does not restore a delegation from an earlier cycle.
- `ConwayUnRegDRep` clears delegations to that DRep.
- Re-registering the DRep starts with an empty delegation set; delegators must delegate again.
- Updating a registered DRep does not start a new lifecycle.

As a regression case, a retired DRep whose historical delegation rows previously selected two delegators now returns HTTP 200 with `[]`, matching Blockfrost.

## Performance verification

Verification used a local read-only deployment connected to the configured PostgreSQL mainnet database.

Request used for the corrected old-versus-new comparison:

```http
GET /api/v1/blockfrost/governance/dreps/drep1y29h2q6cst2pvkl2sqqvf5ljcy36uv7pmy482xnczddzgqshus24w/delegators?page=1&count=100&order=asc
```

| Implementation | Result | Latency |
|---|---|---:|
| Old `issue-864` implementation | Client timeout without response | >180,098.3 ms |
| Fixed branch, warm median | HTTP 200, 100 rows | 69.2 ms |
| Fixed branch, warm maximum | HTTP 200, 100 rows | 138.2 ms |
| Blockfrost during the corrected old-version run | HTTP 200, 100 rows | 830.7 ms |

The measured lower bound is more than 1,300 times faster than the old implementation for the same DRep, page, count, order, and mainnet database configuration.

Across six warm pagination/order cases, local medians ranged from 32 ms to 141 ms. Adam's original PostgreSQL measurements in #1067 were 1,711-2,270 ms, providing a separate environment-level baseline.

## Blockfrost comparison

At a synchronized chain tip, six combinations of `page`, `count`, and `order` matched Blockfrost exactly for delegator addresses and ordering.

The checkpoint calculation was also compared with a full-history calculation for 100 addresses:

```text
matched addresses: 100/100
max_abs_delta:      0
sum_abs_delta:      0
```

A later mainnet fallback-focused sample used checkpoint epoch `647`:

```text
active delegators:              79,418
addresses without checkpoint:    3,156
observed fallback rate:          3.9739%
```

For a DRep with 59 fallback addresses out of 115 local delegators, all 59 addresses were present on Blockfrost and all 59 amounts matched exactly. One example without `epoch_stake(647)` produced `4152` lovelace from both local Yaci Store and Blockfrost.

## Follow-up issues

The fallback-focused comparison identified two issues that are not caused by the reward-checkpoint calculation and should be investigated separately:

- **AdaPot active-stake/reward parity:** For all 22 checkpoint-backed addresses whose amounts differed, the checkpoint result matched Yaci Store's full-history calculation exactly. The entire `12,148` lovelace difference came from member rewards earned in epoch `646`. Yaci Store's total active stake for that epoch was `156,993,730,649` lovelace higher than Blockfrost's, which produced slightly higher pool and member rewards. A follow-up should determine why the AdaPot `epoch_stake` snapshot begins to diverge at epoch `646`; changing the DRep checkpoint query would only hide the upstream data difference.
- **Conway bootstrap delegation lifecycle:** The additional Blockfrost delegator delegated to the DRep immediately before that DRep's registration certificate in the same transaction. The Conway ledger permits this ordering during the bootstrap phase, but the current query requires the delegation certificate to occur at or after the DRep registration certificate. A follow-up should use the latest DRep unregistration as the delegation-cycle boundary, while still requiring the DRep's current lifecycle state to be registered, so re-registration cannot revive delegations cleared by an earlier unregistration.

These findings do not change the performance result or the verified checkpoint-versus-full-history parity. They limit claims of full Blockfrost result parity until the upstream AdaPot snapshot difference and the bootstrap-era lifecycle edge case are resolved.

## Verification

The following commands completed successfully with Java 21:

```bash
./gradlew :extensions:blockfrost:blockfrost-governance:test
./gradlew :applications:all:bootJar
```

Focused storage tests cover pagination, full chain ordering, redelegation, stake registration cycles, DRep registration cycles, reward checkpoint boundaries, full-history fallback, and negative reward clamping. The focused test source is intentionally not included in this PR yet; it remains outside the committed diff for separate review.

At the current remote head (`3e77a7bb1`), both SonarCloud checks pass. No separate GitHub build/test check is currently reported for this draft PR.

## Known trade-offs

- Full-history fallback favors correctness over latency. It represented approximately 3.97% of active delegators in the measured mainnet snapshot, but can be concentrated within individual DReps. A page containing 59 fallback addresses took approximately 7.06 seconds on its first local request.
- The response is assembled from multiple read statements without a shared repeatable-read snapshot. Consolidating the reads or adding a common transaction snapshot is outside this PR's current scope.
- Focused test source is not yet part of the PR, although it was executed locally.
