### PR TITLE
fix: remove redundant pool retirement snapshot filter [2.0.x]

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/StakeSnapshotService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/StakeSnapshotService.java
@@ -172,7 +172,6 @@ public class StakeSnapshotService {
                                  SELECT
                                      pool_id,
                                      status,
-                                     retire_epoch,
                                      registration_slot,
                                      slot,
                                      ROW_NUMBER() OVER (
@@ -265,10 +264,7 @@ public class StakeSnapshotService {
                             d.rn = 1
                     and not exists(
                                     select 1 from ss_pool_status p
-                                    where d.pool_id = p.pool_id and p.rn = 1
-                                      and (p.status = 'RETIRED'
-                                           or (p.status = 'RETIRING' and p.retire_epoch <= :epoch)
-                                           or d.slot < p.registration_slot)
+                                    where d.pool_id = p.pool_id and p.rn = 1 and (p.status = 'RETIRED' or d.slot < p.registration_slot)
                             )
                             AND sd.address IS NULL;
                 """;

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/StakesnapshotServiceTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/service/StakesnapshotServiceTest.java
@@ -11,8 +11,6 @@ import org.springframework.context.annotation.ComponentScan;
 
 import java.io.IOException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest
 @ComponentScan
 public class StakesnapshotServiceTest {
@@ -27,74 +25,12 @@ public class StakesnapshotServiceTest {
     @BeforeEach
     public void setup() {
         storeProperties.setMainnet(true);
-        dslContext.execute("delete from epoch_stake");
-        dslContext.execute("delete from pool");
-        dslContext.execute("delete from delegation");
-        dslContext.execute("delete from stake_address_balance");
-    }
-
-    @Test
-    void shouldExcludePoolWhenRetirementIsEffectiveWithoutRetiredRow() {
-        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
-        insertPoolStatus("pool1", "RETIRING", 9, 100L, 10);
-
-        stakeSnapshotService.takeStakeSnapshot(10);
-
-        assertThat(epochStakeCount(10)).isZero();
-    }
-
-    @Test
-    void shouldIncludePoolWhenRetirementIsInFuture() {
-        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
-        insertPoolStatus("pool1", "RETIRING", 9, 100L, 11);
-
-        stakeSnapshotService.takeStakeSnapshot(10);
-
-        assertThat(epochStakeCount(10)).isOne();
-    }
-
-    @Test
-    void shouldIncludePoolWhenLaterUpdateCancelsEffectiveRetirement() {
-        insertDelegationAndBalance("pool1", "stake1", 10, 1_000L);
-        insertPoolStatus("pool1", "RETIRING", 9, 100L, 10);
-        insertPoolStatus("pool1", "UPDATE", 9, 110L, null);
-
-        stakeSnapshotService.takeStakeSnapshot(10);
-
-        assertThat(epochStakeCount(10)).isOne();
     }
 
 //    @Test
     void takeSnapshot() throws IOException {
         dslContext.execute("delete from epoch_stake where epoch >= 207");
         stakeSnapshotService.takeStakeSnapshot(207);
-    }
-
-    private void insertDelegationAndBalance(String poolId, String address, int epoch, long amount) {
-        dslContext.execute("""
-                insert into delegation
-                    (tx_hash, cert_index, tx_index, credential, pool_id, address, epoch, slot)
-                values (?, 0, 0, ?, ?, ?, ?, 90)
-                """, "delegation-" + address, "credential-" + address, poolId, address, epoch - 1);
-        dslContext.execute("""
-                insert into stake_address_balance (address, slot, quantity, epoch)
-                values (?, 80, ?, ?)
-                """, address, amount, epoch - 1);
-    }
-
-    private void insertPoolStatus(String poolId, String status, int epoch, long slot, Integer retireEpoch) {
-        dslContext.execute("""
-                insert into pool
-                    (pool_id, tx_hash, cert_index, tx_index, status, epoch, retire_epoch,
-                     registration_slot, slot)
-                values (?, ?, 0, 0, ?, ?, ?, 1, ?)
-                """, poolId, status + "-" + slot, status, epoch, retireEpoch, slot);
-    }
-
-    private int epochStakeCount(int epoch) {
-        return dslContext.fetchCount(
-                dslContext.selectFrom(org.jooq.impl.DSL.table("epoch_stake"))
-                        .where(org.jooq.impl.DSL.field("epoch").eq(epoch)));
     }
 
 


### PR DESCRIPTION
## Summary

Backports #1097 to the `release/2.0.x` branch.

- remove the stake snapshot fallback that treats an effective RETIRING status as RETIRED
- rely on the repaired epoch-transition flow to create the derived RETIRED row
- remove the tests and helpers that covered only the fallback behavior

This avoids masking a future failure in the RETIRING-to-RETIRED transition and keeps pool retirement state consistent across stake snapshots and refund processing.
