### PR TITLE
fix(submit): register blst for native image

### DIFF
--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/jni-config.json
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/jni-config.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "supranational.blst.blstJNI",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.blst",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Pairing",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.PT",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Scalar",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.SecretKey",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.BLST_ERROR",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/native-image.properties
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=supranational.blst

--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/resource-config.json
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/resource-config.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "supranational/blst/Linux/amd64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Linux/aarch64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Mac/x86_64/libblst\\.dylib"
+      },
+      {
+        "pattern": "supranational/blst/Mac/aarch64/libblst\\.dylib"
+      }
+    ]
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.7.2"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.7.2"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.7.2"
 cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.7.2"
-scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0"
+scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:1.1.0"
 
 cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.2"
 


### PR DESCRIPTION
## Summary

- register the bundled Linux and macOS blst native libraries as GraalVM image resources
- register the blst SWIG classes and methods for JNI access
- initialize supranational.blst at image runtime so its native loader can extract and load the platform library
- keep the metadata in components/submit so every native application using the Scalus evaluator inherits it

## Verification

- ran the components:submit test suite and JAR build successfully with Oracle GraalVM 21.0.5
- built applications/all with profile=all using Oracle GraalVM Native Image 21.0.5; nativeCompile completed successfully and produced a macOS ARM64 executable
- verified the submit JAR contains native-image.properties, resource-config.json, and jni-config.json under META-INF/native-image/yaci-store-submit
- verified the generated native executable embeds supranational/blst/Mac/aarch64/libblst.dylib and supranational.blst.blstJNI

An end-to-end evaluation of a BLS12-381 Plutus transaction through the native Store endpoint was not run; that requires a configured Store database/network and a suitable transaction fixture.

Fixes #1045