### PR TITLE
fix(blockfrost): return stake registration deposit from current epoch params

### DIFF
--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/dto/BFAccountRegistrationDto.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/dto/BFAccountRegistrationDto.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class BFAccountRegistrationDto {
     private String txHash;
     private String action;
+    private String deposit;
     private Long txSlot;
     private Long blockTime;
     private Long blockHeight;

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/mapper/BFAccountMapper.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/mapper/BFAccountMapper.java
@@ -44,6 +44,7 @@ public interface BFAccountMapper {
     BFAccountDelegationDto toDelegationDto(AccountDelegation source);
 
     @Mapping(target = "action", source = "type", qualifiedByName = "registrationTypeToAction")
+    @Mapping(target = "deposit", ignore = true)
     BFAccountRegistrationDto toRegistrationDto(AccountRegistration source);
 
     @Mapping(target = "amount", source = "amount", qualifiedByName = "stringOrZero")

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/mapper/BFAccountMapper.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/mapper/BFAccountMapper.java
@@ -20,6 +20,11 @@ public interface BFAccountMapper {
 
     BFAccountMapper INSTANCE = Mappers.getMapper(BFAccountMapper.class);
 
+    String ACTION_REGISTERED = "registered";
+    String ACTION_DEREGISTERED = "deregistered";
+    String REWARD_TYPE_REFUND = "refund";
+    String REWARD_TYPE_POOL_DEPOSIT_REFUND = "pool_deposit_refund";
+
     @Mapping(target = "controlledAmount", source = "controlledAmount", qualifiedByName = "stringOrZero")
     @Mapping(target = "rewardsSum", source = "rewardsSum", qualifiedByName = "stringOrZero")
     @Mapping(target = "withdrawalsSum", source = "withdrawalsSum", qualifiedByName = "stringOrZero")
@@ -88,9 +93,9 @@ public interface BFAccountMapper {
     @Named("registrationTypeToAction")
     default String registrationTypeToAction(String type) {
         if (type != null && type.toUpperCase().contains("DEREGISTRATION")) {
-            return "deregistered";
+            return ACTION_DEREGISTERED;
         }
-        return "registered";
+        return ACTION_REGISTERED;
     }
 
     @Named("normalizeRewardType")
@@ -99,8 +104,8 @@ public interface BFAccountMapper {
             return type;
         }
 
-        if ("refund".equalsIgnoreCase(type)) {
-            return "pool_deposit_refund";
+        if (REWARD_TYPE_REFUND.equalsIgnoreCase(type)) {
+            return REWARD_TYPE_POOL_DEPOSIT_REFUND;
         }
 
         return type;

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountService.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountService.java
@@ -53,7 +53,7 @@ public class BFAccountService {
                 .stream()
                 .map(registration -> {
                     var dto = mapper.toRegistrationDto(registration);
-                    if ("registered".equals(dto.getAction()))
+                    if (BFAccountMapper.ACTION_REGISTERED.equals(dto.getAction()))
                         dto.setDeposit(keyDeposit);
                     return dto;
                 })

--- a/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountService.java
+++ b/extensions/blockfrost/account/src/main/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountService.java
@@ -3,9 +3,12 @@ package com.bloxbean.cardano.yaci.store.blockfrost.account.service;
 import com.bloxbean.cardano.yaci.store.blockfrost.account.dto.*;
 import com.bloxbean.cardano.yaci.store.blockfrost.account.mapper.BFAccountMapper;
 import com.bloxbean.cardano.yaci.store.blockfrost.account.storage.BFAccountStorageReader;
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.client.epoch.EpochParamClient;
 import com.bloxbean.cardano.yaci.store.common.model.Order;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -18,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BFAccountService {
     private final BFAccountStorageReader storageReader;
+    private final ObjectProvider<EpochParamClient> epochParamClient;
     private final BFAccountMapper mapper = BFAccountMapper.INSTANCE;
 
     public BFAccountContentDto getAccountInfo(String stakeAddress) {
@@ -43,8 +47,27 @@ public class BFAccountService {
     }
 
     public List<BFAccountRegistrationDto> findRegistrations(String stakeAddress, int page, int count, Order order) {
+        String keyDeposit = currentKeyDeposit();
+
         return storageReader.findRegistrations(stakeAddress, page, count, order)
-                .stream().map(mapper::toRegistrationDto).toList();
+                .stream()
+                .map(registration -> {
+                    var dto = mapper.toRegistrationDto(registration);
+                    if ("registered".equals(dto.getAction()))
+                        dto.setDeposit(keyDeposit);
+                    return dto;
+                })
+                .toList();
+    }
+
+    private String currentKeyDeposit() {
+        var client = epochParamClient.getIfAvailable();
+        if (client == null)
+            return null;
+
+        return client.getLatestProtocolParams()
+                .map(ProtocolParams::getKeyDeposit)
+                .orElse(null);
     }
 
     public List<BFAccountWithdrawalDto> findWithdrawals(String stakeAddress, int page, int count, Order order) {

--- a/extensions/blockfrost/account/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountServiceTest.java
+++ b/extensions/blockfrost/account/src/test/java/com/bloxbean/cardano/yaci/store/blockfrost/account/service/BFAccountServiceTest.java
@@ -1,0 +1,89 @@
+package com.bloxbean.cardano.yaci.store.blockfrost.account.service;
+
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.blockfrost.account.dto.BFAccountRegistrationDto;
+import com.bloxbean.cardano.yaci.store.blockfrost.account.storage.BFAccountStorageReader;
+import com.bloxbean.cardano.yaci.store.blockfrost.account.storage.impl.model.AccountRegistration;
+import com.bloxbean.cardano.yaci.store.client.epoch.EpochParamClient;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BFAccountServiceTest {
+    private static final String STAKE_ADDRESS = "stake_test1uztg6yppa0t30rslkrneva5c9qju40rhndjnuy356kxw83s6n95nu";
+
+    @Mock
+    private BFAccountStorageReader storageReader;
+
+    @Mock
+    private ObjectProvider<EpochParamClient> epochParamClient;
+
+    @Mock
+    private EpochParamClient epochParamClientBean;
+
+    @InjectMocks
+    private BFAccountService service;
+
+    @BeforeEach
+    void setUp() {
+        when(storageReader.findRegistrations(anyString(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(
+                        new AccountRegistration("tx1", "STAKE_REGISTRATION", 100L, 1000L, 10L),
+                        new AccountRegistration("tx2", "STAKE_DEREGISTRATION", 200L, 2000L, 20L)));
+    }
+
+    @Test
+    void findRegistrations_WhenKeyDepositAvailable_SetsItOnRegistrationsOnly() {
+        ProtocolParams protocolParams = new ProtocolParams();
+        protocolParams.setKeyDeposit("2000000");
+
+        when(epochParamClient.getIfAvailable()).thenReturn(epochParamClientBean);
+        when(epochParamClientBean.getLatestProtocolParams()).thenReturn(Optional.of(protocolParams));
+
+        List<BFAccountRegistrationDto> registrations =
+                service.findRegistrations(STAKE_ADDRESS, 1, 100, Order.asc);
+
+        assertThat(registrations)
+                .extracting(BFAccountRegistrationDto::getAction, BFAccountRegistrationDto::getDeposit)
+                .containsExactly(
+                        Tuple.tuple("registered", "2000000"),
+                        Tuple.tuple("deregistered", null));
+    }
+
+    @Test
+    void findRegistrations_WhenProtocolParamsMissing_LeavesDepositNull() {
+        when(epochParamClient.getIfAvailable()).thenReturn(epochParamClientBean);
+        when(epochParamClientBean.getLatestProtocolParams()).thenReturn(Optional.empty());
+
+        List<BFAccountRegistrationDto> registrations =
+                service.findRegistrations(STAKE_ADDRESS, 1, 100, Order.asc);
+
+        assertThat(registrations).extracting(BFAccountRegistrationDto::getDeposit).containsOnlyNulls();
+    }
+
+    @Test
+    void findRegistrations_WhenEpochStoreDisabled_LeavesDepositNull() {
+        when(epochParamClient.getIfAvailable()).thenReturn(null);
+
+        List<BFAccountRegistrationDto> registrations =
+                service.findRegistrations(STAKE_ADDRESS, 1, 100, Order.asc);
+
+        assertThat(registrations).extracting(BFAccountRegistrationDto::getDeposit).containsOnlyNulls();
+    }
+}


### PR DESCRIPTION
Addresses #1084.

@adamcazes — this is the workaround discussed in #1084.

## Problem

`GET /accounts/{stake_address}/registrations` omits the `deposit` field that Blockfrost documents and returns on every entry.

It cannot be served from storage today: `stake_registration` has no `deposit` column, and `StakeRegProcessor` drops the certificate's `getCoin()` at ingest.

## Change

Blockfrost-layer workaround, per the direction in #1084. Storing the per-certificate deposit is tracked separately in #451.

| file | change |
|---|---|
| `BFAccountRegistrationDto` | add `deposit` (lovelace string) |
| `BFAccountMapper` | `@Mapping(target = "deposit", ignore = true)` — owned by the service |
| `BFAccountService.findRegistrations` | resolve the current epoch's `keyDeposit` once per call; set on `registered`, `null` on `deregistered` |
| `BFAccountServiceTest` | new — 3 cases |

`keyDeposit` comes from `EpochParamClient.getLatestProtocolParams()`, injected as an `ObjectProvider` so the endpoint still answers when the epoch store is disabled — `deposit` is `null` there instead of the request failing.

No schema change, no processor change, no new module dependency (`components:client` already arrives via `stores:staking`).

## Verification

Read-only against synced instances:

| network | epoch | case | `deposit` |
|---|---|---|---|
| mainnet | 649 | Conway registration | `"2000000"` |
| mainnet | 649 | deregistration | `null` |
| mainnet | 649 | pre-Conway registration (block 4,490,613) | `"2000000"` |
| preprod | 307 | Conway registration | `"2000000"` |
| preprod | 307 | deregistration | `null` |
| preprod | 307 | pre-Conway registration (block 48) | `"2000000"` |

Pre-Conway rows are covered because the value comes from epoch parameters, not the certificate.

New tests: key deposit available → set on registrations only; protocol params absent → `null`; epoch store disabled → `null`.

## Notes

It reads `keyDeposit` from the current epoch, as originally specified. Switching to the registration's own epoch would need a new `EpochParamClient` method, so it is left to #451.

The genesis-file fallback for scoped indexers is not included — #451 supersedes it.
