### PR TITLE
[Merge to main] fix(submit): register blst for native image

### DIFF
--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/jni-config.json
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/jni-config.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "supranational.blst.blstJNI",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.blst",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Pairing",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.PT",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Scalar",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.SecretKey",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.BLST_ERROR",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/native-image.properties
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=supranational.blst

--- a/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/resource-config.json
+++ b/components/submit/src/main/resources/META-INF/native-image/yaci-store-submit/resource-config.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "supranational/blst/Linux/amd64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Linux/aarch64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Mac/x86_64/libblst\\.dylib"
+      },
+      {
+        "pattern": "supranational/blst/Mac/aarch64/libblst\\.dylib"
+      }
+    ]
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ cardano-client-lib = "com.bloxbean.cardano:cardano-client-lib:0.8.0-pre4"
 cardano-client-backend = "com.bloxbean.cardano:cardano-client-backend:0.8.0-pre4"
 cardano-client-backend-ogmios = "com.bloxbean.cardano:cardano-client-backend-ogmios:0.8.0-pre4"
 cardano-client-backend-blockfrost = "com.bloxbean.cardano:cardano-client-backend-blockfrost:0.8.0-pre4"
-scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0"
+scalus-bloxbean-cardano-client-lib = "org.scalus:scalus-bloxbean-cardano-client-lib_3:1.1.0"
 
 cf-rewards="org.cardanofoundation:cf-rewards-calculation:1.0.2"
 


### PR DESCRIPTION
## Summary

- port the native-image blst support from #1113 to main
- register bundled Linux and macOS blst native libraries as GraalVM image resources
- register the blst SWIG classes and methods for JNI access
- initialize supranational.blst at image runtime
- upgrade Scalus from 0.17.0 to 1.1.0
- preserve main's newer Yaci and Cardano Client Library versions while resolving the cherry-pick conflict

## Verification

- `JAVA_HOME=/Users/satya/.sdkman/candidates/java/21-librca ./gradlew :components:submit:test :components:submit:jar --console=plain`
- verified the generated submit JAR contains `native-image.properties`, `resource-config.json`, and `jni-config.json` under `META-INF/native-image/yaci-store-submit`

Source PR: #1113

Fixes #1045