### PR TITLE
[merge to 2.0.x[ fix(core): bulk (set-based) cursor deletes to prevent cleanup OOM

### DIFF
--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/storage/impl/CursorRepository.java
@@ -3,6 +3,9 @@ package com.bloxbean.cardano.yaci.store.core.storage.impl;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.model.CursorEntity;
 import com.bloxbean.cardano.yaci.store.core.storage.impl.model.CursorId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,8 +18,19 @@ public interface CursorRepository extends JpaRepository<CursorEntity, CursorId> 
 
     Optional<CursorEntity> findByIdAndBlockHash(Long id, String blockHash);
 
-    int deleteByIdAndSlotGreaterThan(Long id, Long slot);
+    // Set-based (bulk) deletes. These were Spring Data DERIVED deletes, which Spring implements by
+    // SELECTing every matching row into the persistence context and removing them one entity at a
+    // time -- so memory scales with the number of rows deleted. When cursor_ is large (e.g. the
+    // cleanup below has never completed since genesis) a single run loads millions of CursorEntity
+    // objects and throws OutOfMemoryError; the cursor then never prunes, so the failure is permanent
+    // and self-reinforcing. A @Modifying @Query issues one SQL DELETE with memory independent of the
+    // number of rows removed.
+    @Modifying
+    @Query("delete from CursorEntity c where c.id = :id and c.slot > :slot")
+    int deleteByIdAndSlotGreaterThan(@Param("id") Long id, @Param("slot") Long slot);
 
     //Required for history cleanup
-    int deleteByIdAndBlockLessThan(Long id, Long block);
+    @Modifying
+    @Query("delete from CursorEntity c where c.id = :id and c.block < :block")
+    int deleteByIdAndBlockLessThan(@Param("id") Long id, @Param("block") Long block);
 }


### PR DESCRIPTION
## Summary

  Backports #1055 to `release/2.0.x`.

  Changes cursor cleanup repository deletes from Spring Data derived deletes to set-based bulk `@Modifying @Query` deletes, avoiding loading all matching `CursorEntity` rows into the persistence context during cleanup.