### PR TITLE
 [Merge to 2.0.x] fix(governance): backport DRep active_until replay fix

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepExpiryService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepExpiryService.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.core.model.certs.CertificateType;
 import com.bloxbean.cardano.yaci.core.model.governance.DrepType;
 import com.bloxbean.cardano.yaci.core.model.governance.VoterType;
+import com.bloxbean.cardano.yaci.store.common.domain.GovActionStatus;
 import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
 import com.bloxbean.cardano.yaci.store.common.util.ListUtil;
 import com.bloxbean.cardano.yaci.store.common.util.Tuple;
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
 import static com.bloxbean.cardano.yaci.store.epoch.jooq.Tables.EPOCH_PARAM;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.*;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
-import static com.bloxbean.cardano.yaci.store.governanceaggr.util.DRepExpiryUtil.isEpochRangeDormant;
+import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.GOV_ACTION_PROPOSAL_STATUS;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +45,6 @@ public class DRepExpiryService {
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final EraService eraService;
     private final GovEpochActivityRepository govEpochActivityRepository;
-    private final GovEpochActivityService govEpochActivityService;
     private final DSLContext dsl;
     private final ObjectMapper objectMapper;
 
@@ -74,18 +74,23 @@ public class DRepExpiryService {
 
         Map<Tuple<String, DrepType>, DRepExpiryUtil.DRepRegistrationInfo> registrationMap = new ConcurrentHashMap<>();
         Map<Tuple<String, DrepType>, DRepExpiryUtil.DRepInteractionInfo> lastInteractionMap = new ConcurrentHashMap<>();
+        Map<Tuple<String, DrepType>, List<DRepExpiryUtil.DRepInteractionInfo>> interactionEventsMap = new ConcurrentHashMap<>();
 
         targetDRepsBatches.parallelStream().forEach(batch -> {
             Map<Tuple<String, DrepType>, DRepExpiryUtil.DRepRegistrationInfo> batchRegistrationMap =
                     findRegistrationInfos(batch, leftBoundaryEpoch);
             Map<Tuple<String, DrepType>, DRepExpiryUtil.DRepInteractionInfo> batchInteractionMap =
                     findLastInteractions(batch, leftBoundaryEpoch);
+            Map<Tuple<String, DrepType>, List<DRepExpiryUtil.DRepInteractionInfo>> batchInteractionEventsMap =
+                    findInteractionInfos(batch, leftBoundaryEpoch);
 
             registrationMap.putAll(batchRegistrationMap);
             lastInteractionMap.putAll(batchInteractionMap);
+            interactionEventsMap.putAll(batchInteractionEventsMap);
         });
 
         Set<Integer> dormantEpochsToLeftBoundaryEpoch = govEpochActivityRepository.findDormantEpochsInEpochRange(firstEpochNoInConwayOrLater, leftBoundaryEpoch);
+        Set<Integer> nonDormantProposalEpochsToLeftBoundaryEpoch = findNonDormantProposalStatusEpochs(firstEpochNoInConwayOrLater, leftBoundaryEpoch);
 
         List<DRepExpiryUtil.ProposalSubmissionInfo> proposalSubmissionInfos = findProposalWithEpochLessThanOrEqualTo(leftBoundaryEpoch);
 
@@ -94,18 +99,7 @@ public class DRepExpiryService {
                         .reversed())
                 .toList();
 
-        DRepExpiryUtil.ProposalSubmissionInfo mostRecentProposal = proposalSubmissionInfos.stream()
-                .max(Comparator.comparingLong(DRepExpiryUtil.ProposalSubmissionInfo::slot))
-                .orElse(null);
-
         List<MapSqlParameterSource> batch = new ArrayList<>();
-
-        var recentGovEpochActivityOpt = govEpochActivityService.getGovEpochActivity(leftBoundaryEpoch);
-
-        if (recentGovEpochActivityOpt.isEmpty()) {
-            log.error("GovEpochActivityEntity not found for epoch {}", leftBoundaryEpoch);
-            return;
-        }
 
         for (Tuple<String, DrepType> dRep : targetDReps) {
             var dRepRegistration = registrationMap.get(dRep);
@@ -140,40 +134,15 @@ public class DRepExpiryService {
                     leftBoundaryEpoch
             );
 
-            /* Calculate active_until value */
-            boolean isLeftBoundaryEpochDormant = dormantEpochsToLeftBoundaryEpoch.contains(leftBoundaryEpoch);
-            int dormantEpochCount = recentGovEpochActivityOpt.get().getDormantEpochCount();
-            boolean leftBoundaryEpochHadNewProposal = false;
+            int activeUntil = DRepExpiryUtil.calculateDRepActiveUntil(
+                    dRepRegistration,
+                    interactionEventsMap.getOrDefault(dRep, Collections.emptyList()),
+                    proposalSubmissionInfos,
+                    nonDormantProposalEpochsToLeftBoundaryEpoch,
+                    firstEpochNoInConwayOrLater,
+                    leftBoundaryEpoch
+            );
 
-            // check if the left boundary epoch had a proposal
-            if (isLeftBoundaryEpochDormant && mostRecentProposal != null) {
-                int mostRecentProposalEpoch = mostRecentProposal.epoch();
-                if (mostRecentProposalEpoch == leftBoundaryEpoch) {
-                    leftBoundaryEpochHadNewProposal = true;
-                }
-            }
-
-            int activeUntil = expiry;
-
-            /* if the left boundary epoch is dormant and there was no new proposal (dormant period is ongoing), drep is not inactive,
-             we should set activeUntil to expiry - dormantEpochCount
-             the active_until value is only updated after the dormant period ends. */
-            if (isLeftBoundaryEpochDormant && !leftBoundaryEpochHadNewProposal && expiry >= leftBoundaryEpoch) { // TODO: expiry >= leftBoundaryEpoch or expiry > leftBoundaryEpoch?
-                activeUntil = expiry - dormantEpochCount;
-            }
-
-            // continue adjusting the active_until value, if the drep was registered in a dormant period and in V9
-            if (dRepLastInteraction == null|| dRepLastInteraction.epoch() < dRepRegistration.epoch()) {
-                int dRepRegistrationEpoch = dRepRegistration.epoch();
-                // check left boundary epoch is in a dormant period , no proposal in left boundary epoch
-                // and drep was registered in this dormant period and drep registration is in V9
-                if (isEpochRangeDormant(dRepRegistrationEpoch, leftBoundaryEpoch, dormantEpochsToLeftBoundaryEpoch)
-                        && !leftBoundaryEpochHadNewProposal && dRepRegistration.protocolMajorVersion() == 9) {
-                    activeUntil = dRepRegistrationEpoch + dRepRegistration.dRepActivity();
-                }
-            }
-
-            /* active_until calculation ends */
             batch.add(new MapSqlParameterSource()
                     .addValue("drep_hash", dRep._1)
                     .addValue("drep_type", dRep._2.name())
@@ -232,10 +201,14 @@ public class DRepExpiryService {
                         DREP_REGISTRATION.CRED_TYPE,
                         DREP_REGISTRATION.SLOT,
                         DREP_REGISTRATION.EPOCH,
+                        DREP_REGISTRATION.TX_INDEX,
+                        DREP_REGISTRATION.CERT_INDEX,
                         DSL.rowNumber()
                                 .over()
                                 .partitionBy(DREP_REGISTRATION.DREP_HASH, DREP_REGISTRATION.CRED_TYPE)
-                                .orderBy(DREP_REGISTRATION.SLOT.desc())
+                                .orderBy(DREP_REGISTRATION.SLOT.desc(),
+                                        DREP_REGISTRATION.TX_INDEX.desc(),
+                                        DREP_REGISTRATION.CERT_INDEX.desc())
                                 .as("rn")
                 )
                 .from(DREP_REGISTRATION)
@@ -251,6 +224,8 @@ public class DRepExpiryService {
                     ranked.field(DREP_REGISTRATION.CRED_TYPE),
                     ranked.field(DREP_REGISTRATION.SLOT),
                     ranked.field(DREP_REGISTRATION.EPOCH),
+                    ranked.field(DREP_REGISTRATION.TX_INDEX),
+                    ranked.field(DREP_REGISTRATION.CERT_INDEX),
                     drepActivityField.cast(Integer.class).as("drep_activity"),
                     protocolMajorVerField.cast(Integer.class).as("protocol_major_ver")
             )
@@ -264,6 +239,8 @@ public class DRepExpiryService {
                     ranked.field(DREP_REGISTRATION.CRED_TYPE),
                     ranked.field(DREP_REGISTRATION.SLOT),
                     ranked.field(DREP_REGISTRATION.EPOCH),
+                    ranked.field(DREP_REGISTRATION.TX_INDEX),
+                    ranked.field(DREP_REGISTRATION.CERT_INDEX),
                     EPOCH_PARAM.PARAMS
             )
             .from(ranked)
@@ -278,6 +255,8 @@ public class DRepExpiryService {
             DrepType type = DrepType.valueOf(record.get(DREP_REGISTRATION.CRED_TYPE));
             long registrationSlot = record.get(DREP_REGISTRATION.SLOT);
             int registrationEpoch = record.get(DREP_REGISTRATION.EPOCH);
+            int txIndex = record.get(DREP_REGISTRATION.TX_INDEX);
+            int certIndex = record.get(DREP_REGISTRATION.CERT_INDEX);
             int drepActivity = 0;
             int protocolMajorVer = 0;
 
@@ -296,7 +275,116 @@ public class DRepExpiryService {
                 protocolMajorVer = record.get("protocol_major_ver", Integer.class);
             }
 
-            map.put(new Tuple<>(hash, type), new DRepExpiryUtil.DRepRegistrationInfo(registrationSlot, registrationEpoch, drepActivity, protocolMajorVer));
+            map.put(new Tuple<>(hash, type), new DRepExpiryUtil.DRepRegistrationInfo(registrationSlot, registrationEpoch, drepActivity, protocolMajorVer, txIndex, certIndex));
+        }
+
+        return map;
+    }
+
+    private Map<Tuple<String, DrepType>, List<DRepExpiryUtil.DRepInteractionInfo>> findInteractionInfos(Set<Tuple<String, DrepType>> drepHashAndTypes, int epoch) {
+        if (drepHashAndTypes.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Field<String> drepActivityField = null;
+        SQLDialect dialect = dsl.dialect();
+
+        if (dialect.family() == SQLDialect.POSTGRES) {
+            drepActivityField = DSL.field("params->>'drep_activity'", String.class);
+        } else if (dialect.family() == SQLDialect.MYSQL) {
+            drepActivityField = DSL.function("JSON_EXTRACT", SQLDataType.VARCHAR, DSL.field("params"), DSL.inline("$.drep_activity"));
+        }
+
+        List<Condition> dRepRegConditions = drepHashAndTypes
+                .stream()
+                .map(t -> DREP_REGISTRATION.DREP_HASH.eq(t._1).and(DREP_REGISTRATION.CRED_TYPE.eq(t._2.name())))
+                .collect(Collectors.toList());
+
+        var updates = dsl.select(DREP_REGISTRATION.DREP_HASH.as("drep_hash"), DREP_REGISTRATION.CRED_TYPE.as("drep_type"),
+                        DREP_REGISTRATION.EPOCH.as("epoch"), DREP_REGISTRATION.SLOT.as("slot"),
+                        DREP_REGISTRATION.TX_INDEX.as("tx_index"), DREP_REGISTRATION.CERT_INDEX.as("event_index"))
+                .from(DREP_REGISTRATION)
+                .where(DREP_REGISTRATION.TYPE.eq(CertificateType.UPDATE_DREP_CERT.name())
+                        .and(DREP_REGISTRATION.EPOCH.le(epoch))
+                        .and(DSL.or(dRepRegConditions)));
+
+        Set<Tuple<String, VoterType>> drepAndVoterTypes = drepHashAndTypes.stream()
+                .map(t -> new Tuple<>(t._1, t._2 == DrepType.ADDR_KEYHASH ? VoterType.DREP_KEY_HASH : VoterType.DREP_SCRIPT_HASH))
+                .collect(Collectors.toSet());
+
+        List<Condition> voteConditions = drepAndVoterTypes
+                .stream()
+                .map(t -> VOTING_PROCEDURE.VOTER_HASH.eq(t._1).and(VOTING_PROCEDURE.VOTER_TYPE.eq(t._2.name())))
+                .toList();
+
+        var votes = dsl.select(VOTING_PROCEDURE.VOTER_HASH.as("drep_hash"),
+                        DSL.decode()
+                                .value(VOTING_PROCEDURE.VOTER_TYPE)
+                                .when(VoterType.DREP_KEY_HASH.name(), DrepType.ADDR_KEYHASH.name())
+                                .when(VoterType.DREP_SCRIPT_HASH.name(), DrepType.SCRIPTHASH.name())
+                                .as("drep_type"),
+                        VOTING_PROCEDURE.EPOCH.as("epoch"), VOTING_PROCEDURE.SLOT.as("slot"),
+                        VOTING_PROCEDURE.TX_INDEX.as("tx_index"), VOTING_PROCEDURE.IDX.as("event_index"))
+                .from(VOTING_PROCEDURE)
+                .where(VOTING_PROCEDURE.EPOCH.le(epoch)).and(DSL.or(voteConditions));
+
+        var interactionSubquery = updates.unionAll(votes).asTable("sub");
+
+        Result<?> result;
+        if (dialect.family() == SQLDialect.POSTGRES || dialect.family() == SQLDialect.MYSQL) {
+            result = dsl.select(
+                    interactionSubquery.field("drep_hash", String.class),
+                    interactionSubquery.field("drep_type", String.class),
+                    interactionSubquery.field("epoch", Integer.class),
+                    interactionSubquery.field("slot", Long.class),
+                    interactionSubquery.field("tx_index", Integer.class),
+                    interactionSubquery.field("event_index", Integer.class),
+                    drepActivityField.cast(Integer.class).as("drep_activity")
+            )
+            .from(interactionSubquery)
+            .join(EPOCH_PARAM).on(EPOCH_PARAM.EPOCH.eq(interactionSubquery.field("epoch", Integer.class)))
+            .fetch();
+        } else {
+            result = dsl.select(
+                    interactionSubquery.field("drep_hash", String.class),
+                    interactionSubquery.field("drep_type", String.class),
+                    interactionSubquery.field("epoch", Integer.class),
+                    interactionSubquery.field("slot", Long.class),
+                    interactionSubquery.field("tx_index", Integer.class),
+                    interactionSubquery.field("event_index", Integer.class),
+                    EPOCH_PARAM.PARAMS
+            )
+            .from(interactionSubquery)
+            .join(EPOCH_PARAM).on(EPOCH_PARAM.EPOCH.eq(interactionSubquery.field("epoch", Integer.class)))
+            .fetch();
+        }
+
+        Map<Tuple<String, DrepType>, List<DRepExpiryUtil.DRepInteractionInfo>> map = new HashMap<>();
+        for (Record record : result) {
+            String hash = record.get("drep_hash", String.class);
+            DrepType type = DrepType.valueOf(record.get("drep_type", String.class));
+            int interactionEpoch = record.get("epoch", Integer.class);
+            long slot = record.get("slot", Long.class);
+            int txIndex = record.get("tx_index", Integer.class);
+            int eventIndex = record.get("event_index", Integer.class);
+            int drepActivity = 0;
+
+            if (dialect.family() == SQLDialect.H2) {
+                var paramsJson = record.get(EPOCH_PARAM.PARAMS).data();
+                ProtocolParams protocolParam;
+                try {
+                    protocolParam = objectMapper.readValue(paramsJson, ProtocolParams.class);
+                    drepActivity = protocolParam.getDrepActivity();
+                } catch (JsonProcessingException e) {
+                    log.error("Failed to parse protocol params JSON: {}", paramsJson, e);
+                }
+            } else {
+                drepActivity = record.get("drep_activity", Integer.class);
+            }
+
+            var key = new Tuple<>(hash, type);
+            map.computeIfAbsent(key, unused -> new ArrayList<>())
+                    .add(new DRepExpiryUtil.DRepInteractionInfo(interactionEpoch, drepActivity, slot, txIndex, eventIndex));
         }
 
         return map;
@@ -410,6 +498,74 @@ public class DRepExpiryService {
         return map;
     }
 
+    private Set<Integer> findNonDormantProposalStatusEpochs(int fromEpoch, int toEpoch) {
+        if (fromEpoch > toEpoch) {
+            return Collections.emptySet();
+        }
+
+        Field<String> govActionLifetimeField = null;
+        SQLDialect dialect = dsl.dialect();
+
+        if (dialect.family() == SQLDialect.POSTGRES) {
+            govActionLifetimeField = DSL.field("params->>'gov_action_lifetime'", String.class);
+        } else if (dialect.family() == SQLDialect.MYSQL) {
+            govActionLifetimeField = DSL.function("JSON_EXTRACT", SQLDataType.VARCHAR, DSL.field("params"), DSL.inline("$.gov_action_lifetime"));
+        }
+
+        if (dialect.family() == SQLDialect.POSTGRES || dialect.family() == SQLDialect.MYSQL) {
+            Field<Integer> expiresAfter = DSL.field("{0} + {1}", Integer.class,
+                    GOV_ACTION_PROPOSAL.EPOCH,
+                    govActionLifetimeField.cast(Integer.class));
+
+            return dsl.selectDistinct(GOV_ACTION_PROPOSAL_STATUS.EPOCH)
+                    .from(GOV_ACTION_PROPOSAL_STATUS)
+                    .join(GOV_ACTION_PROPOSAL).on(GOV_ACTION_PROPOSAL_STATUS.GOV_ACTION_TX_HASH.eq(GOV_ACTION_PROPOSAL.TX_HASH)
+                            .and(GOV_ACTION_PROPOSAL_STATUS.GOV_ACTION_INDEX.eq(GOV_ACTION_PROPOSAL.IDX)))
+                    .join(EPOCH_PARAM).on(GOV_ACTION_PROPOSAL.EPOCH.eq(EPOCH_PARAM.EPOCH))
+                    .where(nonDormantProposalStatusCondition(fromEpoch, toEpoch)
+                            .and(GOV_ACTION_PROPOSAL_STATUS.EPOCH.le(expiresAfter)))
+                    .fetchSet(GOV_ACTION_PROPOSAL_STATUS.EPOCH);
+        }
+
+        Result<?> result = dsl.select(
+                        GOV_ACTION_PROPOSAL_STATUS.EPOCH.as("status_epoch"),
+                        GOV_ACTION_PROPOSAL.EPOCH.as("proposal_epoch"),
+                        EPOCH_PARAM.PARAMS
+                )
+                .from(GOV_ACTION_PROPOSAL_STATUS)
+                .join(GOV_ACTION_PROPOSAL).on(GOV_ACTION_PROPOSAL_STATUS.GOV_ACTION_TX_HASH.eq(GOV_ACTION_PROPOSAL.TX_HASH)
+                        .and(GOV_ACTION_PROPOSAL_STATUS.GOV_ACTION_INDEX.eq(GOV_ACTION_PROPOSAL.IDX)))
+                .join(EPOCH_PARAM).on(GOV_ACTION_PROPOSAL.EPOCH.eq(EPOCH_PARAM.EPOCH))
+                .where(nonDormantProposalStatusCondition(fromEpoch, toEpoch))
+                .fetch();
+
+        Set<Integer> nonDormantEpochs = new HashSet<>();
+        for (Record record : result) {
+            int statusEpoch = record.get("status_epoch", Integer.class);
+            int proposalEpoch = record.get("proposal_epoch", Integer.class);
+
+            var paramsJson = record.get(EPOCH_PARAM.PARAMS).data();
+            try {
+                ProtocolParams protocolParam = objectMapper.readValue(paramsJson, ProtocolParams.class);
+                if (statusEpoch <= proposalEpoch + protocolParam.getGovActionLifetime()) {
+                    nonDormantEpochs.add(statusEpoch);
+                }
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse protocol params JSON: {}", paramsJson, e);
+            }
+        }
+
+        return nonDormantEpochs;
+    }
+
+    private Condition nonDormantProposalStatusCondition(int fromEpoch, int toEpoch) {
+        return GOV_ACTION_PROPOSAL_STATUS.STATUS.in(
+                        GovActionStatus.ACTIVE.name(),
+                        GovActionStatus.RATIFIED.name())
+                .and(GOV_ACTION_PROPOSAL_STATUS.EPOCH.ge(fromEpoch))
+                .and(GOV_ACTION_PROPOSAL_STATUS.EPOCH.le(toEpoch));
+    }
+
     private List<DRepExpiryUtil.ProposalSubmissionInfo> findProposalWithEpochLessThanOrEqualTo(int epoch) {
         Field<String> govActionLifetimeField = null;
         SQLDialect dialect = dsl.dialect();
@@ -425,6 +581,8 @@ public class DRepExpiryService {
             result = dsl.select(
                     GOV_ACTION_PROPOSAL.SLOT,
                     GOV_ACTION_PROPOSAL.EPOCH,
+                    GOV_ACTION_PROPOSAL.TX_INDEX,
+                    GOV_ACTION_PROPOSAL.IDX,
                     govActionLifetimeField.cast(Integer.class).as("gov_action_lifetime")
             )
             .from(GOV_ACTION_PROPOSAL)
@@ -435,6 +593,8 @@ public class DRepExpiryService {
             result = dsl.select(
                     GOV_ACTION_PROPOSAL.SLOT,
                     GOV_ACTION_PROPOSAL.EPOCH,
+                    GOV_ACTION_PROPOSAL.TX_INDEX,
+                    GOV_ACTION_PROPOSAL.IDX,
                     EPOCH_PARAM.PARAMS
             )
             .from(GOV_ACTION_PROPOSAL)
@@ -447,6 +607,8 @@ public class DRepExpiryService {
         for (Record record : result) {
             long slot = record.get(GOV_ACTION_PROPOSAL.SLOT);
             int proposalEpoch = record.get(GOV_ACTION_PROPOSAL.EPOCH);
+            int txIndex = record.get(GOV_ACTION_PROPOSAL.TX_INDEX);
+            int index = record.get(GOV_ACTION_PROPOSAL.IDX);
             int govActionLifetime = 0;
 
             if (dialect.family() == SQLDialect.H2) {
@@ -462,7 +624,7 @@ public class DRepExpiryService {
                 govActionLifetime = record.get("gov_action_lifetime", Integer.class);
             }
 
-            proposalInfos.add(new DRepExpiryUtil.ProposalSubmissionInfo(slot, proposalEpoch, govActionLifetime));
+            proposalInfos.add(new DRepExpiryUtil.ProposalSubmissionInfo(slot, proposalEpoch, govActionLifetime, txIndex, index));
         }
 
         return proposalInfos;

--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/DRepExpiryUtil.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/util/DRepExpiryUtil.java
@@ -259,6 +259,148 @@ public class DRepExpiryUtil {
     }
 
     /**
+     * Replays the ledger's stored {@code drepExpiry} state up to the evaluated epoch.
+     *
+     * <p>Proposal transactions fold pending dormant epochs into the stored value. DRep
+     * registration, update, and vote events recompute the stored value from the current
+     * protocol parameters and pending dormant counter.</p>
+     */
+    public static int calculateDRepActiveUntil(
+            DRepRegistrationInfo registrationInfo,
+            List<DRepInteractionInfo> dRepInteractions,
+            List<ProposalSubmissionInfo> proposalSubmissions,
+            Set<Integer> nonDormantProposalEpochs,
+            int eraFirstEpoch,
+            int evaluatedEpoch
+    ) {
+        int activeUntil = 0;
+        int dormantCounter = 0;
+        boolean registered = false;
+
+        List<ExpiryEvent> events = new java.util.ArrayList<>();
+        events.add(new ExpiryEvent(
+                EventType.REGISTRATION,
+                registrationInfo.epoch(),
+                registrationInfo.slot(),
+                registrationInfo.txIndex(),
+                registrationInfo.certIndex(),
+                registrationInfo.dRepActivity(),
+                registrationInfo.protocolMajorVersion()));
+
+        dRepInteractions.stream()
+                .filter(interaction -> isAfterOrSamePosition(
+                        interaction.epoch(),
+                        interaction.slot(),
+                        interaction.txIndex(),
+                        interaction.eventIndex(),
+                        registrationInfo.epoch(),
+                        registrationInfo.slot(),
+                        registrationInfo.txIndex(),
+                        registrationInfo.certIndex()))
+                .filter(interaction -> interaction.epoch() <= evaluatedEpoch)
+                .forEach(interaction -> events.add(new ExpiryEvent(
+                        EventType.INTERACTION,
+                        interaction.epoch(),
+                        interaction.slot(),
+                        interaction.txIndex(),
+                        interaction.eventIndex(),
+                        interaction.dRepActivity(),
+                        0)));
+
+        proposalSubmissions.stream()
+                .filter(proposal -> proposal.epoch() >= eraFirstEpoch && proposal.epoch() <= evaluatedEpoch)
+                .forEach(proposal -> events.add(new ExpiryEvent(
+                        EventType.PROPOSAL,
+                        proposal.epoch(),
+                        proposal.slot(),
+                        proposal.txIndex(),
+                        proposal.index(),
+                        0,
+                        0)));
+
+        events.sort(Comparator
+                .comparingInt(ExpiryEvent::epoch)
+                .thenComparingLong(ExpiryEvent::slot)
+                .thenComparingInt(ExpiryEvent::txIndex)
+                .thenComparingInt(ExpiryEvent::priority)
+                .thenComparingInt(ExpiryEvent::eventIndex));
+
+        int eventIndex = 0;
+        for (int epoch = eraFirstEpoch; epoch <= evaluatedEpoch; epoch++) {
+            // Ledger updates the dormant counter at the epoch boundary before in-epoch events.
+            if (!nonDormantProposalEpochs.contains(epoch)) {
+                dormantCounter++;
+            }
+
+            while (eventIndex < events.size() && events.get(eventIndex).epoch() == epoch) {
+                ExpiryEvent event = events.get(eventIndex);
+                switch (event.type()) {
+                    case PROPOSAL -> {
+                        if (registered && activeUntil + dormantCounter >= epoch) {
+                            activeUntil += dormantCounter;
+                        }
+                        dormantCounter = 0;
+                    }
+                    case REGISTRATION -> {
+                        registered = true;
+                        if (event.protocolMajorVersion() == 9) {
+                            activeUntil = epoch + event.dRepActivity();
+                        } else {
+                            activeUntil = epoch + event.dRepActivity() - dormantCounter;
+                        }
+                    }
+                    case INTERACTION -> {
+                        if (registered) {
+                            activeUntil = epoch + event.dRepActivity() - dormantCounter;
+                        }
+                    }
+                }
+                eventIndex++;
+            }
+        }
+
+        return activeUntil;
+    }
+
+    private static boolean isAfterOrSamePosition(int epoch, long slot, int txIndex, int eventIndex,
+                                                 int otherEpoch, long otherSlot, int otherTxIndex, int otherEventIndex) {
+        if (epoch != otherEpoch) {
+            return epoch > otherEpoch;
+        }
+        if (slot != otherSlot) {
+            return slot > otherSlot;
+        }
+        if (txIndex != otherTxIndex) {
+            return txIndex > otherTxIndex;
+        }
+        return eventIndex >= otherEventIndex;
+    }
+
+    private enum EventType {
+        PROPOSAL,
+        REGISTRATION,
+        INTERACTION
+    }
+
+    private record ExpiryEvent(
+            EventType type,
+            int epoch,
+            long slot,
+            int txIndex,
+            int eventIndex,
+            int dRepActivity,
+            int protocolMajorVersion
+    ) {
+        int priority() {
+            return switch (type) {
+                case PROPOSAL -> 0;
+                case REGISTRATION -> 1;
+                case INTERACTION -> 2;
+            };
+        }
+    }
+
+    /**
      * Finds the last dormant period from a set of dormant epochs.
      * A dormant period is a continuous sequence of dormant epochs.
      *
@@ -308,7 +450,11 @@ public class DRepExpiryUtil {
      * @param dRepActivity         The {@code dRepActivity} value from protocol parameters at the time of registration.
      * @param protocolMajorVersion The major protocol version at the time of registration.
      */
-    public record DRepRegistrationInfo(long slot, int epoch, int dRepActivity, int protocolMajorVersion) {
+    public record DRepRegistrationInfo(long slot, int epoch, int dRepActivity, int protocolMajorVersion,
+                                       int txIndex, int certIndex) {
+        public DRepRegistrationInfo(long slot, int epoch, int dRepActivity, int protocolMajorVersion) {
+            this(slot, epoch, dRepActivity, protocolMajorVersion, 0, 0);
+        }
     }
 
     /**
@@ -318,7 +464,10 @@ public class DRepExpiryUtil {
      * @param epoch        The epoch in which the interaction occurred.
      * @param dRepActivity The {@code dRepActivity} value from protocol parameters at the time of registration.
      */
-    public record DRepInteractionInfo(int epoch, int dRepActivity) {
+    public record DRepInteractionInfo(int epoch, int dRepActivity, long slot, int txIndex, int eventIndex) {
+        public DRepInteractionInfo(int epoch, int dRepActivity) {
+            this(epoch, dRepActivity, 0, 0, 0);
+        }
     }
 
     /**
@@ -328,6 +477,9 @@ public class DRepExpiryUtil {
      * @param epoch             The epoch in which the proposal was submitted.
      * @param govActionLifeTime The {@code govActionLifeTime} value from protocol parameters, the number of epochs the proposal is considered active.
      */
-    public record ProposalSubmissionInfo(long slot, int epoch, int govActionLifeTime) {
+    public record ProposalSubmissionInfo(long slot, int epoch, int govActionLifeTime, int txIndex, int index) {
+        public ProposalSubmissionInfo(long slot, int epoch, int govActionLifeTime) {
+            this(slot, epoch, govActionLifeTime, 0, 0);
+        }
     }
 }

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/DRepExpiryUtilTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/processor/DRepExpiryUtilTest.java
@@ -3,6 +3,8 @@ package com.bloxbean.cardano.yaci.store.governanceaggr.processor;
 import com.bloxbean.cardano.yaci.store.governanceaggr.util.DRepExpiryUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -690,6 +692,134 @@ public class DRepExpiryUtilTest {
                 25);
     }
 
+    @Test
+    public void shouldReplayActiveUntilAcrossPv9ProposalFlushes() {
+        int eraFirstEpoch = 492;
+        var registration = new DRepExpiryUtil.DRepRegistrationInfo(42596698L, 493, 20, 9, 0, 0);
+        var proposals = List.of(
+                new DRepExpiryUtil.ProposalSubmissionInfo(42510119L, 492, 60, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(50184338L, 580, 60, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(51202227L, 592, 60, 0, 0)
+        );
+        // Non-dormant epochs are epochs with proposal state visible at the boundary.
+        var nonDormantProposalEpochs = new HashSet<Integer>();
+        nonDormantProposalEpochs.add(493);
+        nonDormantProposalEpochs.add(581);
+        nonDormantProposalEpochs.addAll(rangeClosed(593, 598));
+
+        // PV9 registration keeps the stored active_until at epoch + dRepActivity:
+        // 493 + 20 = 513. The epoch-492 proposal has already flushed the first
+        // Conway dormant epoch, and epochs after registration remain pending
+        // in the dormant counter until a later proposal arrives.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(), proposals, nonDormantProposalEpochs, eraFirstEpoch, 570))
+                .isEqualTo(513);
+
+        // The proposal submitted in epoch 580 flushes pending dormant epochs
+        // 494-580 into the stored active_until: 513 + 87 = 600.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(), proposals, nonDormantProposalEpochs, eraFirstEpoch, 582))
+                .isEqualTo(600);
+
+        // The next proposal flushes dormant epochs 582-592, moving the stored
+        // active_until from 600 to 611.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(), proposals, nonDormantProposalEpochs, eraFirstEpoch, 593))
+                .isEqualTo(611);
+
+        var voteAt598 = new DRepExpiryUtil.DRepInteractionInfo(598, 20, 51679073L, 0, 0);
+        // Epochs 593-598 are non-dormant, so the vote recomputes active_until
+        // from the current epoch without subtracting a pending counter: 598 + 20.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(voteAt598), proposals, nonDormantProposalEpochs, eraFirstEpoch, 599))
+                .isEqualTo(618);
+    }
+
+    @Test
+    public void shouldKeepRawActiveUntilStableDuringDormantPeriodAfterVote() {
+        var registration = new DRepExpiryUtil.DRepRegistrationInfo(1L, 990, 20, 10, 0, 0);
+        var proposals = List.of(
+                new DRepExpiryUtil.ProposalSubmissionInfo(100L, 993, 15, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(300L, 1013, 15, 0, 0)
+        );
+        var interactions = List.of(
+                new DRepExpiryUtil.DRepInteractionInfo(993, 20, 101L, 1, 0),
+                new DRepExpiryUtil.DRepInteractionInfo(1013, 20, 301L, 1, 0)
+        );
+        var nonDormantProposalEpochs = Set.<Integer>of();
+
+        // In PV10, registration/vote stores epoch + dRepActivity - pending
+        // dormant counter. The proposal and vote in epoch 993 leave the stored
+        // value at 993 + 20 = 1013; later dormant epochs only remain pending.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, interactions, proposals, nonDormantProposalEpochs, 990, 1000))
+                .isEqualTo(1013);
+
+        // The proposal in epoch 1013 flushes the pending dormant counter, then
+        // the same-epoch vote recomputes the stored active_until to 1013 + 20.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, interactions, proposals, nonDormantProposalEpochs, 990, 1014))
+                .isEqualTo(1033);
+    }
+
+    @Test
+    public void shouldNotCountProposalSubmissionEpochAsDormantForActiveUntil() {
+        var registration = new DRepExpiryUtil.DRepRegistrationInfo(78488970L, 908, 20, 10, 0, 0);
+        var proposals = List.of(
+                new DRepExpiryUtil.ProposalSubmissionInfo(78488971L, 908, 15, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(79111020L, 915, 15, 0, 0)
+        );
+        var voteAt910 = new DRepExpiryUtil.DRepInteractionInfo(910, 20, 78695050L, 0, 0);
+        // Valid RATIFIED status still represents proposal presence for that epoch.
+        var nonDormantProposalEpochs = Set.of(908, 909, 910, 911, 912, 916);
+
+        // The proposal/status epoch 908 is non-dormant, so PV10 registration is
+        // not penalized by a dormant counter. The vote sets 910 + 20 = 930, and
+        // the epoch-915 proposal flushes dormant epochs 913-915: 930 + 3 = 933.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(voteAt910), proposals, nonDormantProposalEpochs, 908, 916))
+                .isEqualTo(933);
+    }
+
+    @Test
+    public void shouldNotReviveInactiveDRepWhenProposalFlushesDormantCounter() {
+        var registration = new DRepExpiryUtil.DRepRegistrationInfo(1L, 0, 3, 10, 0, 0);
+        var proposals = List.of(
+                new DRepExpiryUtil.ProposalSubmissionInfo(0L, 0, 4, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(60L, 6, 4, 0, 0)
+        );
+        // Proposal at epoch 0 with lifetime 4 is active through epoch 4.
+        var nonDormantProposalEpochs = Set.of(0, 1, 2, 3, 4);
+
+        // By epoch 6 the DRep is already inactive: stored active_until 3 plus pending
+        // dormant epochs 5-6 gives effective active_until 5, which is still
+        // before the proposal epoch. The flush resets the counter without reviving it.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(), proposals, nonDormantProposalEpochs, 0, 6))
+                .isEqualTo(3);
+    }
+
+    @Test
+    public void shouldFlushDormantCounterWhenPv10ProposalArrivesInDormantEpoch() {
+        // Earlier proposal state keeps epochs 593-673 non-dormant.
+        var registration = new DRepExpiryUtil.DRepRegistrationInfo(57890157L, 670, 20, 10, 0, 0);
+        var proposals = List.of(
+                new DRepExpiryUtil.ProposalSubmissionInfo(59080597L, 683, 60, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(59184828L, 685, 60, 0, 0),
+                new DRepExpiryUtil.ProposalSubmissionInfo(59388112L, 687, 60, 0, 0)
+        );
+        var nonDormantProposalEpochs = new HashSet<Integer>();
+        nonDormantProposalEpochs.addAll(rangeClosed(593, 673));
+        nonDormantProposalEpochs.add(684);
+
+        // Before registration, there are 100 pending dormant epochs from
+        // 493-592. PV10 stores 670 + 20 - 100 = 590, and the proposal in epoch
+        // 683 flushes all 110 pending dormant epochs into that active DRep.
+        assertThat(DRepExpiryUtil.calculateDRepActiveUntil(
+                registration, List.of(), proposals, nonDormantProposalEpochs, 493, 683))
+                .isEqualTo(700);
+    }
+
     private void assertExpiryV9(DRepExpiryUtil.DRepRegistrationInfo registration,
                                 DRepExpiryUtil.DRepInteractionInfo lastInteraction,
                                 Set<Integer> dormantEpochs,
@@ -722,5 +852,13 @@ public class DRepExpiryUtilTest {
                 evaluatedEpoch);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    private Set<Integer> rangeClosed(int startInclusive, int endInclusive) {
+        Set<Integer> result = new HashSet<>();
+        for (int epoch = startInclusive; epoch <= endInclusive; epoch++) {
+            result.add(epoch);
+        }
+        return result;
     }
 }

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepExpiryServiceTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/DRepExpiryServiceTest.java
@@ -1,0 +1,266 @@
+package com.bloxbean.cardano.yaci.store.governanceaggr.service;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.store.core.domain.CardanoEra;
+import com.bloxbean.cardano.yaci.store.core.service.EraService;
+import com.bloxbean.cardano.yaci.store.governanceaggr.storage.impl.repository.GovEpochActivityRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DRepExpiryServiceTest {
+
+    private static final String DREP_HASH = "967c86ac16aea79dea7609c8b186f91c259a458a00e7d4ed3a7f9d3a";
+
+    @Mock
+    private EraService eraService;
+    @Mock
+    private GovEpochActivityRepository govEpochActivityRepository;
+
+    private JdbcTemplate jdbcTemplate;
+    private DRepExpiryService dRepExpiryService;
+
+    @BeforeEach
+    void setUp() {
+        var dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:" + UUID.randomUUID() + ";MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1");
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        var namedJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        var dsl = DSL.using(dataSource, SQLDialect.H2);
+
+        dRepExpiryService = new DRepExpiryService(
+                namedJdbcTemplate,
+                eraService,
+                govEpochActivityRepository,
+                dsl,
+                new ObjectMapper());
+
+        createSchema();
+
+        when(eraService.getEras()).thenReturn(List.of(CardanoEra.builder()
+                .era(Era.Conway)
+                .startSlot(42_508_827L)
+                .build()));
+        when(eraService.getEpochNo(Era.Conway, 42_508_827L)).thenReturn(492);
+    }
+
+    @Test
+    void activeUntilCountsFirstConwayEpochDormancyBeforeFirstProposal() {
+        // The first Conway epoch has no proposal visible at its boundary, so it
+        // contributes one pending dormant epoch before any in-epoch events.
+        when(govEpochActivityRepository.findDormantEpochsInEpochRange(492, 492))
+                .thenReturn(Set.of(492));
+
+        insertEpochParam(492, 9, 20, 60);
+
+        // The DRep registers before the first proposal in epoch 492. PV9
+        // registration stores 492 + 20, then the proposal flushes the pending
+        // first-Conway dormant epoch into active_until.
+        insertDRepRegistration(492, 42_509_000L);
+        insertProposal("first-conway-proposal", 492, 42_510_000L);
+        insertDRepDist(493);
+
+        dRepExpiryService.calculateAndUpdateExpiryForEpoch(493);
+
+        Integer activeUntil = jdbcTemplate.queryForObject("""
+                SELECT active_until
+                FROM drep_dist
+                WHERE epoch = 493
+                  AND drep_hash = ?
+                """, Integer.class, DREP_HASH);
+
+        assertThat(activeUntil).isEqualTo(513);
+    }
+
+    @Test
+    void activeUntilTreatsRatifiedProposalStatusEpochAsNonDormant() {
+        // Proposal status at epoch 493 represents proposal presence at the
+        // boundary, so epoch 493 must not be counted as dormant.
+        when(govEpochActivityRepository.findDormantEpochsInEpochRange(492, 580))
+                .thenReturn(Set.of());
+
+        insertEpochParam(492, 9, 20, 60);
+        insertEpochParam(493, 9, 20, 60);
+        insertEpochParam(580, 9, 20, 60);
+
+        // This mirrors a proposal submitted at Conway start and observed as
+        // RATIFIED in epoch 493, followed by a later proposal that flushes the
+        // dormant counter accumulated after the DRep registration.
+        insertDRepRegistration();
+        insertProposal("proposal-at-era-start", 492, 42_510_119L);
+        insertProposalStatus("proposal-at-era-start", 493, "RATIFIED");
+        insertProposal("proposal-flush", 580, 50_184_338L);
+        insertDRepDist(581);
+
+        dRepExpiryService.calculateAndUpdateExpiryForEpoch(581);
+
+        Integer activeUntil = jdbcTemplate.queryForObject("""
+                SELECT active_until
+                FROM drep_dist
+                WHERE epoch = 581
+                  AND drep_hash = ?
+                """, Integer.class, DREP_HASH);
+
+        assertThat(activeUntil).isEqualTo(600);
+    }
+
+    @Test
+    void activeUntilTreatsExpiredProposalStatusEpochAsDormant() {
+        // With lifetime 2, the epoch-492 proposal is active through epoch 494.
+        // Its EXPIRED status in epoch 495 must not make that epoch non-dormant.
+        when(govEpochActivityRepository.findDormantEpochsInEpochRange(492, 580))
+                .thenReturn(Set.of());
+
+        insertEpochParam(492, 9, 20, 2);
+        insertEpochParam(495, 9, 20, 60);
+        insertEpochParam(580, 9, 20, 60);
+
+        // The DRep registers in the expired-status epoch, so that epoch remains
+        // dormant and is included in the later proposal flush.
+        insertDRepRegistration(495, 42_700_000L);
+        insertProposal("expires-before-registration", 492, 42_510_119L);
+        insertProposalStatus("expires-before-registration", 493, "ACTIVE");
+        insertProposalStatus("expires-before-registration", 494, "ACTIVE");
+        insertProposalStatus("expires-before-registration", 495, "EXPIRED");
+        insertProposal("proposal-flush", 580, 50_184_338L);
+        insertDRepDist(581);
+
+        dRepExpiryService.calculateAndUpdateExpiryForEpoch(581);
+
+        Integer activeUntil = jdbcTemplate.queryForObject("""
+                SELECT active_until
+                FROM drep_dist
+                WHERE epoch = 581
+                  AND drep_hash = ?
+                """, Integer.class, DREP_HASH);
+
+        assertThat(activeUntil).isEqualTo(601);
+    }
+
+    private void createSchema() {
+        jdbcTemplate.execute("""
+                CREATE TABLE drep_dist (
+                    drep_hash varchar(56),
+                    drep_type varchar(40),
+                    amount bigint,
+                    epoch int,
+                    active_until int,
+                    expiry int,
+                    primary key (drep_hash, drep_type, epoch)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE drep_registration (
+                    tx_hash varchar(64) not null,
+                    cert_index int not null,
+                    tx_index int not null,
+                    type varchar(50),
+                    drep_hash varchar(56),
+                    cred_type varchar(40),
+                    epoch int,
+                    slot bigint,
+                    primary key (tx_hash, cert_index)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE voting_procedure (
+                    voter_hash varchar(56),
+                    voter_type varchar(40),
+                    epoch int,
+                    slot bigint,
+                    tx_index int,
+                    idx int
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE gov_action_proposal (
+                    tx_hash varchar(64),
+                    idx int,
+                    epoch int,
+                    slot bigint,
+                    tx_index int
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE gov_action_proposal_status (
+                    gov_action_tx_hash varchar(64),
+                    gov_action_index int,
+                    type varchar(50),
+                    status varchar(50),
+                    epoch int
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE epoch_param (
+                    epoch int primary key,
+                    params varchar
+                )
+                """);
+    }
+
+    private void insertEpochParam(int epoch, int protocolMajorVersion, int dRepActivity, int govActionLifetime) {
+        jdbcTemplate.update("""
+                INSERT INTO epoch_param (epoch, params)
+                VALUES (?, ?)
+                """, epoch, """
+                {"protocol_major_ver":%d,"drep_activity":%d,"gov_action_lifetime":%d}
+                """.formatted(protocolMajorVersion, dRepActivity, govActionLifetime));
+    }
+
+    private void insertDRepRegistration() {
+        // Default fixture: the DRep registers in epoch 493 after the Conway-start
+        // proposal, matching the preprod mismatch scenario.
+        insertDRepRegistration(493, 42596698);
+    }
+
+    private void insertDRepRegistration(int epoch, long slot) {
+        jdbcTemplate.update("""
+                INSERT INTO drep_registration
+                    (tx_hash, cert_index, tx_index, type, drep_hash, cred_type, epoch, slot)
+                VALUES ('drep-reg', 0, 0, 'REG_DREP_CERT', ?, 'ADDR_KEYHASH', ?, ?)
+                """, DREP_HASH, epoch, slot);
+    }
+
+    private void insertProposal(String txHash, int epoch, long slot) {
+        jdbcTemplate.update("""
+                INSERT INTO gov_action_proposal
+                    (tx_hash, idx, epoch, slot, tx_index)
+                VALUES (?, 0, ?, ?, 0)
+                """, txHash, epoch, slot);
+    }
+
+    private void insertProposalStatus(String txHash, int epoch, String status) {
+        jdbcTemplate.update("""
+                INSERT INTO gov_action_proposal_status
+                    (gov_action_tx_hash, gov_action_index, type, status, epoch)
+                VALUES (?, 0, 'PARAMETER_CHANGE_ACTION', ?, ?)
+                """, txHash, status, epoch);
+    }
+
+    private void insertDRepDist(int epoch) {
+        // Seed the row that calculateAndUpdateExpiryForEpoch updates.
+        jdbcTemplate.update("""
+                INSERT INTO drep_dist
+                    (drep_hash, drep_type, amount, epoch)
+                VALUES (?, 'ADDR_KEYHASH', 1, ?)
+                """, DREP_HASH, epoch);
+    }
+}


### PR DESCRIPTION
 ## Summary

  Backports #966 to `release/2.0.x`.

  This aligns DRep `active_until` calculation in `governance-aggr` with the ledger-style expiry replay merged into `main`.
