### PR TITLE
fix(assets-ext): propagate CIP-26 token deletions from the upstream registry [cherry-pick 2.0.x]

### DIFF
--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/ChangedMappings.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/model/ChangedMappings.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Result of diffing the mappings folder between two commits of the token registry repository.
+ *
+ * @param upsertedFiles    mapping files that were added or modified and must be (re-)indexed
+ * @param deletedFileNames file names (e.g. {@code <subject>.json}) of mapping files that were
+ *                         removed from the registry and whose metadata must be deleted locally
+ */
+public record ChangedMappings(List<Path> upsertedFiles, List<String> deletedFileNames) {
+
+    public static ChangedMappings empty() {
+        return new ChangedMappings(List.of(), List.of());
+    }
+
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.util.MappingsUtil.extractLogo;
@@ -72,6 +73,40 @@ public class Cip26MetadataService {
                     cip26Metadata.getSubject(), e.getMessage(), e);
             return InsertOutcome.TRANSIENTLY_FAILED;
         }
+    }
+
+    /**
+     * Deletes the metadata row (logo included — it lives on the same row) for a subject
+     * whose mapping file was removed from the upstream registry. Deleting a subject that
+     * is not present locally is a no-op and still counts as {@link DeleteOutcome#DELETED}.
+     */
+    @Transactional
+    public DeleteOutcome deleteMapping(String subject) {
+        try {
+            cip26MetadataRepository.deleteById(subject);
+            return DeleteOutcome.DELETED;
+        } catch (NonTransientDataAccessException e) {
+            log.error("Permanent delete failure for token subject '{}', skipping: {}",
+                    subject, e.getMessage());
+            return DeleteOutcome.PERMANENTLY_FAILED;
+        } catch (TransientDataAccessException e) {
+            log.warn("Transient delete failure for token subject '{}', will retry next sync: {}",
+                    subject, e.getMessage());
+            return DeleteOutcome.TRANSIENTLY_FAILED;
+        } catch (Exception e) {
+            // Unknown exception type — conservative default is "transient" so
+            // we don't silently leave a removed token behind.
+            log.error("Unclassified delete failure for token subject '{}', will retry next sync: {}",
+                    subject, e.getMessage(), e);
+            return DeleteOutcome.TRANSIENTLY_FAILED;
+        }
+    }
+
+    /**
+     * @return subjects of all CIP-26 metadata rows currently stored locally
+     */
+    public List<String> findAllSubjects() {
+        return cip26MetadataRepository.findAllSubjects();
     }
 
     /**

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncService.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26SyncState;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.ChangedMappings;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
@@ -77,8 +78,10 @@ public class Cip26MetadataSyncService {
                 return;
             }
 
-            List<File> filesToProcess = resolveFilesToProcess(lastHash, newHashOpt, repoPathOpt.get());
-            log.info("Resolved {} file(s) to process", filesToProcess.size());
+            PendingChanges pendingChanges = resolvePendingChanges(lastHash, newHashOpt, repoPathOpt.get());
+            List<File> filesToProcess = pendingChanges.filesToProcess();
+            log.info("Resolved {} file(s) to process, {} subject(s) to delete",
+                    filesToProcess.size(), pendingChanges.subjectsToDelete().size());
 
             // Batch-resolve git metadata for all files in a single history walk
             Set<String> fileNames = filesToProcess.stream()
@@ -91,6 +94,7 @@ public class Cip26MetadataSyncService {
 
             long processStart = System.currentTimeMillis();
             boolean anyTransientFailure = processMappingFiles(filesToProcess, mappingDetailsMap);
+            anyTransientFailure |= processDeletions(pendingChanges.subjectsToDelete());
 
             if (anyTransientFailure) {
                 log.warn("At least one entry hit a transient failure. Commit hash will not be advanced so those entries are retried on next sync.");
@@ -265,19 +269,104 @@ public class Cip26MetadataSyncService {
                 : fileName;
     }
 
-    private List<File> resolveFilesToProcess(String lastHash, Optional<String> newHashOpt, Path repoPath) {
+    private PendingChanges resolvePendingChanges(String lastHash, Optional<String> newHashOpt, Path repoPath) {
         if (lastHash != null && newHashOpt.isPresent()) {
             log.info("Incremental sync from {} to {}", lastHash, newHashOpt.get());
-            List<File> files = gitService.getChangedFiles(lastHash, newHashOpt.get()).stream()
+            ChangedMappings changedMappings = gitService.getChangedMappings(lastHash, newHashOpt.get());
+            List<File> files = changedMappings.upsertedFiles().stream()
                     .map(Path::toFile).toList();
-            log.info("Incremental sync: processing {} changed file(s)", files.size());
-            return files;
+            List<String> subjectsToDelete = changedMappings.deletedFileNames().stream()
+                    .map(Cip26MetadataSyncService::stripJsonExtension)
+                    .toList();
+            log.info("Incremental sync: processing {} changed file(s), {} deleted file(s)",
+                    files.size(), subjectsToDelete.size());
+            return new PendingChanges(files, subjectsToDelete);
         }
 
         log.info("Full sync: processing all files");
         File mappings = repoPath.toFile();
-        return Optional.ofNullable(mappings.listFiles())
+        List<File> files = Optional.ofNullable(mappings.listFiles())
                 .map(Arrays::asList).orElse(List.of());
+        return new PendingChanges(files, resolveStaleSubjects(files));
+    }
+
+    /**
+     * Full-sync reconciliation: subjects present in the local DB whose mapping file no longer
+     * exists in the registry were removed upstream (possibly while commit-hash tracking was
+     * unavailable) and must be deleted locally.
+     */
+    private List<String> resolveStaleSubjects(List<File> presentFiles) {
+        if (presentFiles.isEmpty()) {
+            log.warn("Full sync found no mapping files. Skipping stale-subject cleanup as a safety measure.");
+            return List.of();
+        }
+        Set<String> presentSubjects = new HashSet<>();
+        for (File presentFile : presentFiles) {
+            presentSubjects.add(stripJsonExtension(presentFile.getName()));
+        }
+        List<String> staleSubjects = tokenMetadataService.findAllSubjects().stream()
+                .filter(subject -> !presentSubjects.contains(subject))
+                .toList();
+        if (!staleSubjects.isEmpty()) {
+            log.info("Full sync: {} stale subject(s) no longer present in the registry will be deleted",
+                    staleSubjects.size());
+        }
+        return staleSubjects;
+    }
+
+    /**
+     * Returns true iff at least one deletion hit a transient failure — same
+     * cursor semantics as {@link #processMappingFiles}: transient failures
+     * block the cursor advance so the next sync retries them, while permanent
+     * failures are logged and skipped past.
+     */
+    private boolean processDeletions(List<String> subjectsToDelete) {
+        if (subjectsToDelete.isEmpty()) {
+            return false;
+        }
+        boolean anyTransient = false;
+        int deleted = 0;
+        int permanentlyFailed = 0;
+        for (String subject : subjectsToDelete) {
+            switch (tokenMetadataService.deleteMapping(subject)) {
+                case DELETED -> {
+                    deleted++;
+                    log.info("Deleted metadata for subject '{}' removed from the registry", subject);
+                }
+                case PERMANENTLY_FAILED -> permanentlyFailed++;
+                case TRANSIENTLY_FAILED -> anyTransient = true;
+            }
+        }
+        log.info("Deletion processing complete: {}/{} deleted (perm-failed={}). Cursor will {} advance.",
+                deleted, subjectsToDelete.size(), permanentlyFailed, anyTransient ? "NOT" : "");
+        return anyTransient;
+    }
+
+    /**
+     * The database changes one sync run still has to apply: mapping files to upsert and
+     * subjects to delete. How each side is resolved depends on the sync mode:
+     *
+     * <p><b>Incremental sync</b> (a last processed commit hash is stored and HEAD is known):
+     * both sides come from the git tree diff between the two commits. Added/modified mapping
+     * files become {@code filesToProcess}; deleted mapping files become {@code subjectsToDelete}
+     * (filename minus the {@code .json} extension — for canonical registry entries the filename
+     * equals the subject; for the mismatched spam files that were never indexed the resulting
+     * delete is a harmless no-op).
+     *
+     * <p><b>Full sync</b> (first run, or commit-hash tracking unavailable): there is no diff to
+     * consult, so {@code filesToProcess} is every file in the mappings folder and
+     * {@code subjectsToDelete} is derived by reconciliation — DB subjects with no corresponding
+     * mapping file were removed upstream while tracking was lost and must go. An empty mappings
+     * folder is treated as a broken clone rather than "everything was deleted", and yields no
+     * deletions.
+     *
+     * <p>Transiently-failed deletions, like transiently-failed upserts, prevent the commit hash
+     * from advancing so the work is retried on the next run.
+     *
+     * @param filesToProcess   mapping files to parse and upsert into the metadata table
+     * @param subjectsToDelete subjects whose metadata rows must be removed locally
+     */
+    private record PendingChanges(List<File> filesToProcess, List<String> subjectsToDelete) {
     }
 
 }

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/DeleteOutcome.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/DeleteOutcome.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
+
+/**
+ * Result of attempting to delete a single CIP-26 entry whose mapping file was
+ * removed from the upstream registry.
+ *
+ * <p>Same cursor semantics as {@link InsertOutcome}: any
+ * {@link #TRANSIENTLY_FAILED} in a batch blocks the {@code last_commit_hash}
+ * advance so the next sync retries; {@link #PERMANENTLY_FAILED} entries are
+ * documented as stuck and skipped past.
+ */
+public enum DeleteOutcome {
+
+    /** Row was deleted (or was already absent — deletion is idempotent). */
+    DELETED,
+
+    /**
+     * The database rejected the delete with a non-transient error (e.g. a
+     * foreign-key reference from another table). Retrying the same delete
+     * won't help; advance past it and log loudly so operators can intervene.
+     */
+    PERMANENTLY_FAILED,
+
+    /**
+     * Delete failed with what looks like a recoverable database condition
+     * (lock timeout, lost connection, deadlock) or an exception we don't
+     * recognise. The cursor must NOT advance — the next sync retries.
+     */
+    TRANSIENTLY_FAILED
+}

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitService.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitService.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
 
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.ChangedMappings;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -336,10 +337,10 @@ public class GitService {
         return Optional.empty();
     }
 
-    public List<Path> getChangedFiles(String fromHash, String toHash) {
+    public ChangedMappings getChangedMappings(String fromHash, String toHash) {
         if (git == null) {
             log.warn(GIT_NOT_INITIALIZED);
-            return List.of();
+            return ChangedMappings.empty();
         }
         try {
             Repository repository = git.getRepository();
@@ -349,7 +350,7 @@ public class GitService {
 
             if (oldId == null || newId == null) {
                 log.warn("Could not resolve commit hashes: {} -> {}", fromHash, toHash);
-                return List.of();
+                return ChangedMappings.empty();
             }
 
             AbstractTreeIterator oldTree = prepareTreeParser(repository, oldId);
@@ -362,17 +363,26 @@ public class GitService {
                     .call();
 
             Path repoRoot = getGitFolder().toPath();
-            return diffs.stream()
+            List<Path> upsertedFiles = diffs.stream()
                     .filter(d -> d.getChangeType() == DiffEntry.ChangeType.ADD
                             || d.getChangeType() == DiffEntry.ChangeType.MODIFY)
                     .map(DiffEntry::getNewPath)
                     .filter(path -> path.endsWith(".json"))
                     .map(repoRoot::resolve)
                     .toList();
+
+            List<String> deletedFileNames = diffs.stream()
+                    .filter(d -> d.getChangeType() == DiffEntry.ChangeType.DELETE)
+                    .map(DiffEntry::getOldPath)
+                    .filter(path -> path.endsWith(".json"))
+                    .map(path -> path.substring(path.lastIndexOf('/') + 1))
+                    .toList();
+
+            return new ChangedMappings(upsertedFiles, deletedFileNames);
         } catch (Exception e) {
             log.warn("Failed to get changed files between {} and {}", fromHash, toHash, e);
         }
-        return List.of();
+        return ChangedMappings.empty();
     }
 
     private AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId) throws IOException {

--- a/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26MetadataRepository.java
+++ b/extensions/assets-ext/src/main/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/storage/impl/repository/Cip26MetadataRepository.java
@@ -2,9 +2,15 @@ package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl
 
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.storage.impl.model.Cip26Metadata;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface Cip26MetadataRepository extends JpaRepository<Cip26Metadata, String> {
+
+    @Query("select t.subject from Cip26Metadata t")
+    List<String> findAllSubjects();
 
 }

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -177,6 +178,67 @@ class Cip26MetadataServiceTest {
             InsertOutcome outcome = service.insertLogo(mapping("subject1"));
 
             assertThat(outcome).isEqualTo(InsertOutcome.TRANSIENTLY_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMapping")
+    class DeleteMapping {
+
+        private static final String SUBJECT =
+                "ff7cad970d3a755a1ff0335ccb3f3c1cabf31aacf3f23dd13db61b0630313030";
+
+        @Test
+        void returnsDeletedOnHappyPath() {
+            DeleteOutcome outcome = service.deleteMapping(SUBJECT);
+
+            assertThat(outcome).isEqualTo(DeleteOutcome.DELETED);
+            verify(cip26MetadataRepository).deleteById(SUBJECT);
+        }
+
+        @Test
+        void returnsPermanentlyFailedOnNonTransientDataAccessException() {
+            doThrow(new DataIntegrityViolationException("fk violation"))
+                    .when(cip26MetadataRepository).deleteById(SUBJECT);
+
+            DeleteOutcome outcome = service.deleteMapping(SUBJECT);
+
+            assertThat(outcome).isEqualTo(DeleteOutcome.PERMANENTLY_FAILED);
+        }
+
+        @Test
+        void returnsTransientlyFailedOnTransientDataAccessException() {
+            doThrow(new CannotAcquireLockException("lock timeout"))
+                    .when(cip26MetadataRepository).deleteById(SUBJECT);
+
+            DeleteOutcome outcome = service.deleteMapping(SUBJECT);
+
+            assertThat(outcome).isEqualTo(DeleteOutcome.TRANSIENTLY_FAILED);
+        }
+
+        @Test
+        void returnsTransientlyFailedOnUnclassifiedException() {
+            // Unknown exception type — conservative default so a removed token
+            // is not silently left behind.
+            doThrow(new RuntimeException("DB error"))
+                    .when(cip26MetadataRepository).deleteById(SUBJECT);
+
+            DeleteOutcome outcome = service.deleteMapping(SUBJECT);
+
+            assertThat(outcome).isEqualTo(DeleteOutcome.TRANSIENTLY_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllSubjects")
+    class FindAllSubjects {
+
+        @Test
+        void delegatesToRepository() {
+            when(cip26MetadataRepository.findAllSubjects())
+                    .thenReturn(java.util.List.of("subject1", "subject2"));
+
+            assertThat(service.findAllSubjects()).containsExactly("subject1", "subject2");
         }
     }
 }

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/Cip26MetadataSyncServiceTest.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
 
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.ChangedMappings;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.Mapping;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.enums.SyncStatusEnum;
@@ -106,7 +107,7 @@ class Cip26MetadataSyncServiceTest {
 
             service.synchronizeDatabase();
 
-            verify(gitService, never()).getChangedFiles(any(), any());
+            verify(gitService, never()).getChangedMappings(any(), any());
             assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
         }
 
@@ -141,8 +142,8 @@ class Cip26MetadataSyncServiceTest {
                     .thenReturn(Optional.of(Path.of("/tmp/repo")));
             when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
 
-            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
-                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/test.json")));
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(Path.of("/tmp/repo/mappings/test.json")), List.of()));
 
             // filename ("test") MUST equal inner subject — the sync now skips mismatches deterministically.
             Mapping mockMapping = new Mapping("test", null, null, null, null, null, null, null);
@@ -157,6 +158,7 @@ class Cip26MetadataSyncServiceTest {
 
             verify(tokenMetadataService).insertMapping(any(), any(), any());
             verify(tokenMetadataService).insertLogo(any());
+            verify(tokenMetadataService, never()).deleteMapping(any());
             verify(syncStateRepository).save(any(Cip26SyncState.class));
             assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
             assertThat(service.getSyncStatus().isInitialSyncDone()).isTrue();
@@ -171,8 +173,8 @@ class Cip26MetadataSyncServiceTest {
                     .thenReturn(Optional.of(Path.of("/tmp/repo")));
             when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
 
-            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
-                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/fail.json")));
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(Path.of("/tmp/repo/mappings/fail.json")), List.of()));
 
             Mapping mockMapping = new Mapping("fail", null, null, null, null, null, null, null);
             when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mockMapping));
@@ -197,8 +199,8 @@ class Cip26MetadataSyncServiceTest {
                     .thenReturn(Optional.of(Path.of("/tmp/repo")));
             when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
 
-            when(gitService.getChangedFiles(OLD_HASH, NEW_HASH))
-                    .thenReturn(List.of(Path.of("/tmp/repo/mappings/perm.json")));
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(Path.of("/tmp/repo/mappings/perm.json")), List.of()));
 
             Mapping mockMapping = new Mapping("perm", null, null, null, null, null, null, null);
             when(tokenMappingService.parseMappings(any())).thenReturn(Optional.of(mockMapping));
@@ -235,8 +237,8 @@ class Cip26MetadataSyncServiceTest {
 
             service.synchronizeDatabase();
 
-            // Full sync doesn't call getChangedFiles — uses listFiles instead
-            verify(gitService, never()).getChangedFiles(any(), any());
+            // Full sync doesn't call getChangedMappings — uses listFiles instead
+            verify(gitService, never()).getChangedMappings(any(), any());
             assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
         }
     }
@@ -268,7 +270,10 @@ class Cip26MetadataSyncServiceTest {
 
             service.synchronizeDatabase();
 
-            verifyNoInteractions(tokenMetadataService);
+            // Full-sync reconciliation still reads the stored subjects, but nothing is written.
+            verify(tokenMetadataService, never()).insertMapping(any(), any(), any());
+            verify(tokenMetadataService, never()).insertLogo(any());
+            verify(tokenMetadataService, never()).deleteMapping(any());
             // Hash still advanced — parsing failures are skipped, not errors
             verify(syncStateRepository).save(any(Cip26SyncState.class));
         }
@@ -285,7 +290,10 @@ class Cip26MetadataSyncServiceTest {
 
             service.synchronizeDatabase();
 
-            verifyNoInteractions(tokenMetadataService);
+            // Full-sync reconciliation still reads the stored subjects, but nothing is written.
+            verify(tokenMetadataService, never()).insertMapping(any(), any(), any());
+            verify(tokenMetadataService, never()).insertLogo(any());
+            verify(tokenMetadataService, never()).deleteMapping(any());
             verify(syncStateRepository).save(any(Cip26SyncState.class));
         }
 
@@ -334,6 +342,118 @@ class Cip26MetadataSyncServiceTest {
             // Only the legit file's mapping made it through to insertMapping.
             verify(tokenMetadataService, times(1)).insertMapping(any(), any(), any());
             verify(syncStateRepository).save(any(Cip26SyncState.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("token removals")
+    class TokenRemovals {
+
+        @TempDir
+        Path repoDir;
+
+        @BeforeEach
+        void initStatus() {
+            assetsStoreProperties.getCip26().setEnabled(true);
+            service.initSyncStatus();
+            when(networkDefaults.isRegistryAvailable()).thenReturn(true);
+        }
+
+        private void stubIncrementalSync() {
+            when(syncStateRepository.findTopByOrderByIdDesc())
+                    .thenReturn(Optional.of(offChainState(OLD_HASH)));
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(Path.of("/tmp/repo")));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+        }
+
+        @Test
+        void incrementalSync_deletesTokensRemovedFromRegistry() {
+            stubIncrementalSync();
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(), List.of("removedtoken.json")));
+            when(tokenMetadataService.deleteMapping("removedtoken")).thenReturn(DeleteOutcome.DELETED);
+
+            service.synchronizeDatabase();
+
+            verify(tokenMetadataService).deleteMapping("removedtoken");
+            verify(tokenMetadataService, never()).insertMapping(any(), any(), any());
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+
+        @Test
+        void hashNotAdvanced_whenDeleteTransientlyFails() {
+            stubIncrementalSync();
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(), List.of("removedtoken.json")));
+            when(tokenMetadataService.deleteMapping("removedtoken"))
+                    .thenReturn(DeleteOutcome.TRANSIENTLY_FAILED);
+
+            service.synchronizeDatabase();
+
+            // A transiently-failed deletion must be retried on the next sync,
+            // so the commit hash is not advanced.
+            verify(syncStateRepository, never()).save(any());
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+
+        @Test
+        void hashAdvances_whenDeletePermanentlyFails() {
+            stubIncrementalSync();
+            when(gitService.getChangedMappings(OLD_HASH, NEW_HASH))
+                    .thenReturn(new ChangedMappings(List.of(), List.of("removedtoken.json")));
+            when(tokenMetadataService.deleteMapping("removedtoken"))
+                    .thenReturn(DeleteOutcome.PERMANENTLY_FAILED);
+
+            service.synchronizeDatabase();
+
+            // Permanent failures must NOT block the cursor — otherwise the sync
+            // would loop forever on a delete that can never succeed.
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+        }
+
+        @Test
+        void fullSync_deletesStaleSubjectsNoLongerInRegistry() throws IOException {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(repoDir));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+
+            Files.writeString(repoDir.resolve("presenttoken.json"), "{}");
+            when(tokenMappingService.parseMappings(any()))
+                    .thenReturn(Optional.of(new Mapping("presenttoken", null, null, null, null, null, null, null)));
+            when(gitService.getAllMappingDetails(any())).thenReturn(
+                    Map.of("presenttoken.json", new MappingUpdateDetails("author@test.com", LocalDateTime.now())));
+            when(tokenMetadataService.insertMapping(any(), any(), any()))
+                    .thenReturn(InsertOutcome.INSERTED);
+            when(tokenMetadataService.insertLogo(any())).thenReturn(InsertOutcome.INSERTED);
+            when(tokenMetadataService.findAllSubjects())
+                    .thenReturn(List.of("presenttoken", "staletoken"));
+            when(tokenMetadataService.deleteMapping("staletoken")).thenReturn(DeleteOutcome.DELETED);
+
+            service.synchronizeDatabase();
+
+            verify(tokenMetadataService).deleteMapping("staletoken");
+            verify(tokenMetadataService, never()).deleteMapping("presenttoken");
+            verify(syncStateRepository).save(any(Cip26SyncState.class));
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
+        }
+
+        @Test
+        void fullSync_skipsStaleCleanup_whenNoMappingFilesFound() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            when(gitService.cloneCardanoTokenRegistryGitRepository())
+                    .thenReturn(Optional.of(repoDir)); // empty temp dir — no mapping files
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(NEW_HASH));
+
+            service.synchronizeDatabase();
+
+            // An empty mappings folder is treated as a broken clone, not a registry
+            // where every token was removed — nothing must be deleted.
+            verify(tokenMetadataService, never()).findAllSubjects();
+            verify(tokenMetadataService, never()).deleteMapping(any());
+            assertThat(service.getSyncStatus().getStatus()).isEqualTo(SyncStatusEnum.SYNC_DONE);
         }
     }
 

--- a/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitServiceTest.java
+++ b/extensions/assets-ext/src/test/java/com/bloxbean/cardano/yaci/store/extensions/assetstore/cip26/service/GitServiceTest.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.service;
 
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.AssetsExtStoreProperties;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.Cip26NetworkDefaults;
+import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.ChangedMappings;
 import com.bloxbean.cardano.yaci.store.extensions.assetstore.cip26.model.MappingUpdateDetails;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -102,8 +103,17 @@ class GitServiceTest {
     }
 
     @Nested
-    @DisplayName("getChangedFiles")
-    class GetChangedFiles {
+    @DisplayName("getChangedMappings")
+    class GetChangedMappings {
+
+        private RevCommit deleteMappingFile(Git git, String fileName) throws Exception {
+            Path repoDir = git.getRepository().getWorkTree().toPath();
+            Files.delete(repoDir.resolve("mappings/" + fileName));
+            git.rm().addFilepattern("mappings/" + fileName).call();
+            return git.commit().setMessage("delete " + fileName)
+                    .setAuthor(new PersonIdent("Dev", "dev@test.com"))
+                    .call();
+        }
 
         @Test
         void returnsChangedMappingFiles() throws Exception {
@@ -114,15 +124,88 @@ class GitServiceTest {
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             String newHash = testRepo.log().setMaxCount(1).call().iterator().next().getName();
 
-            List<Path> changed = gitService.getChangedFiles(oldHash, newHash);
+            ChangedMappings changed = gitService.getChangedMappings(oldHash, newHash);
 
-            assertThat(changed).hasSize(1);
-            assertThat(changed.getFirst().getFileName().toString()).isEqualTo("token1.json");
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().getFirst().getFileName().toString()).isEqualTo("token1.json");
+            assertThat(changed.deletedFileNames()).isEmpty();
+        }
+
+        @Test
+        void reportsDeletedJsonFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+            String oldHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "token1.json");
+            String newHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(oldHash, newHash);
+
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).containsExactly("token1.json");
+        }
+
+        @Test
+        void filtersOutDeletedNonJsonFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "readme.txt", "text", "dev@test.com");
+            String oldHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "readme.txt");
+            String newHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(oldHash, newHash);
+
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
+        }
+
+        @Test
+        void reportsDeletionsAlongsideUpserts() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String oldHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "token1.json");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+            String newHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(oldHash, newHash);
+
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().getFirst().getFileName().toString()).isEqualTo("token2.json");
+            assertThat(changed.deletedFileNames()).containsExactly("token1.json");
+        }
+
+        @Test
+        void doesNotReportDeletionWhenFileIsDeletedAndReAddedWithinRange() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "token1.json", "{\"v\":1}", "dev@test.com");
+            String oldHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "token1.json");
+            addMappingFile(testRepo, "token1.json", "{\"v\":2}", "dev@test.com");
+            String newHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(oldHash, newHash);
+
+            // The tree diff sees the net change (a modification), not the intermediate delete.
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
         void returnsEmptyWhenGitIsNull() {
-            assertThat(gitService.getChangedFiles("aaa", "bbb")).isEmpty();
+            ChangedMappings changed = gitService.getChangedMappings("aaa", "bbb");
+
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -130,8 +213,12 @@ class GitServiceTest {
             testRepo = initRepoWithMappings();
             gitService.git = testRepo;
 
-            assertThat(gitService.getChangedFiles("0000000000000000000000000000000000000000",
-                    "1111111111111111111111111111111111111111")).isEmpty();
+            ChangedMappings changed = gitService.getChangedMappings(
+                    "0000000000000000000000000000000000000000",
+                    "1111111111111111111111111111111111111111");
+
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
     }
 


### PR DESCRIPTION
Cherry-pick of #1102 into release/2.0.x.

Cherry-picked commit: 7e51339b03ea4e1ea44e3578a45c1712fa774c67