### PR TITLE
fix: make AdaPot epoch transition rollback-safe

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobManager.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobManager.java
@@ -6,12 +6,19 @@ import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
 import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
 import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
 import com.bloxbean.cardano.yaci.store.core.annotation.ReadOnly;
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Manages and processes AdaPot jobs, specifically related to reward calculations.
@@ -23,11 +30,18 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Slf4j
 public class AdaPotJobManager {
     private final BlockingQueue<AdaPotJob> jobQueue = new LinkedBlockingQueue<>();
+    private final AtomicReference<ActiveJob> activeJob = new AtomicReference<>();
 
     private final AdaPotJobStorage adaPotJobStorage;
     private final AdaPotJobProcessor adaPotJobProcessor;
 
+    @Autowired
     public AdaPotJobManager(AdaPotJobStorage adaPotJobStorage, AdaPotJobProcessor adaPotJobProcessor) {
+        this(adaPotJobStorage, adaPotJobProcessor, true);
+    }
+
+    AdaPotJobManager(AdaPotJobStorage adaPotJobStorage, AdaPotJobProcessor adaPotJobProcessor,
+                     boolean startProcessor) {
         this.adaPotJobStorage = adaPotJobStorage;
         this.adaPotJobProcessor = adaPotJobProcessor;
 
@@ -36,8 +50,10 @@ public class AdaPotJobManager {
         resetStartedJobs();
         loadPendingJobs();
 
-        // Start a virtual thread for job processing
-        Thread.startVirtualThread(this::processJobs);
+        if (startProcessor) {
+            // Start a virtual thread for job processing
+            Thread.startVirtualThread(this::processJobs);
+        }
     }
 
     // Reset jobs from STARTED to NOT_STARTED on restart
@@ -62,10 +78,52 @@ public class AdaPotJobManager {
      * @param slot  slot number
      */
     public void triggerRewardCalcJob(int epoch, long slot, long block) {
-        AdaPotJob job = new AdaPotJob(epoch, slot, block, AdaPotJobType.REWARD_CALC, AdaPotJobStatus.NOT_STARTED, 0L, 0L, 0L, 0L, 0L,
-                AdaPotJobExtraInfo.builder().drepExpiryCalcTime(0L).govActionStatusCalcTime(0L).build(), null);
+        triggerRewardCalcJob(epoch, slot, block, null);
+    }
+
+    public void triggerRewardCalcJob(int epoch, long slot, long block, String blockHash) {
+        AdaPotJob job = AdaPotJob.builder()
+                .epoch(epoch)
+                .slot(slot)
+                .block(block)
+                .blockHash(blockHash)
+                .type(AdaPotJobType.REWARD_CALC)
+                .status(AdaPotJobStatus.NOT_STARTED)
+                .totalTime(0L)
+                .rewardCalcTime(0L)
+                .updateRewardTime(0L)
+                .stakeSnapshotTime(0L)
+                .drepDistrSnapshotTime(0L)
+                .extraInfo(AdaPotJobExtraInfo.builder()
+                        .drepExpiryCalcTime(0L)
+                        .govActionStatusCalcTime(0L)
+                        .build())
+                .build();
         adaPotJobStorage.save(job);
         jobQueue.add(job);
+    }
+
+    @EventListener
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public void handleRollback(RollbackEvent rollbackEvent) {
+        long rollbackSlot = rollbackEvent.getRollbackTo().getSlot();
+
+        jobQueue.removeIf(job -> {
+            if (job.getSlot() != null && job.getSlot() > rollbackSlot) {
+                log.info("Removed queued AdaPot job for epoch {} at slot {} after rollback to slot {}",
+                        job.getEpoch(), job.getSlot(), rollbackSlot);
+                return true;
+            }
+            return false;
+        });
+
+        ActiveJob runningJob = activeJob.get();
+        if (runningJob != null && runningJob.job().getSlot() != null
+                && runningJob.job().getSlot() > rollbackSlot) {
+            runningJob.cancel();
+            log.info("Cancelled running AdaPot job for epoch {} at slot {} after rollback to slot {}",
+                    runningJob.job().getEpoch(), runningJob.job().getSlot(), rollbackSlot);
+        }
     }
 
     private void processJobs() {
@@ -77,22 +135,59 @@ public class AdaPotJobManager {
                 if (job == null)
                     continue;
 
+                ActiveJob runningJob = activateJob(job);
                 try {
-                    Thread.sleep(5000);
-                } catch (InterruptedException e) {
-                    log.error("Error in thread.sleep", e);
-                }
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                        log.error("Error in thread.sleep", e);
+                    }
 
-                if (job != null) {
-                    boolean status = adaPotJobProcessor.processJob(job);
+                    boolean status;
+                    status = adaPotJobProcessor.processJob(job, runningJob::isCancelled);
                     if (!status) {
                         log.error("Reward calculation failed for epoch : " + job.getEpoch());
                         return;
                     }
+                } finally {
+                    activeJob.compareAndSet(runningJob, null);
                 }
             } catch (Exception e) {
                 log.error("Error processing reward calc job", e);
             }
+        }
+    }
+
+    int queuedJobCount() {
+        return jobQueue.size();
+    }
+
+    boolean isCancelled(AdaPotJob job) {
+        ActiveJob runningJob = activeJob.get();
+        return runningJob != null
+                && runningJob.key().equals(JobKey.from(job))
+                && runningJob.isCancelled();
+    }
+
+    private ActiveJob activateJob(AdaPotJob job) {
+        ActiveJob runningJob = new ActiveJob(job, JobKey.from(job), new AtomicBoolean(false));
+        activeJob.set(runningJob);
+        return runningJob;
+    }
+
+    private record JobKey(Integer epoch, Long slot, Long block, String blockHash) {
+        private static JobKey from(AdaPotJob job) {
+            return new JobKey(job.getEpoch(), job.getSlot(), job.getBlock(), job.getBlockHash());
+        }
+    }
+
+    private record ActiveJob(AdaPotJob job, JobKey key, AtomicBoolean cancelled) {
+        private void cancel() {
+            cancelled.set(true);
+        }
+
+        private boolean isCancelled() {
+            return cancelled.get();
         }
     }
 }

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobProcessor.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobProcessor.java
@@ -34,6 +34,8 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 @Component
@@ -55,9 +57,21 @@ public class AdaPotJobProcessor {
     private final DSLContext dsl;
 
     public boolean processJob(AdaPotJob job) throws InterruptedException {
-        // Set job status to STARTED and update in the database
-        job.setStatus(AdaPotJobStatus.STARTED);
-        adaPotJobStorage.save(job);
+        return processJob(job, () -> false);
+    }
+
+    public boolean processJob(AdaPotJob job, BooleanSupplier cancelled) throws InterruptedException {
+        try {
+            ensureCurrentJob(job, cancelled);
+
+            // Set job status to STARTED and update in the database
+            job.setStatus(AdaPotJobStatus.STARTED);
+            adaPotJobStorage.save(job);
+        } catch (StaleAdaPotJobException e) {
+            log.info("Skipping stale AdaPot job for epoch {} at slot {}: {}",
+                    job.getEpoch(), job.getSlot(), e.getMessage());
+            return true;
+        }
 
         int retryCount = 0;
 
@@ -71,10 +85,12 @@ public class AdaPotJobProcessor {
                 var start = Instant.now();
 
                 //Fire pre-adapot job processing event
+                ensureCurrentJob(job, cancelled);
                 var preAdaPotJobProcessingEvent = new PreAdaPotJobProcessingEvent(job.getEpoch(), job.getSlot(), job.getBlock());
                 publisher.publishEvent(preAdaPotJobProcessingEvent);
 
                 //create AdaPot entry for the epoch
+                ensureCurrentJob(job, cancelled);
                 adaPotService.createAdaPot(job.getEpoch(), job.getSlot());
 
                 //Update Fee pot
@@ -82,6 +98,7 @@ public class AdaPotJobProcessor {
                 if (totalFeeInEpoch == null) totalFeeInEpoch = BigInteger.ZERO;
                 log.info("Total fee in epoch {} : {}", job.getEpoch() - 1, totalFeeInEpoch);
                 //Update total fee in the epoch
+                ensureCurrentJob(job, cancelled);
                 adaPotService.updateEpochFee(job.getEpoch(), totalFeeInEpoch);
                 var end = Instant.now();
                 log.info("Fee snapshot time in millis : {}, epoch: {}", end.toEpochMilli() - start.toEpochMilli(), job.getEpoch());
@@ -89,13 +106,15 @@ public class AdaPotJobProcessor {
                 //Update deposit stake pot
                 start = Instant.now();
                 var deposits = depositSnapshotService.getNetStakeDepositInEpoch(job.getEpoch() - 1);
+                ensureCurrentJob(job, cancelled);
                 adaPotService.updateAdaPotDeposit(job.getEpoch(), deposits);
                 end = Instant.now();
                 log.info("Deposit snapshot time in millis : {}, epoch: {}", end.toEpochMilli() - start.toEpochMilli(), job.getEpoch());
 
                 //Calculate rewards
                 start = Instant.now();
-                Either<String, Boolean> result = calculateRewards(job);
+                ensureCurrentJob(job, cancelled);
+                Either<String, Boolean> result = calculateRewards(job, cancelled);
                 end = Instant.now();
                 job.setTotalTime(end.toEpochMilli() - start.toEpochMilli());
                 log.info("Reward calculation time in millis : {}, epoch: {}", end.toEpochMilli() - start.toEpochMilli(), job.getEpoch());
@@ -114,11 +133,13 @@ public class AdaPotJobProcessor {
 
 
                 if (result.isRight()) {
+                    ensureCurrentJob(job, cancelled);
                     job.setStatus(AdaPotJobStatus.COMPLETED);
                     job.setErrorMessage(null);
                     adaPotJobStorage.save(job);
                     return true;
                 } else {
+                    ensureCurrentJob(job, cancelled);
                     job.setErrorMessage("Reward calculation failed : " + result.getLeft());
                     adaPotJobStorage.save(job);
                     //TODO -- Retry logic
@@ -127,6 +148,7 @@ public class AdaPotJobProcessor {
 
                     if (retryCount > 3) {
                         log.error("Reward calculation failed for epoch " + job.getEpoch() + ", retry count exceeded. Marking as failed");
+                        ensureCurrentJob(job, cancelled);
                         job.setErrorMessage("Reward calculation failed. Retry count exceeded : " + result.getLeft());
                         adaPotJobStorage.save(job);
                         return false;
@@ -135,15 +157,26 @@ public class AdaPotJobProcessor {
                     Thread.sleep(5000);
                 }
             }
+        } catch (StaleAdaPotJobException e) {
+            log.info("Stopped stale AdaPot job for epoch {} at slot {}: {}",
+                    job.getEpoch(), job.getSlot(), e.getMessage());
+            return true;
         } catch (Exception e) {
             log.error("Adapot job processing failed", e);
+            try {
+                ensureCurrentJob(job, cancelled);
+            } catch (StaleAdaPotJobException staleJobException) {
+                log.info("Not saving failure state for stale or cancelled AdaPot job for epoch {} at slot {}",
+                        job.getEpoch(), job.getSlot());
+                return true;
+            }
             job.setErrorMessage("Reward calculation failed due to unknown exception : " + e.getMessage());
             adaPotJobStorage.save(job);
             return false;
         }
     }
 
-    private Either<String, Boolean> calculateRewards(AdaPotJob job) {
+    private Either<String, Boolean> calculateRewards(AdaPotJob job, BooleanSupplier cancelled) {
         try {
             long nonByronEpoch = eraService.getFirstNonByronEpoch().orElse(0);
 
@@ -195,6 +228,7 @@ public class AdaPotJobProcessor {
 
             //update rewards
             start = Instant.now();
+            ensureCurrentJob(job, cancelled);
             // Ensure partition exists for PostgreSQL (other databases use regular tables)
             if (dsl.dialect().family() == SQLDialect.POSTGRES) {
                 partitionManager.ensureRewardPartition(epoch);
@@ -205,12 +239,15 @@ public class AdaPotJobProcessor {
 
             //Now take snapshot
             start = Instant.now();
+            ensureCurrentJob(job, cancelled);
             stakeSnapshotService.takeStakeSnapshot(epoch - 1);
             end = Instant.now();
             job.setStakeSnapshotTime(end.toEpochMilli() - start.toEpochMilli());
 
+            ensureCurrentJob(job, cancelled);
             publisher.publishEvent(new StakeSnapshotTakenEvent(epoch - 1, job.getSlot()));
 
+            ensureCurrentJob(job, cancelled);
             adaPotJobStorage.getJobByTypeAndEpoch(AdaPotJobType.REWARD_CALC, epoch)
                     .ifPresent(adaPotJob -> {
                         job.setDrepDistrSnapshotTime(adaPotJob.getDrepDistrSnapshotTime());
@@ -218,9 +255,32 @@ public class AdaPotJobProcessor {
                     });
 
             return Either.right(true);
+        } catch (StaleAdaPotJobException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error calculating rewards for epoch : " + job.getEpoch(), e);
             return Either.left(e.getMessage());
+        }
+    }
+
+    private void ensureCurrentJob(AdaPotJob job, BooleanSupplier cancelled) {
+        if (cancelled.getAsBoolean()) {
+            throw new StaleAdaPotJobException("job was cancelled by rollback");
+        }
+
+        var currentJob = adaPotJobStorage.getJobByTypeAndEpoch(job.getType(), job.getEpoch())
+                .orElseThrow(() -> new StaleAdaPotJobException("job no longer exists"));
+
+        if (!Objects.equals(currentJob.getSlot(), job.getSlot())
+                || !Objects.equals(currentJob.getBlock(), job.getBlock())
+                || !Objects.equals(currentJob.getBlockHash(), job.getBlockHash())) {
+            throw new StaleAdaPotJobException("job was replaced by a different transition block");
+        }
+    }
+
+    private static class StaleAdaPotJobException extends RuntimeException {
+        private StaleAdaPotJobException(String message) {
+            super(message);
         }
     }
 

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/domain/AdaPotJob.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/domain/AdaPotJob.java
@@ -18,6 +18,7 @@ public class AdaPotJob {
     private Integer epoch;
     private Long slot;
     private Long block;
+    private String blockHash;
     private AdaPotJobType type;
     private AdaPotJobStatus status;
     private Long totalTime;

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/storage/impl/AdaPotJobEntity.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/job/storage/impl/AdaPotJobEntity.java
@@ -20,6 +20,9 @@ public class AdaPotJobEntity {
     @Column(name = "block")
     private Long block;
 
+    @Column(name = "block_hash")
+    private String blockHash;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private AdaPotJobType type;
@@ -74,6 +77,14 @@ public class AdaPotJobEntity {
 
     public void setBlock(Long block) {
         this.block = block;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
     }
 
     public AdaPotJobType getType() {

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/AdaPotProcessor.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/AdaPotProcessor.java
@@ -54,7 +54,10 @@ public class AdaPotProcessor {
 
         //Calculate epoch rewards
         Integer epoch = epochTransitionCommitEvent.getEpoch();
-        adaPotJobManager.triggerRewardCalcJob(epoch, epochTransitionCommitEvent.getMetadata().getSlot(), epochTransitionCommitEvent.getMetadata().getBlock());
+        adaPotJobManager.triggerRewardCalcJob(epoch,
+                epochTransitionCommitEvent.getMetadata().getSlot(),
+                epochTransitionCommitEvent.getMetadata().getBlock(),
+                epochTransitionCommitEvent.getMetadata().getBlockHash());
     }
 
     @EventListener

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/StakeSnapshotService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/StakeSnapshotService.java
@@ -172,6 +172,7 @@ public class StakeSnapshotService {
                                  SELECT
                                      pool_id,
                                      status,
+                                     retire_epoch,
                                      registration_slot,
                                      slot,
                                      ROW_NUMBER() OVER (
@@ -264,7 +265,10 @@ public class StakeSnapshotService {
                             d.rn = 1
                     and not exists(
                                     select 1 from ss_pool_status p
-                                    where d.pool_id = p.pool_id and p.rn = 1 and (p.status = 'RETIRED' or d.slot < p.registration_slot)
+                                    where d.pool_id = p.pool_id and p.rn = 1
+                                      and (p.status = 'RETIRED'
+                                           or (p.status = 'RETIRING' and p.retire_epoch <= :epoch)
+                                           or d.slot < p.registration_slot)
                             )
                             AND sd.address IS NULL;
                 """;

--- a/aggregates/adapot/src/main/resources/db/store/h2/V0_1300_5__add_block_hash_column.sql
+++ b/aggregates/adapot/src/main/resources/db/store/h2/V0_1300_5__add_block_hash_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE adapot_jobs
+    ADD COLUMN block_hash varchar(64);

--- a/aggregates/adapot/src/main/resources/db/store/mysql/V0_1300_5__add_block_hash_column.sql
+++ b/aggregates/adapot/src/main/resources/db/store/mysql/V0_1300_5__add_block_hash_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE adapot_jobs
+    ADD COLUMN block_hash varchar(64);

--- a/aggregates/adapot/src/main/resources/db/store/postgresql/V0_1300_5__add_block_hash_column.sql
+++ b/aggregates/adapot/src/main/resources/db/store/postgresql/V0_1300_5__add_block_hash_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE adapot_jobs
+    ADD COLUMN block_hash varchar(64);

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobManagerTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobManagerTest.java
@@ -1,0 +1,136 @@
+package com.bloxbean.cardano.yaci.store.adapot.job;
+
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJob;
+import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
+import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AdaPotJobManagerTest {
+
+    @Test
+    void shouldRemoveQueuedJobCreatedAfterRollbackPoint() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+
+        manager.triggerRewardCalcJob(644, 192844802L, 13695759L);
+        assertThat(manager.queuedJobCount()).isOne();
+
+        manager.handleRollback(RollbackEvent.builder()
+                .rollbackTo(new Point(192844727L, "rollback-hash"))
+                .build());
+
+        assertThat(manager.queuedJobCount()).isZero();
+    }
+
+    @Test
+    void shouldKeepQueuedJobAtOrBeforeRollbackPoint() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+
+        manager.triggerRewardCalcJob(644, 192844727L, 13695758L);
+        manager.handleRollback(RollbackEvent.builder()
+                .rollbackTo(new Point(192844727L, "rollback-hash"))
+                .build());
+
+        assertThat(manager.queuedJobCount()).isOne();
+    }
+
+    @Test
+    void shouldMarkRunningJobAsCancelledAfterRollback() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+        var runningJob = AdaPotJob.builder()
+                .epoch(644)
+                .slot(192844802L)
+                .block(13695759L)
+                .blockHash("orphan-hash")
+                .build();
+        ReflectionTestUtils.invokeMethod(manager, "activateJob", runningJob);
+
+        manager.handleRollback(RollbackEvent.builder()
+                .rollbackTo(new Point(192844727L, "rollback-hash"))
+                .build());
+
+        assertThat(manager.isCancelled(runningJob)).isTrue();
+    }
+
+    @Test
+    void shouldUseBlockHashToDistinguishJobsAtSameSlotAndBlock() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+        var orphanJob = AdaPotJob.builder()
+                .epoch(644)
+                .slot(192844802L)
+                .block(13695759L)
+                .blockHash("orphan-hash")
+                .build();
+        var canonicalJob = AdaPotJob.builder()
+                .epoch(644)
+                .slot(192844802L)
+                .block(13695759L)
+                .blockHash("canonical-hash")
+                .build();
+        ReflectionTestUtils.invokeMethod(manager, "activateJob", orphanJob);
+
+        manager.handleRollback(RollbackEvent.builder()
+                .rollbackTo(new Point(192844727L, "rollback-hash"))
+                .build());
+
+        assertThat(manager.isCancelled(orphanJob)).isTrue();
+        assertThat(manager.isCancelled(canonicalJob)).isFalse();
+    }
+
+    @Test
+    void shouldNotCarryCancellationToAReplayedIdenticalJob() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+        var firstExecution = AdaPotJob.builder()
+                .epoch(644)
+                .slot(192844802L)
+                .block(13695759L)
+                .blockHash("same-hash")
+                .build();
+        var replayedExecution = AdaPotJob.builder()
+                .epoch(644)
+                .slot(192844802L)
+                .block(13695759L)
+                .blockHash("same-hash")
+                .build();
+        ReflectionTestUtils.invokeMethod(manager, "activateJob", firstExecution);
+        manager.handleRollback(RollbackEvent.builder()
+                .rollbackTo(new Point(192844727L, "rollback-hash"))
+                .build());
+        assertThat(manager.isCancelled(firstExecution)).isTrue();
+
+        ReflectionTestUtils.invokeMethod(manager, "activateJob", replayedExecution);
+
+        assertThat(manager.isCancelled(replayedExecution)).isFalse();
+    }
+
+    @Test
+    void shouldPersistTransitionBlockHashWhenJobIsTriggered() {
+        AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+        when(storage.getJobsByTypeAndStatus(any(), any())).thenReturn(List.of());
+        var manager = new AdaPotJobManager(storage, mock(AdaPotJobProcessor.class), false);
+
+        manager.triggerRewardCalcJob(644, 192844802L, 13695759L, "transition-hash");
+
+        verify(storage).save(org.mockito.ArgumentMatchers.argThat(job ->
+                "transition-hash".equals(job.getBlockHash())));
+    }
+}

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobProcessorTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/job/AdaPotJobProcessorTest.java
@@ -1,0 +1,113 @@
+package com.bloxbean.cardano.yaci.store.adapot.job;
+
+import com.bloxbean.cardano.yaci.store.adapot.AdaPotProperties;
+import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJob;
+import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobStatus;
+import com.bloxbean.cardano.yaci.store.adapot.job.domain.AdaPotJobType;
+import com.bloxbean.cardano.yaci.store.adapot.job.storage.AdaPotJobStorage;
+import com.bloxbean.cardano.yaci.store.adapot.service.AdaPotService;
+import com.bloxbean.cardano.yaci.store.adapot.service.EpochRewardCalculationService;
+import com.bloxbean.cardano.yaci.store.adapot.snapshot.DepositSnapshotService;
+import com.bloxbean.cardano.yaci.store.adapot.snapshot.StakeSnapshotService;
+import com.bloxbean.cardano.yaci.store.adapot.storage.PartitionManager;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.service.EraService;
+import com.bloxbean.cardano.yaci.store.transaction.storage.TransactionStorageReader;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdaPotJobProcessorTest {
+    private final AdaPotJobStorage storage = mock(AdaPotJobStorage.class);
+    private final ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    private final AdaPotJobProcessor processor = new AdaPotJobProcessor(
+            mock(StoreProperties.class),
+            mock(AdaPotProperties.class),
+            storage,
+            mock(EraService.class),
+            mock(EpochRewardCalculationService.class),
+            mock(StakeSnapshotService.class),
+            mock(DepositSnapshotService.class),
+            mock(AdaPotService.class),
+            mock(TransactionStorageReader.class),
+            publisher,
+            mock(PartitionManager.class),
+            mock(DSLContext.class));
+
+    @Test
+    void shouldSkipJobCancelledByRollback() throws InterruptedException {
+        AdaPotJob job = job(644, 192844802L, 13695759L);
+
+        boolean result = processor.processJob(job, () -> true);
+
+        assertThat(result).isTrue();
+        verify(storage, never()).save(job);
+        verify(publisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldSkipJobReplacedByCanonicalTransition() throws InterruptedException {
+        AdaPotJob staleJob = job(644, 192844802L, 13695759L, "orphan-hash");
+        AdaPotJob canonicalJob = job(644, 192845302L, 13695759L, "canonical-hash");
+        when(storage.getJobByTypeAndEpoch(AdaPotJobType.REWARD_CALC, 644))
+                .thenReturn(Optional.of(canonicalJob));
+
+        boolean result = processor.processJob(staleJob);
+
+        assertThat(result).isTrue();
+        verify(storage, never()).save(staleJob);
+        verify(publisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldSkipJobReplacedAtSameSlotAndBlockByDifferentHash() throws InterruptedException {
+        AdaPotJob staleJob = job(644, 192844802L, 13695759L, "orphan-hash");
+        AdaPotJob canonicalJob = job(644, 192844802L, 13695759L, "canonical-hash");
+        when(storage.getJobByTypeAndEpoch(AdaPotJobType.REWARD_CALC, 644))
+                .thenReturn(Optional.of(canonicalJob));
+
+        boolean result = processor.processJob(staleJob);
+
+        assertThat(result).isTrue();
+        verify(storage, never()).save(staleJob);
+        verify(publisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldStopRunningJobWhenRollbackCancelsIt() throws InterruptedException {
+        AdaPotJob job = job(644, 192844802L, 13695759L);
+        when(storage.getJobByTypeAndEpoch(AdaPotJobType.REWARD_CALC, 644))
+                .thenReturn(Optional.of(job));
+        AtomicInteger cancellationChecks = new AtomicInteger();
+
+        boolean result = processor.processJob(job, () -> cancellationChecks.incrementAndGet() > 1);
+
+        assertThat(result).isTrue();
+        verify(storage).save(job);
+        verify(publisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+
+    private AdaPotJob job(int epoch, long slot, long block) {
+        return job(epoch, slot, block, null);
+    }
+
+    private AdaPotJob job(int epoch, long slot, long block, String blockHash) {
+        return AdaPotJob.builder()
+                .epoch(epoch)
+                .slot(slot)
+                .block(block)
+                .blockHash(blockHash)
+                .type(AdaPotJobType.REWARD_CALC)
+                .status(AdaPotJobStatus.NOT_STARTED)
+                .build();
+    }
+}

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/StakesnapshotServiceTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/StakesnapshotServiceTest.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.ComponentScan;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 @ComponentScan
 public class StakesnapshotServiceTest {
@@ -25,12 +27,74 @@ public class StakesnapshotServiceTest {
     @BeforeEach
     public void setup() {
         storeProperties.setMainnet(true);
+        dslContext.execute("delete from epoch_stake");
+        dslContext.execute("delete from pool");
+        dslContext.execute("delete from delegation");
+        dslContext.execute("delete from stake_address_balance");
+    }
+
+    @Test
+    void shouldExcludePoolWhenRetirementIsEffectiveWithoutRetiredRow() {
+        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
+        insertPoolStatus("pool1", "RETIRING", 9, 100L, 10);
+
+        stakeSnapshotService.takeStakeSnapshot(10);
+
+        assertThat(epochStakeCount(10)).isZero();
+    }
+
+    @Test
+    void shouldIncludePoolWhenRetirementIsInFuture() {
+        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
+        insertPoolStatus("pool1", "RETIRING", 9, 100L, 11);
+
+        stakeSnapshotService.takeStakeSnapshot(10);
+
+        assertThat(epochStakeCount(10)).isOne();
+    }
+
+    @Test
+    void shouldIncludePoolWhenLaterUpdateCancelsEffectiveRetirement() {
+        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
+        insertPoolStatus("pool1", "RETIRING", 9, 100L, 10);
+        insertPoolStatus("pool1", "UPDATE", 9, 110L, null);
+
+        stakeSnapshotService.takeStakeSnapshot(10);
+
+        assertThat(epochStakeCount(10)).isOne();
     }
 
 //    @Test
     void takeSnapshot() throws IOException {
         dslContext.execute("delete from epoch_stake where epoch >= 207");
         stakeSnapshotService.takeStakeSnapshot(207);
+    }
+
+    private void insertDelegationAndBalance(String poolId, String address, int epoch, long amount) {
+        dslContext.execute("""
+                insert into delegation
+                    (tx_hash, cert_index, tx_index, credential, pool_id, address, epoch, slot)
+                values (?, 0, 0, ?, ?, ?, ?, 90)
+                """, "delegation-" + address, "credential-" + address, poolId, address, epoch - 1);
+        dslContext.execute("""
+                insert into stake_address_balance (address, slot, quantity, epoch)
+                values (?, 80, ?, ?)
+                """, address, amount, epoch - 1);
+    }
+
+    private void insertPoolStatus(String poolId, String status, int epoch, long slot, Integer retireEpoch) {
+        dslContext.execute("""
+                insert into pool
+                    (pool_id, tx_hash, cert_index, tx_index, status, epoch, retire_epoch,
+                     registration_slot, slot)
+                values (?, ?, 0, 0, ?, ?, ?, 1, ?)
+                """, poolId, status + "-" + slot, status, epoch, retireEpoch, slot);
+    }
+
+    private int epochStakeCount(int epoch) {
+        return dslContext.fetchCount(
+                dslContext.selectFrom(org.jooq.impl.DSL.table("epoch_stake"))
+                        .where(org.jooq.impl.DSL.field("epoch").eq(epoch)));
     }
 
 

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchService.java
@@ -305,6 +305,7 @@ public class BlockFetchService implements BlockChainDataListener {
         }
 
         cursorService.rollback(point.getSlot());
+        restoreEpochStateFromCursor();
 
         //Publish Pre-rollback event
         PreRollbackEvent preRollbackEvent = PreRollbackEvent
@@ -325,6 +326,23 @@ public class BlockFetchService implements BlockChainDataListener {
                 .build();
         log.info("Publishing rollback event : " + rollbackEvent);
         publisher.publishEvent(rollbackEvent);
+    }
+
+    private void restoreEpochStateFromCursor() {
+        cursorService.getCursor().ifPresentOrElse(cursor -> {
+            previousEra = cursor.getEra();
+            // Byron blocks carry their epoch, but the cursor does not. AdaPot starts after Byron,
+            // so leave it unset and let the next Byron block provide the epoch if this ever occurs.
+            previousEpoch = cursor.getEra() == null || cursor.getEra() == Era.Byron
+                    ? null
+                    : eraService.getEpochNo(cursor.getEra(), cursor.getSlot());
+        }, () -> {
+            previousEpoch = null;
+            previousEra = null;
+        });
+
+        log.info("Restored epoch state after rollback. previousEpoch: {}, previousEra: {}",
+                previousEpoch, previousEra);
     }
 
     @Override

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchServiceRollbackTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/service/BlockFetchServiceRollbackTest.java
@@ -1,0 +1,136 @@
+package com.bloxbean.cardano.yaci.store.core.service;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.helper.BlockRangeSync;
+import com.bloxbean.cardano.yaci.helper.BlockSync;
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.Cursor;
+import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.core.metrics.MetricsService;
+import com.bloxbean.cardano.yaci.store.core.service.publisher.ByronBlockEventPublisher;
+import com.bloxbean.cardano.yaci.store.core.service.publisher.ShelleyBlockEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BlockFetchServiceRollbackTest {
+    private ApplicationEventPublisher publisher;
+    private CursorService cursorService;
+    private EraService eraService;
+    private GenesisConfig genesisConfig;
+    private BlockFetchService blockFetchService;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(ApplicationEventPublisher.class);
+        cursorService = mock(CursorService.class);
+        eraService = mock(EraService.class);
+        genesisConfig = mock(GenesisConfig.class);
+
+        blockFetchService = new BlockFetchService(
+                publisher,
+                mock(MetricsService.class),
+                mock(BlockRangeSync.class),
+                mock(BlockSync.class),
+                cursorService,
+                eraService,
+                mock(StoreProperties.class),
+                genesisConfig,
+                mock(ShelleyBlockEventPublisher.class),
+                mock(ByronBlockEventPublisher.class));
+    }
+
+    @Test
+    void shouldRestoreEpochAndEraFromRollbackCursor() {
+        var currentCursor = cursor(192844802L, 13695759L, "current", Era.Conway);
+        var rollbackCursor = cursor(192844727L, 13695758L, "rollback", Era.Conway);
+
+        when(cursorService.getCursor())
+                .thenReturn(Optional.of(currentCursor))
+                .thenReturn(Optional.of(rollbackCursor));
+        when(eraService.getEpochNo(Era.Conway, rollbackCursor.getSlot())).thenReturn(643);
+
+        ReflectionTestUtils.setField(blockFetchService, "previousEpoch", 644);
+        ReflectionTestUtils.setField(blockFetchService, "previousEra", Era.Conway);
+
+        blockFetchService.onRollback(new Point(rollbackCursor.getSlot(), rollbackCursor.getBlockHash()));
+
+        verify(cursorService).rollback(rollbackCursor.getSlot());
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEpoch")).isEqualTo(643);
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEra")).isEqualTo(Era.Conway);
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                blockFetchService, "detectIfNewEpoch", 644, 192845302L)).isTrue();
+    }
+
+    @Test
+    void shouldClearEpochAndEraWhenRollbackLeavesNoCursor() {
+        var currentCursor = cursor(100L, 10L, "current", Era.Conway);
+
+        when(cursorService.getCursor())
+                .thenReturn(Optional.of(currentCursor))
+                .thenReturn(Optional.empty());
+
+        ReflectionTestUtils.setField(blockFetchService, "previousEpoch", 1);
+        ReflectionTestUtils.setField(blockFetchService, "previousEra", Era.Conway);
+
+        blockFetchService.onRollback(new Point(99L, "rollback"));
+
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEpoch")).isNull();
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEra")).isNull();
+    }
+
+    @Test
+    void shouldNotReportEpochChangeAfterRollbackWithinSameEpoch() {
+        var currentCursor = cursor(200L, 20L, "current", Era.Conway);
+        var rollbackCursor = cursor(100L, 10L, "rollback", Era.Conway);
+
+        when(cursorService.getCursor())
+                .thenReturn(Optional.of(currentCursor))
+                .thenReturn(Optional.of(rollbackCursor));
+        when(eraService.getEpochNo(Era.Conway, rollbackCursor.getSlot())).thenReturn(644);
+
+        blockFetchService.onRollback(new Point(rollbackCursor.getSlot(), rollbackCursor.getBlockHash()));
+
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                blockFetchService, "detectIfNewEpoch", 644, 201L)).isFalse();
+    }
+
+    @Test
+    void shouldLeaveByronEpochUnsetWithoutCallingEraService() {
+        var currentCursor = cursor(100L, 20L, "current", Era.Byron);
+        var rollbackCursor = cursor(90L, 19L, "rollback", Era.Byron);
+
+        when(cursorService.getCursor())
+                .thenReturn(Optional.of(currentCursor))
+                .thenReturn(Optional.of(rollbackCursor));
+
+        ReflectionTestUtils.setField(blockFetchService, "previousEpoch", 1);
+        ReflectionTestUtils.setField(blockFetchService, "previousEra", Era.Byron);
+
+        blockFetchService.onRollback(new Point(rollbackCursor.getSlot(), rollbackCursor.getBlockHash()));
+
+        verify(eraService, never()).getEpochNo(Era.Byron, rollbackCursor.getSlot());
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEpoch")).isNull();
+        assertThat(ReflectionTestUtils.getField(blockFetchService, "previousEra")).isEqualTo(Era.Byron);
+    }
+
+    private Cursor cursor(long slot, long block, String hash, Era era) {
+        return Cursor.builder()
+                .slot(slot)
+                .block(block)
+                .blockHash(hash)
+                .era(era)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1092.

- Restore the in-memory era and epoch from the rolled-back cursor before publishing rollback events. This lets the canonical epoch-transition block publish the transition events again.
- Cancel queued or running AdaPot jobs created from rolled-back blocks, and verify that a job still belongs to the current transition block before every important write.
- Persist the transition block hash in `adapot_jobs` and use epoch, slot, block number, and block hash to distinguish competing forks. The new column is nullable for safe upgrades on PostgreSQL, MySQL, and H2.
- Exclude pools whose `RETIRING` status is already effective when building a stake snapshot, even if a derived `RETIRED` row is missing. A later pool update still cancels the retirement because only the latest certificate is considered.
- Avoid calculating an epoch from a Byron cursor, since Byron blocks carry the epoch and AdaPot is not active in Byron.

## Root cause

A rollback crossed a mainnet epoch boundary after the first transition block had been processed. The database cursor moved back, but `BlockFetchService.previousEpoch` kept the newer epoch. When the canonical transition block arrived, Yaci Store did not recognize it as a new epoch, so the transition handlers were not replayed.

This left some derived pool retirement rows and refund processing missing. The AdaPot job created from the rolled-back transition could also remain in memory and continue after its database row was removed or replaced. The resulting stake snapshot included delegations to pools that should already have retired, which caused the treasury, reserves, and distributed rewards mismatch reported for epoch 648.

## Validation

```text
./gradlew -Dorg.gradle.java.home=<java-21> :components:core:test :aggregates:adapot:test --console=plain
BUILD SUCCESSFUL
```

Regression coverage includes:

- rollback across an epoch boundary
- rollback within the same epoch
- Byron cursor rollback guard
- queued and running AdaPot job cancellation
- a canonical transition replacing an orphaned block at the same slot and block number but with a different hash
- effective, future, and cancelled pool retirements in stake snapshots

## Existing affected databases

This fix prevents the problem on future rollbacks. It does not automatically repair already calculated epochs. An affected deployment should replay from before the affected epoch transition so retirement/refund events are rebuilt, then recalculate the affected AdaPot jobs through epoch 648 and compare the result with Koios mainnet.
