### PR TITLE
fix(governance): correct voting procedure indexes

### DIFF
--- a/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/processor/VotingProcedureProcessor.java
+++ b/stores/governance/src/main/java/com/bloxbean/cardano/yaci/store/governance/processor/VotingProcedureProcessor.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,6 +31,10 @@ import static com.bloxbean.cardano.yaci.store.governance.GovernanceStoreConfigur
 @Slf4j
 public class VotingProcedureProcessor {
 
+    private static final Comparator<GovActionId> GOV_ACTION_ID_ORDER = Comparator
+            .comparing(GovActionId::getTransactionId)
+            .thenComparingInt(GovActionId::getGov_action_index);
+
     private final VotingProcedureStorage votingProcedureStorage;
     private final ApplicationEventPublisher publisher;
 
@@ -39,7 +44,6 @@ public class VotingProcedureProcessor {
         EventMetadata eventMetadata = governanceEvent.getMetadata();
 
         List<VotingProcedure> votingProcedures = new ArrayList<>();
-        int index = 0;
 
         for (TxGovernance txGovernance : governanceEvent.getTxGovernanceList()) {
             if (txGovernance.getVotingProcedures() == null) {
@@ -53,8 +57,14 @@ public class VotingProcedureProcessor {
             for (var entry : voting.entrySet()) {
                 Voter voter = entry.getKey();
                 var votingInfoMap = entry.getValue();
+                int index = 0;
 
-                for (var votingInfoEntry : votingInfoMap.entrySet()) {
+                // Ledger GovActionId ordering compares transactionId first, then actionIndex.
+                var orderedVotingInfo = votingInfoMap.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey(GOV_ACTION_ID_ORDER))
+                        .toList();
+
+                for (var votingInfoEntry : orderedVotingInfo) {
                     VotingProcedure votingProcedure = new VotingProcedure();
 
                     var govActionId = votingInfoEntry.getKey();

--- a/stores/governance/src/test/java/com/bloxbean/cardano/yaci/store/governance/processor/VotingProcedureProcessorTest.java
+++ b/stores/governance/src/test/java/com/bloxbean/cardano/yaci/store/governance/processor/VotingProcedureProcessorTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -94,6 +95,57 @@ class VotingProcedureProcessorTest {
         assertThat(votingProceduresSaved.get(0).getGovActionIndex()).isEqualTo(1);
     }
 
+    @Test
+    void givenMultipleVotersAndTransactions_ShouldDeriveIndexPerOrderedVoterActions() {
+        String firstTxHash = "1111111111111111111111111111111111111111111111111111111111111111";
+        String secondTxHash = "2222222222222222222222222222222222222222222222222222222222222222";
+        String firstVoterHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        String secondVoterHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        String firstGovActionTxHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        String secondGovActionTxHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        Map<GovActionId, VotingProcedure> firstVoterActions = new LinkedHashMap<>();
+        firstVoterActions.put(govAction(secondGovActionTxHash, 0), vote(Vote.YES));
+        firstVoterActions.put(govAction(firstGovActionTxHash, 2), vote(Vote.NO));
+        firstVoterActions.put(govAction(firstGovActionTxHash, 1), vote(Vote.ABSTAIN));
+
+        Map<Voter, Map<GovActionId, VotingProcedure>> firstTxVoting = new LinkedHashMap<>();
+        firstTxVoting.put(voter(VoterType.DREP_KEY_HASH, firstVoterHash), firstVoterActions);
+        firstTxVoting.put(voter(VoterType.STAKING_POOL_KEY_HASH, secondVoterHash),
+                Map.of(govAction(secondGovActionTxHash, 1), vote(Vote.YES)));
+
+        Map<Voter, Map<GovActionId, VotingProcedure>> secondTxVoting = new LinkedHashMap<>();
+        secondTxVoting.put(voter(VoterType.DREP_KEY_HASH, firstVoterHash),
+                Map.of(govAction(secondGovActionTxHash, 2), vote(Vote.NO)));
+
+        GovernanceEvent governanceEvent = GovernanceEvent.builder()
+                .metadata(eventMetadata())
+                .txGovernanceList(List.of(
+                        txGovernance(firstTxHash, firstTxVoting),
+                        txGovernance(secondTxHash, secondTxVoting)
+                ))
+                .build();
+
+        votingProcedureProcessor.handleVotingProcedure(governanceEvent);
+
+        verify(votingProcedureStorage).saveAll(votingProceduresCaptor.capture());
+        assertThat(votingProceduresCaptor.getValue())
+                .extracting(
+                        com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure::getTxHash,
+                        com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure::getVoterHash,
+                        com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure::getGovActionTxHash,
+                        com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure::getGovActionIndex,
+                        com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure::getIndex
+                )
+                .containsExactly(
+                        tuple(firstTxHash, firstVoterHash, firstGovActionTxHash, 1, 0L),
+                        tuple(firstTxHash, firstVoterHash, firstGovActionTxHash, 2, 1L),
+                        tuple(firstTxHash, firstVoterHash, secondGovActionTxHash, 0, 2L),
+                        tuple(firstTxHash, secondVoterHash, secondGovActionTxHash, 1, 0L),
+                        tuple(secondTxHash, firstVoterHash, secondGovActionTxHash, 2, 0L)
+                );
+    }
+
     private EventMetadata eventMetadata() {
         return EventMetadata.builder()
                 .block(100L)
@@ -119,5 +171,24 @@ class VotingProcedureProcessorTest {
                                                 .anchor_data_hash("1111111111111111111111111111111111111111111111111111111111111111")
                                                 .build()).build())));
         return votingMap;
+    }
+
+    private TxGovernance txGovernance(String txHash, Map<Voter, Map<GovActionId, VotingProcedure>> voting) {
+        return TxGovernance.builder()
+                .txHash(txHash)
+                .votingProcedures(VotingProcedures.builder().voting(voting).build())
+                .build();
+    }
+
+    private Voter voter(VoterType type, String hash) {
+        return Voter.builder().type(type).hash(hash).build();
+    }
+
+    private GovActionId govAction(String transactionId, int index) {
+        return GovActionId.builder().transactionId(transactionId).gov_action_index(index).build();
+    }
+
+    private VotingProcedure vote(Vote vote) {
+        return VotingProcedure.builder().vote(vote).build();
     }
 }


### PR DESCRIPTION
Fixes #1104 
## Summary

This PR corrects the index assigned to governance voting procedures.

- Reset the index for each voter's governance-action map in each transaction.
- Order governance actions by `(transactionId, actionIndex)` before deriving the index, matching `GovActionId` ordering in cardano-ledger.
- Add regression coverage for multiple actions, voters, and transactions.

## Context

The issue was discovered while resolving Blockfrost governance compatibility gaps in [#865](https://github.com/bloxbean/yaci-store/pull/865), but the root cause is in the governance store ingestion logic rather than the Blockfrost extension.

Cardano ledger represents voting procedures as `Map Voter (Map GovActionId VotingProcedure)`. The previous processor flattened all transactions and voters with one event-wide counter and relied on Java `Map` iteration order. This could produce incorrect and non-deterministic indexes for multi-voter or multi-action transactions.

## Verification performed

- [x] `./gradlew :stores:governance:test --tests com.bloxbean.cardano.yaci.store.governance.processor.VotingProcedureProcessorTest`
- [x] `./gradlew :stores:governance:test`
- [x] Regression test verifies ordering by governance action ID and index reset across voters and transactions.

## Required preprod verification

- [x] Sync a clean Yaci Store instance again on preprod, or re-index governance data from before the selected voting transactions. Restarting an instance with existing rows is not sufficient.
- [ ] Verify a transaction containing multiple governance actions from one voter receives contiguous indexes `0, 1, 2, ...` in `(transactionId, actionIndex)` order.
- [ ] Verify a transaction containing multiple voters starts the index again at `0` for each voter.
- [ ] Verify multiple voting transactions processed in the same event do not carry indexes across transaction boundaries.
- [ ] At an aligned chain tip, compare the affected proposal-vote endpoints with Blockfrost preprod and confirm the returned `cert_index` values match.

## Data compatibility

There is no schema or public API change. Existing voting procedure rows are not rewritten automatically; historical verification requires a fresh sync, re-index, or a separately designed backfill.

## Follow-up issue

  `voting_procedure.idx` is also used by `VotingAggrService#getVotesByDRep` to compare a vote with `drep_registration.cert_index` when both belong to the same transaction.

  These indexes represent positions in different transaction-body collections and therefore are not directly comparable. The ledger processes `CERTS` before `GOV` and removes votes associated with DReps unregistered in the
  transaction without comparing certificate and voting-procedure indexes.

 A follow-up issue should remove this cross-collection index comparison and add coverage for same-transaction DRep unregistration and voting.
