### PR TITLE
fix(governance): avoid comparing unrelated drep vote indexes

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
@@ -189,13 +189,15 @@ public class VotingAggrService {
                 .when(VoterType.DREP_KEY_HASH.name(), StakeCredType.ADDR_KEYHASH.name())
                 .when(VoterType.DREP_SCRIPT_HASH.name(), StakeCredType.SCRIPTHASH.name());
 
-        // Unregistration clears every earlier vote; re-registration does not restore them.
+        // An unregistration invalidates a DRep's votes from earlier transactions and all of its
+        // votes in the same transaction:
+        // https://github.com/IntersectMBO/cardano-ledger/blob/15eee8cb0adfe94f8e26a7057b734b85ff8ee94e/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs#L610-L625
         var unregistrationAtOrAfterVote = dRepUnregistration.SLOT.gt(VOTING_PROCEDURE.SLOT)
                 .or(dRepUnregistration.SLOT.eq(VOTING_PROCEDURE.SLOT)
                         .and(dRepUnregistration.TX_INDEX.gt(VOTING_PROCEDURE.TX_INDEX)))
                 .or(dRepUnregistration.SLOT.eq(VOTING_PROCEDURE.SLOT)
                         .and(dRepUnregistration.TX_INDEX.eq(VOTING_PROCEDURE.TX_INDEX))
-                        .and(dRepUnregistration.CERT_INDEX.ge(VOTING_PROCEDURE.IDX)));
+                        .and(dRepUnregistration.TX_HASH.eq(VOTING_PROCEDURE.TX_HASH)));
 
         var rankedEffectiveVoteQuery = select(
                 VOTING_PROCEDURE.TX_HASH.as("tx_hash"),

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
@@ -65,6 +65,23 @@ class VotingAggrServiceTest {
     }
 
     @Test
+    void getVotesByDRep_excludesVoteWhenUnregistrationIsInSameTransaction() {
+        insertVote("vote-and-unregister", Vote.YES, 9, 100, 2, 2);
+        insertRegistration("vote-and-unregister", CertificateType.UNREG_DREP_CERT, 9, 100, 2, 0);
+
+        assertThat(getVotes()).isEmpty();
+    }
+
+    @Test
+    void getVotesByDRep_excludesSameTransactionVoteAfterReregistration() {
+        insertRegistration("unregister-reregister-and-vote", CertificateType.UNREG_DREP_CERT, 9, 100, 2, 0);
+        insertRegistration("unregister-reregister-and-vote", CertificateType.REG_DREP_CERT, 9, 100, 2, 1);
+        insertVote("unregister-reregister-and-vote", Vote.YES, 9, 100, 2, 2);
+
+        assertThat(getVotes()).isEmpty();
+    }
+
+    @Test
     void getVotesByDRep_ignoresUnregistrationAfterSnapshotEpoch() {
         insertVote("historical-vote", Vote.YES, SNAPSHOT_EPOCH, 100, 1, 0);
         insertRegistration("future-unregister", CertificateType.UNREG_DREP_CERT, SNAPSHOT_EPOCH + 1, 101, 0, 0);

--- a/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
+++ b/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
@@ -18,7 +18,7 @@ API status translation is intentionally separate from rule parity tests.
 | `GovernanceProposalApiStatusIT` | 1 | Public API status mapping from stored proposal status rows |
 | `GovernanceProposalOutcomeIT` | 2 | Post-bootstrap action outcome and ratification-gate parity |
 | `GovernanceDRepVoteTallyIT` | 2 | DRep vote aggregation, replacement, and accepted-ratio parity |
-| `GovernanceDRepLifecycleVoteTallyIT` | 1 | DRep unregister/re-registration lifecycle effect on active proposal tallies |
+| `GovernanceDRepLifecycleVoteTallyIT` | 1 | DRep unregister/re-registration and same-transaction cleanup effects on active proposal tallies |
 | `GovernanceSPOVoteTallyIT` | 2 | SPO stake distribution and mixed voting-group parity |
 | `GovernanceCommitteeVoteTallyIT` | 1 | Committee size and quorum parity |
 | `GovernanceRuleEdgeIT` | 6 active, 1 disabled | Proposal-scoped/default-vote reshaping and voter eligibility edges |
@@ -112,7 +112,7 @@ Covers post-bootstrap qualifier gates where votes would otherwise be sufficient:
 
 ## `GovernanceDRepLifecycleVoteTallyIT`
 
-### `dRepReregistration_shouldNotReviveStaleVoteAndShouldAcceptNewVote`
+### `dRepLifecycle_shouldClearInvalidatedVotesAndAcceptNewVote`
 
 - A DRep with dominant stake votes `YES`, unregisters, re-registers the same
   credential, and restores its delegation without casting a new vote for the proposal.
@@ -121,6 +121,15 @@ Covers post-bootstrap qualifier gates where votes would otherwise be sufficient:
   does not restore the cleared `YES` vote, so the proposal expires.
 - A control proposal verifies that a new `NO` vote cast after re-registration
   is counted while the earlier `YES` vote remains cleared.
+- A same-transaction regression creates two info proposals in one transaction,
+  then submits votes for both proposals together with DRep unregistration and
+  re-registration certificates. Re-registration leaves the DRep available to
+  the `GOV` rule after certificate processing, making the combined transaction valid.
+- The second vote has `voting_procedure.idx = 1` while the unregistration has
+  `drep_registration.cert_index = 0`; both votes must still be cleared because
+  ledger cleanup is transaction-wide and the two index spaces are unrelated.
+- The DRep delegation is restored before the outcome snapshot so distribution
+  eligibility cannot hide an incorrectly retained vote.
 - The test asserts effective voting stats and DB-vs-ledger outcome, not deletion of raw historical vote rows.
 
 ## `GovernanceSPOVoteTallyIT`

--- a/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
+++ b/e2e-tests/GOVERNANCE_DEVNET_IT_TEST_CASES.md
@@ -121,15 +121,18 @@ Covers post-bootstrap qualifier gates where votes would otherwise be sufficient:
   does not restore the cleared `YES` vote, so the proposal expires.
 - A control proposal verifies that a new `NO` vote cast after re-registration
   is counted while the earlier `YES` vote remains cleared.
-- A same-transaction regression creates two info proposals in one transaction,
-  then submits votes for both proposals together with DRep unregistration and
-  re-registration certificates. Re-registration leaves the DRep available to
-  the `GOV` rule after certificate processing, making the combined transaction valid.
+- A same-transaction regression creates an info proposal followed by a new-constitution
+  proposal, then submits votes for both proposals together with DRep unregistration and
+  re-registration certificates. The constitution proposal has enough committee support
+  and would ratify if the dominant DRep's invalidated `YES` vote were retained.
 - The second vote has `voting_procedure.idx = 1` while the unregistration has
   `drep_registration.cert_index = 0`; both votes must still be cleared because
   ledger cleanup is transaction-wide and the two index spaces are unrelated.
 - The DRep delegation is restored before the outcome snapshot so distribution
   eligibility cannot hide an incorrectly retained vote.
+- The test asserts that the restored stake remains in the distribution, calculates
+  the counterfactual accepted ratio, and verifies that the correctly cleared vote
+  changes the outcome from `RATIFIED` to `EXPIRED`.
 - The test asserts effective voting stats and DB-vs-ledger outcome, not deletion of raw historical vote rows.
 
 ## `GovernanceSPOVoteTallyIT`

--- a/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
+++ b/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
@@ -10,14 +10,20 @@ import com.bloxbean.cardano.client.transaction.spec.governance.Voter;
 import com.bloxbean.cardano.client.transaction.spec.governance.VoterType;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
+import com.bloxbean.cardano.yaci.store.common.model.Order;
+import com.bloxbean.cardano.yaci.store.governance.storage.DRepRegistrationStorageReader;
+import com.bloxbean.cardano.yaci.store.governance.storage.VotingProcedureStorageReader;
 import com.bloxbean.cardano.yaci.store.test.e2e.common.GovernanceTxHelper;
 import com.bloxbean.cardano.yaci.store.test.e2e.common.GovernanceTxHelper.CreatedProposal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.time.Duration;
 import java.util.List;
 
@@ -31,6 +37,12 @@ import static org.awaitility.Awaitility.await;
 @ContextConfiguration(initializers = AbstractGovernanceVoteTallyIT.DevKitInitializer.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
+
+    @Autowired
+    private VotingProcedureStorageReader votingProcedureStorageReader;
+
+    @Autowired
+    private DRepRegistrationStorageReader dRepRegistrationStorageReader;
 
     /**
      * Unregistering a DRep clears earlier and same-transaction votes; re-registration does not restore them.
@@ -84,22 +96,29 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                     assertThat(nz(stats.getDrepApprovalRatio())).isZero();
                 });
 
-        assertSameTransactionVotesAreCleared(removedYesDRep);
+        assertSameTransactionVotesAreCleared(
+                removedYesDRep,
+                remainingNoDRep,
+                removedYesStake,
+                remainingNoStake);
     }
 
-    private void assertSameTransactionVotesAreCleared(Account drepAccount) {
+    private void assertSameTransactionVotesAreCleared(Account drepAccount,
+                                                      Account remainingNoDRep,
+                                                      BigInteger expectedRestoredStake,
+                                                      BigInteger remainingNoStake) {
         CreatedProposal proposal = null;
         try {
             waitForEpoch(getCurrentEpoch() + 1);
-            var proposals = createSameTransactionInfoProposals();
+            var proposals = createSameTransactionProposals();
             proposal = proposals.get(1);
 
             assertThat(proposal.index()).isEqualTo(1);
-            assertThat(proposal.proposal().getType()).isEqualTo(GovActionType.INFO_ACTION);
+            assertThat(proposal.proposal().getType()).isEqualTo(GovActionType.NEW_CONSTITUTION);
             var indexed = governanceRuleAssertionHelper.findProposal(proposal.storeGovActionId());
             assertThat(indexed.getTxHash()).isEqualTo(proposal.txHash());
             assertThat(indexed.getIndex()).isEqualTo(proposal.index());
-            assertThat(indexed.getType()).isEqualTo(GovActionType.INFO_ACTION);
+            assertThat(indexed.getType()).isEqualTo(GovActionType.NEW_CONSTITUTION);
 
             CreatedProposal targetProposal = proposal;
             await().atMost(Duration.ofSeconds(90))
@@ -112,11 +131,33 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                         assertThat(snapshot.presentInExpiredGovActions()).isFalse();
                     });
 
-            castVotesUnregisterAndRegister(drepAccount, proposals);
+            governanceTxHelper.castDRepVote(
+                    account0,
+                    remainingNoDRep,
+                    proposal.storeGovActionId(),
+                    Vote.NO);
+            castCommitteeYesVotes(proposal, committeeAccounts.size());
+
+            String lifecycleTxHash = castVotesUnregisterAndRegister(drepAccount, proposals);
+            assertSameTransactionRegressionShape(lifecycleTxHash, proposal);
+
+            // Unregistration also clears delegations in the ledger. Restore the delegation and wait
+            // for a new stake snapshot so an EXPIRED result can only be caused by the cleared vote,
+            // not by the DRep being absent from the ratification distribution.
             governanceTxHelper.delegateVotingPowerToDRep(
                     account0,
                     drepAccount,
                     com.bloxbean.cardano.client.governance.GovId.toDrep(drepAccount.drepId()));
+            int restoredStakeEpoch = getCurrentEpoch() + 2;
+            waitForEpoch(restoredStakeEpoch);
+            waitTillAdaPotJobDone(
+                    adaPotJobRepository,
+                    restoredStakeEpoch,
+                    () -> sameTransactionDiagnostics(targetProposal));
+
+            BigInteger restoredStake = ledgerDRepStake(
+                    com.bloxbean.cardano.client.governance.GovId.toDrep(drepAccount.drepId()));
+            assertStake("re-registered DRep stake", restoredStake, expectedRestoredStake);
 
             int statusProcessingEpoch = proposal.expiryStatusEpoch();
             waitForEpoch(statusProcessingEpoch);
@@ -131,10 +172,38 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
             governanceRuleAssertionHelper.assertVotingStats(
                     proposal.storeGovActionId(),
                     outcomeRow.getEpoch(),
-                    stats -> assertStake(
-                            "same-transaction DRep YES stake",
-                            stats.getDrepYesVoteStake(),
-                            BigInteger.ZERO));
+                    stats -> {
+                        assertStake(
+                                "same-transaction DRep YES stake",
+                                stats.getDrepYesVoteStake(),
+                                BigInteger.ZERO);
+                        assertStake(
+                                "remaining DRep NO stake",
+                                stats.getDrepNoVoteStake(),
+                                remainingNoStake);
+                        assertThat(nz(stats.getDrepDoNotVoteStake()))
+                                .as("restored DRep stake remains in the ratification distribution")
+                                .isGreaterThanOrEqualTo(restoredStake);
+                        assertCommitteePassed(stats);
+
+                        BigInteger actualYes = nz(stats.getDrepTotalYesStake());
+                        BigInteger actualNo = nz(stats.getDrepTotalNoStake());
+                        assertThat(actualNo).isGreaterThanOrEqualTo(restoredStake);
+
+                        // A same-transaction unregistration invalidates this vote even though the DRep
+                        // is active again at the snapshot. Counting the invalidated stake as YES instead
+                        // of do-not-vote/NO would cross the constitution ratification threshold.
+                        BigInteger counterfactualYes = actualYes.add(restoredStake);
+                        BigInteger counterfactualNo = actualNo.subtract(restoredStake);
+                        BigDecimal counterfactualRatio = new BigDecimal(counterfactualYes)
+                                .divide(
+                                        new BigDecimal(counterfactualYes.add(counterfactualNo)),
+                                        8,
+                                        RoundingMode.HALF_UP);
+                        assertThat(counterfactualRatio)
+                                .as("DRep ratio if the same-transaction vote were not cleared")
+                                .isGreaterThanOrEqualTo(DREP_UPDATE_TO_CONSTITUTION_THRESHOLD);
+                    });
             governanceRuleAssertionHelper.assertDbStatusMatchesLedgerSnapshot(
                     proposal.storeGovActionId(),
                     GovActionStatus.EXPIRED);
@@ -146,12 +215,12 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
         }
     }
 
-    private List<CreatedProposal> createSameTransactionInfoProposals() {
+    private List<CreatedProposal> createSameTransactionProposals() {
         Anchor firstAnchor = GovernanceTxHelper.defaultAnchor();
-        Anchor secondAnchor = new Anchor("https://xyz.com/info/1", firstAnchor.getAnchorDataHash());
+        Anchor secondAnchor = new Anchor("https://xyz.com/constitution/1", firstAnchor.getAnchorDataHash());
         var tx = new Tx()
                 .createProposal(GovernanceTxHelper.infoAction(), account0.stakeAddress(), firstAnchor)
-                .createProposal(GovernanceTxHelper.infoAction(), account0.stakeAddress(), secondAnchor)
+                .createProposal(newConstitutionAction(), account0.stakeAddress(), secondAnchor)
                 .from(account0.baseAddress());
 
         var result = new QuickTxBuilder(backendService).compose(tx)
@@ -166,7 +235,7 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                 governanceTxHelper.waitForCreatedProposal(result.getValue(), 1));
     }
 
-    private void castVotesUnregisterAndRegister(Account drepAccount, List<CreatedProposal> proposals) {
+    private String castVotesUnregisterAndRegister(Account drepAccount, List<CreatedProposal> proposals) {
         var voter = new Voter(VoterType.DREP_KEY_HASH, drepAccount.drepCredential());
         var tx = new Tx();
         for (CreatedProposal proposal : proposals) {
@@ -187,6 +256,38 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
 
         assertThat(result.isSuccessful()).as(result.toString()).isTrue();
         checkIfUtxoAvailable(result.getValue(), account0.baseAddress());
+        return result.getValue();
+    }
+
+    private void assertSameTransactionRegressionShape(String txHash, CreatedProposal targetProposal) {
+        await().atMost(Duration.ofSeconds(90))
+                .pollInterval(Duration.ofSeconds(2))
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    var targetVotes = votingProcedureStorageReader.findByTxHash(txHash).stream()
+                            .filter(vote -> vote.getGovActionTxHash().equals(targetProposal.txHash()))
+                            .filter(vote -> vote.getGovActionIndex().equals(targetProposal.index()))
+                            .toList();
+                    var unregistrations = dRepRegistrationStorageReader
+                            .findDeRegistrations(0, 500, Order.desc)
+                            .stream()
+                            .filter(registration -> registration.getTxHash().equals(txHash))
+                            .toList();
+
+                    assertThat(targetVotes).singleElement();
+                    assertThat(unregistrations).singleElement();
+
+                    var targetVote = targetVotes.getFirst();
+                    var unregistration = unregistrations.getFirst();
+                    assertThat(targetVote.getTxIndex()).isEqualTo(unregistration.getTxIndex());
+                    assertThat(targetVote.getIndex()).isEqualTo(1L);
+                    assertThat(unregistration.getCertIndex()).isZero();
+
+                    // Regression fixture for https://github.com/bloxbean/yaci-store/issues/1108.
+                    // Voting-procedure and certificate indexes belong to unrelated collections;
+                    // their inequality only confirms that this transaction exercises the reported case.
+                    assertThat(targetVote.getIndex()).isGreaterThan(unregistration.getCertIndex());
+                });
     }
 
     private String sameTransactionDiagnostics(CreatedProposal proposal) {

--- a/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
+++ b/e2e-tests/src/test/java/com/bloxbean/cardano/yaci/store/test/e2e/gov/GovernanceDRepLifecycleVoteTallyIT.java
@@ -1,18 +1,28 @@
 package com.bloxbean.cardano.yaci.store.test.e2e.gov;
 
 import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.function.helper.SignerProviders;
+import com.bloxbean.cardano.client.quicktx.QuickTxBuilder;
+import com.bloxbean.cardano.client.quicktx.Tx;
+import com.bloxbean.cardano.client.transaction.spec.governance.Anchor;
 import com.bloxbean.cardano.client.transaction.spec.governance.Vote;
+import com.bloxbean.cardano.client.transaction.spec.governance.Voter;
+import com.bloxbean.cardano.client.transaction.spec.governance.VoterType;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
 import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
 import com.bloxbean.cardano.yaci.store.test.e2e.common.GovernanceTxHelper;
+import com.bloxbean.cardano.yaci.store.test.e2e.common.GovernanceTxHelper.CreatedProposal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * DRep lifecycle rows are isolated because registration changes are irreversible within a devnet run.
@@ -23,10 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
 
     /**
-     * Re-registering a DRep does not restore votes cleared by its earlier deregistration.
+     * Unregistering a DRep clears earlier and same-transaction votes; re-registration does not restore them.
      */
     @Test
-    void dRepReregistration_shouldNotReviveStaleVoteAndShouldAcceptNewVote() {
+    void dRepLifecycle_shouldClearInvalidatedVotesAndAcceptNewVote() {
         ensureDRepUnregisterFixture();
 
         Account removedYesDRep = accountAt(5);
@@ -73,6 +83,115 @@ class GovernanceDRepLifecycleVoteTallyIT extends AbstractGovernanceVoteTallyIT {
                     assertStake("post-registration DRep NO stake", stats.getDrepNoVoteStake(), removedYesStake);
                     assertThat(nz(stats.getDrepApprovalRatio())).isZero();
                 });
+
+        assertSameTransactionVotesAreCleared(removedYesDRep);
+    }
+
+    private void assertSameTransactionVotesAreCleared(Account drepAccount) {
+        CreatedProposal proposal = null;
+        try {
+            waitForEpoch(getCurrentEpoch() + 1);
+            var proposals = createSameTransactionInfoProposals();
+            proposal = proposals.get(1);
+
+            assertThat(proposal.index()).isEqualTo(1);
+            assertThat(proposal.proposal().getType()).isEqualTo(GovActionType.INFO_ACTION);
+            var indexed = governanceRuleAssertionHelper.findProposal(proposal.storeGovActionId());
+            assertThat(indexed.getTxHash()).isEqualTo(proposal.txHash());
+            assertThat(indexed.getIndex()).isEqualTo(proposal.index());
+            assertThat(indexed.getType()).isEqualTo(GovActionType.INFO_ACTION);
+
+            CreatedProposal targetProposal = proposal;
+            await().atMost(Duration.ofSeconds(90))
+                    .pollInterval(Duration.ofSeconds(2))
+                    .ignoreExceptions()
+                    .untilAsserted(() -> {
+                        var snapshot = ledgerStateReader.fetchProposalState(targetProposal.storeGovActionId());
+                        assertThat(snapshot.presentInCurrentProposals()).isTrue();
+                        assertThat(snapshot.presentInEnactedGovActions()).isFalse();
+                        assertThat(snapshot.presentInExpiredGovActions()).isFalse();
+                    });
+
+            castVotesUnregisterAndRegister(drepAccount, proposals);
+            governanceTxHelper.delegateVotingPowerToDRep(
+                    account0,
+                    drepAccount,
+                    com.bloxbean.cardano.client.governance.GovId.toDrep(drepAccount.drepId()));
+
+            int statusProcessingEpoch = proposal.expiryStatusEpoch();
+            waitForEpoch(statusProcessingEpoch);
+            waitTillAdaPotJobDone(
+                    adaPotJobRepository,
+                    statusProcessingEpoch,
+                    () -> sameTransactionDiagnostics(targetProposal));
+
+            var outcomeRow = governanceRuleAssertionHelper.assertLatestDbStatus(
+                    proposal.storeGovActionId(),
+                    GovActionStatus.EXPIRED);
+            governanceRuleAssertionHelper.assertVotingStats(
+                    proposal.storeGovActionId(),
+                    outcomeRow.getEpoch(),
+                    stats -> assertStake(
+                            "same-transaction DRep YES stake",
+                            stats.getDrepYesVoteStake(),
+                            BigInteger.ZERO));
+            governanceRuleAssertionHelper.assertDbStatusMatchesLedgerSnapshot(
+                    proposal.storeGovActionId(),
+                    GovActionStatus.EXPIRED);
+        } catch (AssertionError | RuntimeException e) {
+            throw new AssertionError(
+                    "Governance vote tally scenario failed: DRep unregistration clears every vote in the same transaction.\n"
+                            + sameTransactionDiagnostics(proposal),
+                    e);
+        }
+    }
+
+    private List<CreatedProposal> createSameTransactionInfoProposals() {
+        Anchor firstAnchor = GovernanceTxHelper.defaultAnchor();
+        Anchor secondAnchor = new Anchor("https://xyz.com/info/1", firstAnchor.getAnchorDataHash());
+        var tx = new Tx()
+                .createProposal(GovernanceTxHelper.infoAction(), account0.stakeAddress(), firstAnchor)
+                .createProposal(GovernanceTxHelper.infoAction(), account0.stakeAddress(), secondAnchor)
+                .from(account0.baseAddress());
+
+        var result = new QuickTxBuilder(backendService).compose(tx)
+                .withSigner(SignerProviders.drepKeySignerFrom(account0))
+                .withSigner(SignerProviders.signerFrom(account0))
+                .completeAndWait(System.out::println);
+
+        assertThat(result.isSuccessful()).as(result.toString()).isTrue();
+        checkIfUtxoAvailable(result.getValue(), account0.baseAddress());
+        return List.of(
+                governanceTxHelper.waitForCreatedProposal(result.getValue(), 0),
+                governanceTxHelper.waitForCreatedProposal(result.getValue(), 1));
+    }
+
+    private void castVotesUnregisterAndRegister(Account drepAccount, List<CreatedProposal> proposals) {
+        var voter = new Voter(VoterType.DREP_KEY_HASH, drepAccount.drepCredential());
+        var tx = new Tx();
+        for (CreatedProposal proposal : proposals) {
+            tx.createVote(
+                    voter,
+                    GovernanceTxHelper.clientGovActionId(proposal.storeGovActionId()),
+                    Vote.YES,
+                    GovernanceTxHelper.defaultAnchor());
+        }
+        tx.unregisterDRep(drepAccount.drepCredential())
+                .registerDRep(drepAccount, GovernanceTxHelper.defaultAnchor())
+                .from(account0.baseAddress());
+
+        var result = new QuickTxBuilder(backendService).compose(tx)
+                .withSigner(SignerProviders.signerFrom(account0))
+                .withSigner(SignerProviders.drepKeySignerFrom(drepAccount))
+                .completeAndWait(System.out::println);
+
+        assertThat(result.isSuccessful()).as(result.toString()).isTrue();
+        checkIfUtxoAvailable(result.getValue(), account0.baseAddress());
+    }
+
+    private String sameTransactionDiagnostics(CreatedProposal proposal) {
+        return "currentEpoch=" + getCurrentEpoch()
+                + "\nproposal=" + (proposal == null ? "not-created" : proposal.storeGovActionId());
     }
 
     private void registerDRepAndRestoreDelegation(Account drepAccount) {


### PR DESCRIPTION
## Summary

  Correct DRep vote aggregation by removing the comparison between voting_procedure.idx and drep_registration.cert_index.

  These indexes belong to different transaction-body collections and have no meaningful ordering relationship. Same-transaction unregistration is now detected using transaction identity, aligning effective vote selection with
  Cardano ledger semantics.

  Fixes #1108.
  Related to #1054.

  ## Root cause

  `VotingAggrService#getVotesByDRep` used drep_registration.cert_index >= voting_procedure.idx when a vote and DRep unregistration shared the same slot and transaction index.

  This could incorrectly retain or remove a vote because:

  - voting_procedure.idx identifies a governance action within a voter's voting procedures.
  - drep_registration.cert_index identifies a certificate within the transaction certificate list.
  - The two indexes are independent and must not be compared.

  A DRep unregistration invalidates votes from earlier transactions and all votes from that DRep in the same transaction. The ledger implements same-transaction cleanup without comparing certificate and voting-procedure indexes:

  https://github.com/IntersectMBO/cardano-ledger/blob/15eee8cb0adfe94f8e26a7057b734b85ff8ee94e/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs#L610-L625

  The integration test added in #1054 passed because it exercised vote, unregistration, re-registration, delegation, and replacement vote across separate transactions. It did not exercise the invalid same-transaction index
  comparison.

  ## Changes

  - Replace the same-transaction cert_index/idx comparison with transaction hash equality.
  - Preserve the existing slot and transaction-index ordering for unregistrations in later transactions.
  - Add unit coverage for:
      - a vote and unregistration stored in the same transaction;
      - same-transaction unregistration, re-registration, and voting.

  - Extend GovernanceDRepLifecycleVoteTallyIT with a deterministic ledger-valid scenario:
      - create two InfoAction proposals in one transaction;
      - target the second proposal, producing voting_procedure.idx = 1;
      - submit votes together with an unregistration at cert_index = 0 and a subsequent re-registration;
      - restore delegation before the outcome snapshot;
      - verify that the target DRep vote stake remains zero.

  - Update the governance DevKit test-case documentation.

  The re-registration certificate keeps the DRep available after certificate processing, allowing the ledger GOV rule to process the votes and then remove them due to the unregistration in the same transaction.

  No schema migration is required.

  ## Testing

  - ./gradlew :aggregates:governance-aggr:test --tests com.bloxbean.cardano.yaci.store.governanceaggr.service.VotingAggrServiceTest --console=plain
  - ./gradlew :aggregates:governance-aggr:test
  - ./gradlew :e2e-tests:compileTestJava --console=plain
  - ./gradlew :e2e-tests:test -PrunE2ETests --tests com.bloxbean.cardano.yaci.store.test.e2e.gov.GovernanceDRepLifecycleVoteTallyIT --console=plain
      - Run against a clean Yaci DevKit devnet
      - 1 test, 0 failures