### PR TITLE
[merge to 2.0.x] feat(staking): persist stake-key deposit on stake_registration

### DIFF
--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessor.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessor.java
@@ -189,6 +189,7 @@ public class GenesisPoolProcessor {
                     .certIndex(i)
                     .txIndex(0)
                     .type(CertificateType.STAKE_REGISTRATION)
+                    .deposit(depositParamService.getKeyDeposit(0))
                     .epoch(genesisBlockEvent.getEpoch())
                     .blockNumber(genesisBlockEvent.getBlock())
                     .blockHash(genesisBlockEvent.getBlockHash())

--- a/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotService.java
+++ b/aggregates/adapot/src/main/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotService.java
@@ -1,6 +1,10 @@
 package com.bloxbean.cardano.yaci.store.adapot.snapshot;
 
+import com.bloxbean.cardano.yaci.store.common.util.ErrorCode;
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -16,55 +20,82 @@ import java.util.Map;
 public class DepositSnapshotService {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final DepositParamService depositParamService;
+    private final ApplicationEventPublisher publisher;
 
     public BigInteger getNetStakeDepositInEpoch(int epoch) {
         // GenesisPoolProcessor writes synthetic "Genesis" rows for devnet initial
         // stake/pool certificates. Those deposits are already seeded into epoch 0,
         // so regular epoch snapshots must exclude them to avoid double-counting.
+        // Legacy deregistration certificates have no coin. For those rows, select the immediately
+        // preceding lifecycle row first and only use its deposit when it is a registration; filtering
+        // to registrations before ordering could incorrectly cross an intervening deregistration.
         String stakeRegDeRegAndPoolDepositQuery = """
-                            SELECT
-                -- Net deposit from stake registrations and deregistrations in the specified epoch
-                COALESCE((
-                             SELECT
-                                 SUM(CASE
-                                         WHEN type = 'STAKE_REGISTRATION' THEN :stake_reg_deposit
-                                         WHEN type = 'STAKE_DEREGISTRATION' THEN -(:stake_reg_deposit)
-                                         ELSE 0
-                                     END) AS net_stake
-                             FROM
-                                 stake_registration
-                             WHERE
-                                 epoch = :epoch
-                               AND tx_hash <> :genesis_tx_hash
-                         ), 0) AS stake_deposits,
+                SELECT
+                    stake.stake_deposits,
+                    stake.unresolved_stake_deposits,
                 
-                -- Net deposit from pool registrations in the specified epoch
-                COALESCE((
-                             SELECT
-                                 SUM(amount) AS net_pool_deposit
-                             FROM
-                                 pool
-                             WHERE
-                                 epoch = :epoch
-                               AND status = 'REGISTRATION'
-                               AND tx_hash <> :genesis_tx_hash
-                         ), 0) AS pool_deposits,
+                    -- Net deposit from pool registrations in the specified epoch
+                    COALESCE((
+                        SELECT SUM(amount)
+                        FROM pool
+                        WHERE epoch = :epoch
+                          AND status = 'REGISTRATION'
+                          AND tx_hash <> :genesis_tx_hash
+                    ), 0) AS pool_deposits,
                 
-                -- Net deposit from pool retirements in the next epoch
-                COALESCE((
-                             SELECT
-                                 SUM(-amount) AS pool_retired
-                             FROM
-                                 pool
-                             WHERE
-                                 epoch = :epoch + 1
-                               AND status = 'RETIRED'
-                         ), 0) AS pool_retires;
+                    -- Net deposit from pool retirements in the next epoch
+                    COALESCE((
+                        SELECT SUM(-amount)
+                        FROM pool
+                        WHERE epoch = :epoch + 1
+                          AND status = 'RETIRED'
+                    ), 0) AS pool_retires
+                FROM (
+                    SELECT
+                        COALESCE(SUM(CASE
+                            WHEN resolved_registration.type = 'STAKE_REGISTRATION'
+                                THEN resolved_registration.deposit
+                            WHEN resolved_registration.type = 'STAKE_DEREGISTRATION'
+                                THEN -resolved_registration.deposit
+                            ELSE 0
+                        END), 0) AS stake_deposits,
+                        COALESCE(SUM(CASE
+                            WHEN resolved_registration.type = 'STAKE_DEREGISTRATION'
+                                 AND resolved_registration.deposit IS NULL
+                                THEN 1
+                            ELSE 0
+                        END), 0) AS unresolved_stake_deposits
+                    FROM (
+                        SELECT registration.type,
+                               COALESCE(registration.deposit, CASE
+                                   WHEN registration.type = 'STAKE_DEREGISTRATION' THEN (
+                                       SELECT CASE
+                                           WHEN lifecycle.type = 'STAKE_REGISTRATION' THEN lifecycle.deposit
+                                           ELSE NULL
+                                       END
+                                       FROM stake_registration lifecycle
+                                       WHERE lifecycle.address = registration.address
+                                         AND (lifecycle.slot < registration.slot
+                                           OR (lifecycle.slot = registration.slot
+                                               AND lifecycle.tx_index < registration.tx_index)
+                                           OR (lifecycle.slot = registration.slot
+                                               AND lifecycle.tx_index = registration.tx_index
+                                               AND lifecycle.cert_index < registration.cert_index))
+                                       ORDER BY lifecycle.slot DESC, lifecycle.tx_index DESC, lifecycle.cert_index DESC
+                                       LIMIT 1
+                                   )
+                                   ELSE NULL
+                               END) AS deposit
+                        FROM stake_registration registration
+                        WHERE registration.epoch = :epoch
+                          AND registration.tx_hash <> :genesis_tx_hash
+                    ) resolved_registration
+                ) stake;
                 """;
 
         Map<String, Object> param = new HashMap<>();
         param.put("epoch", epoch);
-        param.put("stake_reg_deposit", BigInteger.valueOf(2000000));
         param.put("genesis_tx_hash", "Genesis");
 
         var stakeDeposit = jdbcTemplate.queryForObject(stakeRegDeRegAndPoolDepositQuery, param, new RowMapper<StakeDeposit>() {
@@ -73,19 +104,40 @@ public class DepositSnapshotService {
                 return new StakeDeposit(
                         rs.getBigDecimal("stake_deposits").toBigInteger(),
                         rs.getBigDecimal("pool_deposits").toBigInteger(),
-                        rs.getBigDecimal("pool_retires").toBigInteger()
+                        rs.getBigDecimal("pool_retires").toBigInteger(),
+                        rs.getLong("unresolved_stake_deposits")
                 );
             }
         });
 
         BigInteger totalDeposit = BigInteger.ZERO;
-        if(stakeDeposit != null) {
-            totalDeposit = stakeDeposit.netStakeDepositAmount().add(stakeDeposit.poolDepositAmount()).add(stakeDeposit.poolRetiredAmount());
+        if (stakeDeposit != null) {
+            if (stakeDeposit.unresolvedStakeDeposits() > 0) {
+                long unresolvedCount = stakeDeposit.unresolvedStakeDeposits();
+                BigInteger fallbackDeposit = depositParamService.getKeyDeposit(epoch)
+                        .multiply(BigInteger.valueOf(unresolvedCount));
+                String reason = "Unable to resolve " + unresolvedCount
+                        + " legacy stake deregistration deposit(s) for epoch " + epoch;
+
+                publisher.publishEvent(ErrorEvent.builder()
+                        .errorCode(ErrorCode.DATA_MISSING_ERROR.name())
+                        .reason(reason)
+                        .details("Using protocol parameter key deposit fallback: " + fallbackDeposit)
+                        .build());
+
+                totalDeposit = totalDeposit.subtract(fallbackDeposit);
+            }
+            totalDeposit = totalDeposit.add(stakeDeposit.netStakeDepositAmount())
+                    .add(stakeDeposit.poolDepositAmount())
+                    .add(stakeDeposit.poolRetiredAmount());
         }
 
         return totalDeposit;
     }
 }
 
-record StakeDeposit(BigInteger netStakeDepositAmount, BigInteger poolDepositAmount, BigInteger poolRetiredAmount) {
+record StakeDeposit(BigInteger netStakeDepositAmount,
+                    BigInteger poolDepositAmount,
+                    BigInteger poolRetiredAmount,
+                    long unresolvedStakeDeposits) {
 }

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessorTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/processor/GenesisPoolProcessorTest.java
@@ -86,6 +86,7 @@ class GenesisPoolProcessorTest {
     void handleGenesisPoolRegistration_booksPoolDepositsAndStakeRegistrations() {
         when(storeProperties.isMainnet()).thenReturn(false);
         when(depositParamService.getPoolDeposit(0)).thenReturn(POOL_DEPOSIT);
+        when(depositParamService.getKeyDeposit(0)).thenReturn(KEY_DEPOSIT);
 
         genesisPoolProcessor.handleGenesisPoolRegistration(genesisBlockEvent(genesisStaking()));
 
@@ -117,6 +118,9 @@ class GenesisPoolProcessorTest {
         assertThat(stakeRegistrationsCaptor.getValue())
                 .extracting(StakeRegistrationDetail::getTxHash)
                 .containsOnly("Genesis");
+        assertThat(stakeRegistrationsCaptor.getValue())
+                .extracting(StakeRegistrationDetail::getDeposit)
+                .containsOnly(KEY_DEPOSIT);
     }
 
     @Test

--- a/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotServiceTest.java
+++ b/aggregates/adapot/src/test/java/com/bloxbean/cardano/yaci/store/adapot/snapshot/DepositSnapshotServiceTest.java
@@ -1,7 +1,12 @@
 package com.bloxbean.cardano.yaci.store.adapot.snapshot;
 
+import com.bloxbean.cardano.yaci.store.common.util.ErrorCode;
+import com.bloxbean.cardano.yaci.store.events.ErrorEvent;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -9,10 +14,15 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import java.math.BigInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DepositSnapshotServiceTest {
     private DepositSnapshotService depositSnapshotService;
     private JdbcTemplate jdbcTemplate;
+    private DepositParamService depositParamService;
+    private ApplicationEventPublisher publisher;
 
     @BeforeEach
     void setUp() {
@@ -23,7 +33,10 @@ class DepositSnapshotServiceTest {
         dataSource.setPassword("");
 
         jdbcTemplate = new JdbcTemplate(dataSource);
-        depositSnapshotService = new DepositSnapshotService(new NamedParameterJdbcTemplate(dataSource));
+        depositParamService = mock(DepositParamService.class);
+        publisher = mock(ApplicationEventPublisher.class);
+        depositSnapshotService = new DepositSnapshotService(
+                new NamedParameterJdbcTemplate(dataSource), depositParamService, publisher);
 
         jdbcTemplate.execute("DROP TABLE IF EXISTS stake_registration");
         jdbcTemplate.execute("DROP TABLE IF EXISTS pool");
@@ -31,6 +44,11 @@ class DepositSnapshotServiceTest {
                 CREATE TABLE stake_registration (
                     tx_hash VARCHAR(128),
                     type VARCHAR(64),
+                    deposit NUMERIC(38, 0),
+                    address VARCHAR(255),
+                    slot BIGINT,
+                    tx_index INTEGER,
+                    cert_index INTEGER,
                     epoch INTEGER
                 )
                 """);
@@ -45,13 +63,13 @@ class DepositSnapshotServiceTest {
     }
 
     @Test
-    void getNetStakeDepositInEpoch_excludesSyntheticGenesisRowsOnly() {
+    void getNetStakeDepositInEpoch_usesStoredStakeDepositsAndExcludesSyntheticGenesisRows() {
         jdbcTemplate.update("""
-                INSERT INTO stake_registration(tx_hash, type, epoch)
+                INSERT INTO stake_registration(tx_hash, type, deposit, epoch)
                 VALUES
-                    ('Genesis', 'STAKE_REGISTRATION', 0),
-                    ('normal-reg', 'STAKE_REGISTRATION', 0),
-                    ('normal-dereg', 'STAKE_DEREGISTRATION', 0)
+                    ('Genesis', 'STAKE_REGISTRATION', 9000000, 0),
+                    ('normal-reg', 'STAKE_REGISTRATION', 5000000, 0),
+                    ('normal-dereg', 'STAKE_DEREGISTRATION', 2000000, 0)
                 """);
         jdbcTemplate.update("""
                 INSERT INTO pool(tx_hash, status, amount, epoch)
@@ -63,6 +81,92 @@ class DepositSnapshotServiceTest {
 
         BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(0);
 
-        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(600_000_000L));
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(603_000_000L));
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_resolvesLegacyDeregistrationFromActiveRegistration() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(
+                    tx_hash, type, deposit, address, slot, tx_index, cert_index, epoch)
+                VALUES
+                    ('registration', 'STAKE_REGISTRATION', 5000000, 'stake1', 100, 0, 0, 0),
+                    ('legacy-deregistration', 'STAKE_DEREGISTRATION', NULL, 'stake1', 200, 0, 0, 1)
+                """);
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(1);
+
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(-5_000_000));
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_resolvesLifecycleOrderWithinTransaction() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(
+                    tx_hash, type, deposit, address, slot, tx_index, cert_index, epoch)
+                VALUES
+                    ('same-tx', 'STAKE_REGISTRATION', 5000000, 'stake1', 200, 3, 0, 1),
+                    ('same-tx', 'STAKE_DEREGISTRATION', NULL, 'stake1', 200, 3, 1, 1)
+                """);
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(1);
+
+        assertThat(netDeposit).isZero();
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_prefersExplicitDeregistrationDeposit() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(
+                    tx_hash, type, deposit, address, slot, tx_index, cert_index, epoch)
+                VALUES
+                    ('registration', 'STAKE_REGISTRATION', 5000000, 'stake1', 100, 0, 0, 0),
+                    ('explicit-deregistration', 'STAKE_DEREGISTRATION', 7000000, 'stake1', 200, 0, 0, 1)
+                """);
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(1);
+
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(-7_000_000));
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_usesProtocolParameterFallbackAndReportsMissingLifecycle() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(
+                    tx_hash, type, deposit, address, slot, tx_index, cert_index, epoch)
+                VALUES
+                    ('legacy-deregistration-1', 'STAKE_DEREGISTRATION', NULL, 'stake1', 200, 0, 0, 1),
+                    ('legacy-deregistration-2', 'STAKE_DEREGISTRATION', NULL, 'stake2', 201, 0, 0, 1)
+                """);
+        when(depositParamService.getKeyDeposit(1)).thenReturn(BigInteger.valueOf(2_000_000));
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(1);
+
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(-4_000_000));
+        ArgumentCaptor<ErrorEvent> eventCaptor = ArgumentCaptor.forClass(ErrorEvent.class);
+        verify(publisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getErrorCode()).isEqualTo(ErrorCode.DATA_MISSING_ERROR.name());
+        assertThat(eventCaptor.getValue().getReason())
+                .isEqualTo("Unable to resolve 2 legacy stake deregistration deposit(s) for epoch 1");
+        assertThat(eventCaptor.getValue().getDetails())
+                .isEqualTo("Using protocol parameter key deposit fallback: 4000000");
+    }
+
+    @Test
+    void getNetStakeDepositInEpoch_doesNotCrossPreviousDeregistrationLifecycle() {
+        jdbcTemplate.update("""
+                INSERT INTO stake_registration(
+                    tx_hash, type, deposit, address, slot, tx_index, cert_index, epoch)
+                VALUES
+                    ('registration', 'STAKE_REGISTRATION', 5000000, 'stake1', 100, 0, 0, 0),
+                    ('first-deregistration', 'STAKE_DEREGISTRATION', 5000000, 'stake1', 150, 0, 0, 0),
+                    ('second-deregistration', 'STAKE_DEREGISTRATION', NULL, 'stake1', 200, 0, 0, 1)
+                """);
+        when(depositParamService.getKeyDeposit(1)).thenReturn(BigInteger.valueOf(2_000_000));
+
+        BigInteger netDeposit = depositSnapshotService.getNetStakeDepositInEpoch(1);
+
+        assertThat(netDeposit).isEqualTo(BigInteger.valueOf(-2_000_000));
+        verify(publisher).publishEvent(org.mockito.ArgumentMatchers.any(ErrorEvent.class));
     }
 }

--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ErrorCode.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/util/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.common.util;
 
 public enum ErrorCode {
-    BLOCK_PARSE_ERROR
+    BLOCK_PARSE_ERROR,
+    DATA_MISSING_ERROR
 }

--- a/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
+++ b/components/core/src/main/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfig.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yaci.store.core.configuration;
 import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.NetworkType;
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
 import com.bloxbean.cardano.yaci.store.common.exception.StoreRuntimeException;
 import com.bloxbean.cardano.yaci.store.common.genesis.ByronGenesis;
 import com.bloxbean.cardano.yaci.store.common.genesis.ShelleyGenesis;
@@ -52,6 +53,7 @@ public class GenesisConfig {
     private long slotsPerKesPeriod;
     private int maxKesEvolutions;
     private BigInteger maxLovelaceSupply = BigInteger.valueOf(45000000000000000L);
+    private ProtocolParams shelleyGenesisProtocolParams;
 
     public GenesisConfig(StoreProperties storeProperties, ObjectMapper objectMapper, ResourceLoader resourceLoader) {
         this.storeProperties = storeProperties;
@@ -194,6 +196,7 @@ public class GenesisConfig {
         maxKesEvolutions = shelleyGenesis.getMaxKesEvolutions();
         maxLovelaceSupply = shelleyGenesis.getMaxLovelaceSupply();
         epochLength = shelleyGenesis.getEpochLength();
+        shelleyGenesisProtocolParams = shelleyGenesis.getProtocolParams();
 
         long networkMagic = shelleyGenesis.getNetworkMagic();
         if (networkMagic != storeProperties.getProtocolMagic())

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfigTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfigTest.java
@@ -1,0 +1,25 @@
+package com.bloxbean.cardano.yaci.store.core.configuration;
+
+import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.common.domain.NetworkType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GenesisConfigTest {
+
+    @Test
+    void getShelleyGenesisProtocolParams_ReturnsParsedProtocolParams() {
+        StoreProperties storeProperties = new StoreProperties();
+        storeProperties.setProtocolMagic(NetworkType.MAINNET.getProtocolMagic());
+        GenesisConfig genesisConfig = new GenesisConfig(
+                storeProperties, new ObjectMapper(), new DefaultResourceLoader());
+
+        assertThat(genesisConfig.getShelleyGenesisProtocolParams().getKeyDeposit())
+                .isEqualTo(BigInteger.valueOf(2_000_000));
+    }
+}

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/domain/StakeRegistrationDetail.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/domain/StakeRegistrationDetail.java
@@ -11,6 +11,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigInteger;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,6 +27,7 @@ public class StakeRegistrationDetail extends BlockAwareDomain {
     private int certIndex;
     private int txIndex;
     private CertificateType type;
+    private BigInteger deposit;
     private int epoch;
     private long slot;
     private String blockHash;

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/processor/StakeRegProcessor.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/processor/StakeRegProcessor.java
@@ -10,6 +10,7 @@ import com.bloxbean.cardano.yaci.store.events.domain.TxCertificates;
 import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
 import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
 import com.bloxbean.cardano.yaci.store.staking.domain.event.StakeRegDeregEvent;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
 import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorage;
 import com.bloxbean.cardano.yaci.store.staking.util.AddressUtil;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +33,7 @@ import static com.bloxbean.cardano.yaci.store.staking.StakingStoreConfiguration.
 public class StakeRegProcessor {
     private final StakingCertificateStorage stakingStorage;
     private final ApplicationEventPublisher publisher;
+    private final DepositParamService depositParamService;
 
     @EventListener
     @Transactional
@@ -67,7 +70,8 @@ public class StakeRegProcessor {
                                     .build();
                         }
                         stakeRegistrationDetail = buildStakeRegistrationDetail(
-                                stakeRegistration, txHash, index, txIndex, eventMetadata);
+                                stakeRegistration, txHash, index, txIndex,
+                                resolveRegistrationDeposit(certificate, eventMetadata.getEpochNumber()), eventMetadata);
 
                         stakeRegDeRegs.add(stakeRegistrationDetail);
                         break;
@@ -81,7 +85,8 @@ public class StakeRegProcessor {
                                     .build();
                         }
                         stakeRegistrationDetail = buildStakeRegistrationDetail(
-                                stakeDeregistration, txHash, index, txIndex, eventMetadata);
+                                stakeDeregistration, txHash, index, txIndex,
+                                extractDeregistrationDeposit(certificate), eventMetadata);
 
                         stakeRegDeRegs.add(stakeRegistrationDetail);
                         break;
@@ -125,7 +130,8 @@ public class StakeRegProcessor {
 
                         delegation = buildDelegation(stakeDelegation, txHash, index, txIndex, eventMetadata);
                         stakeRegistrationDetail = buildStakeRegistrationDetail(
-                                stakeRegistration, txHash, index, txIndex, eventMetadata);
+                                stakeRegistration, txHash, index, txIndex,
+                                resolveRegistrationDeposit(certificate, eventMetadata.getEpochNumber()), eventMetadata);
 
                         stakeRegDeRegs.add(stakeRegistrationDetail);
                         delegations.add(delegation);
@@ -151,10 +157,36 @@ public class StakeRegProcessor {
         }
     }
 
+    private BigInteger resolveRegistrationDeposit(Certificate certificate, int epoch) {
+        BigInteger coin = switch (certificate.getType()) {
+            case REG_CERT -> ((RegCert) certificate).getCoin();
+            case STAKE_REG_DELEG_CERT -> ((StakeRegDelegCert) certificate).getCoin();
+            case VOTE_REG_DELEG_CERT -> ((VoteRegDelegCert) certificate).getCoin();
+            case STAKE_VOTE_REG_DELEG_CERT -> ((StakeVoteRegDelegCert) certificate).getCoin();
+            default -> null;
+        };
+        if (coin != null) {
+            return coin;
+        }
+        return depositParamService.getKeyDeposit(epoch);
+    }
+
+    /**
+     * Conway unregistration certificates carry their refund explicitly. Legacy deregistration
+     * certificates do not, so their stored deposit remains null and is resolved from lifecycle
+     * history only by consumers that require the refund amount.
+     */
+    private BigInteger extractDeregistrationDeposit(Certificate certificate) {
+        return certificate.getType() == CertificateType.UNREG_CERT
+                ? ((UnregCert) certificate).getCoin()
+                : null;
+    }
+
     private StakeRegistrationDetail buildStakeRegistrationDetail(StakeRegistration stakeRegistration,
                                                                  String txHash,
                                                                  int certIndex,
                                                                  int txIndex,
+                                                                 BigInteger deposit,
                                                                  EventMetadata eventMetadata) {
         Address address =
                 AddressUtil.getRewardAddress(stakeRegistration.getStakeCredential(), eventMetadata.isMainnet());
@@ -168,6 +200,7 @@ public class StakeRegProcessor {
                 .certIndex(certIndex)
                 .txIndex(txIndex)
                 .type(CertificateType.STAKE_REGISTRATION)
+                .deposit(deposit)
                 .epoch(eventMetadata.getEpochNumber())
                 .slot(eventMetadata.getSlot())
                 .blockNumber(eventMetadata.getBlock())
@@ -180,6 +213,7 @@ public class StakeRegProcessor {
                                                                  String txHash,
                                                                  int certIndex,
                                                                  int txIndex,
+                                                                 BigInteger deposit,
                                                                  EventMetadata eventMetadata) {
         Address address =
                 AddressUtil.getRewardAddress(stakeDeregistration.getStakeCredential(), eventMetadata.isMainnet());
@@ -193,6 +227,7 @@ public class StakeRegProcessor {
                 .certIndex(certIndex)
                 .txIndex(txIndex)
                 .type(CertificateType.STAKE_DEREGISTRATION)
+                .deposit(deposit)
                 .epoch(eventMetadata.getEpochNumber())
                 .slot(eventMetadata.getSlot())
                 .blockNumber(eventMetadata.getBlock())

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/service/DepositParamService.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/service/DepositParamService.java
@@ -1,35 +1,54 @@
 package com.bloxbean.cardano.yaci.store.staking.service;
 
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
 import com.bloxbean.cardano.yaci.store.epoch.service.ProtocolParamService;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
+import java.util.function.Function;
 
 import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 
 @Component
-@RequiredArgsConstructor
 public class DepositParamService {
     private final ProtocolParamService protocolParamService;
+    private final GenesisConfig genesisConfig;
+
+    public DepositParamService(@Autowired(required = false) ProtocolParamService protocolParamService,
+                               GenesisConfig genesisConfig) {
+        this.protocolParamService = protocolParamService;
+        this.genesisConfig = genesisConfig;
+    }
 
     public BigInteger getKeyDeposit(int epoch) {
-        return protocolParamService.getProtocolParam(epoch)
-                .map(p -> p.getKeyDeposit())
-                .orElse(adaToLovelace(2));
+        return resolveDeposit(epoch, ProtocolParams::getKeyDeposit, adaToLovelace(2));
     }
 
     public BigInteger getPoolDeposit(int epoch) {
-        return protocolParamService.getProtocolParam(epoch)
-                .map(p -> p.getPoolDeposit())
-                .orElse(adaToLovelace(500));
+        return resolveDeposit(epoch, ProtocolParams::getPoolDeposit, adaToLovelace(500));
     }
 
-    public BigInteger getDRepDeposit(int epoch) {
-        return adaToLovelace(1000);
-    }
+    private BigInteger resolveDeposit(int epoch, Function<ProtocolParams, BigInteger> getter, BigInteger legacyFallback) {
+        if (protocolParamService != null) {
+            BigInteger fromEpoch = protocolParamService.getProtocolParam(epoch)
+                    .map(getter)
+                    .orElse(null);
+            if (fromEpoch != null) {
+                return fromEpoch;
+            }
+        }
 
-    public BigInteger getGovActionDeposit(int epoch) {
-        return adaToLovelace(1000);
+        ProtocolParams genesisParams = genesisConfig.getShelleyGenesisProtocolParams();
+        if (genesisParams != null) {
+            BigInteger fromGenesis = getter.apply(genesisParams);
+            if (fromGenesis != null) {
+                return fromGenesis;
+            }
+        }
+
+        // Preserve the pre-existing defaults when epoch and Shelley genesis parameters are unavailable.
+        return legacyFallback;
     }
 }

--- a/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/model/StakeRegistrationEntity.java
+++ b/stores/staking/src/main/java/com/bloxbean/cardano/yaci/store/staking/storage/impl/model/StakeRegistrationEntity.java
@@ -9,6 +9,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigInteger;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,6 +40,9 @@ public class StakeRegistrationEntity extends BlockAwareEntity {
     @Column(name = "type")
     @Enumerated(EnumType.STRING)
     private CertificateType type;
+
+    @Column(name = "deposit")
+    private BigInteger deposit;
 
     @Column(name = "address")
     private String address;

--- a/stores/staking/src/main/resources/db/store/h2/V0_800_3__stake_registration_deposit.sql
+++ b/stores/staking/src/main/resources/db/store/h2/V0_800_3__stake_registration_deposit.sql
@@ -1,0 +1,7 @@
+ALTER TABLE stake_registration ADD COLUMN deposit BIGINT;
+
+-- Historical versions calculated stake-key registration deposits as 2 ADA. Deregistrations remain
+-- NULL so their refunds can be resolved from the active registration lifecycle.
+-- Networks with a different historical key deposit require a re-sync for exact values.
+UPDATE stake_registration SET deposit = 2000000
+WHERE type = 'STAKE_REGISTRATION' AND deposit IS NULL;

--- a/stores/staking/src/main/resources/db/store/mysql/V0_800_3__stake_registration_deposit.sql
+++ b/stores/staking/src/main/resources/db/store/mysql/V0_800_3__stake_registration_deposit.sql
@@ -1,0 +1,7 @@
+ALTER TABLE stake_registration ADD COLUMN deposit BIGINT;
+
+-- Historical versions calculated stake-key registration deposits as 2 ADA. Deregistrations remain
+-- NULL so their refunds can be resolved from the active registration lifecycle.
+-- Networks with a different historical key deposit require a re-sync for exact values.
+UPDATE stake_registration SET deposit = 2000000
+WHERE type = 'STAKE_REGISTRATION' AND deposit IS NULL;

--- a/stores/staking/src/main/resources/db/store/postgresql/V0_800_3__stake_registration_deposit.sql
+++ b/stores/staking/src/main/resources/db/store/postgresql/V0_800_3__stake_registration_deposit.sql
@@ -1,0 +1,7 @@
+ALTER TABLE stake_registration ADD COLUMN deposit BIGINT;
+
+-- Historical versions calculated stake-key registration deposits as 2 ADA. Deregistrations remain
+-- NULL so their refunds can be resolved from the active registration lifecycle.
+-- Networks with a different historical key deposit require a re-sync for exact values.
+UPDATE stake_registration SET deposit = 2000000
+WHERE type = 'STAKE_REGISTRATION' AND deposit IS NULL;

--- a/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/SpringBootTestApplication.java
+++ b/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/SpringBootTestApplication.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.store.staking;
 
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
 import com.bloxbean.cardano.yaci.store.epoch.service.ProtocolParamService;
 import com.bloxbean.cardano.yaci.store.plugin.core.PluginRegistry;
 import com.bloxbean.cardano.yaci.store.plugin.metrics.PluginMetricsCollector;
@@ -11,6 +12,8 @@ import org.springframework.context.annotation.Bean;
 
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 @SpringBootApplication
 public class SpringBootTestApplication {
     public static void main(String[] args) {
@@ -18,9 +21,14 @@ public class SpringBootTestApplication {
     }
 
     @Bean
-    public DepositParamService depositParamService() {
+    public DepositParamService depositParamService(GenesisConfig genesisConfig) {
         ProtocolParamService protocolParamService = new ProtocolParamService(null);
-        return new DepositParamService(protocolParamService);
+        return new DepositParamService(protocolParamService, genesisConfig);
+    }
+
+    @Bean
+    public GenesisConfig genesisConfig() {
+        return mock(GenesisConfig.class);
     }
 
     @Bean

--- a/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/processor/StakeRegProcessorTest.java
+++ b/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/processor/StakeRegProcessorTest.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yaci.store.staking.processor;
 
 import com.bloxbean.cardano.yaci.core.model.certs.*;
+import com.bloxbean.cardano.yaci.core.model.governance.Drep;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.store.events.CertificateEvent;
 import com.bloxbean.cardano.yaci.store.events.EventMetadata;
@@ -8,7 +9,9 @@ import com.bloxbean.cardano.yaci.store.events.RollbackEvent;
 import com.bloxbean.cardano.yaci.store.events.domain.TxCertificates;
 import com.bloxbean.cardano.yaci.store.staking.domain.Delegation;
 import com.bloxbean.cardano.yaci.store.staking.domain.StakeRegistrationDetail;
+import com.bloxbean.cardano.yaci.store.staking.service.DepositParamService;
 import com.bloxbean.cardano.yaci.store.staking.storage.StakingCertificateStorage;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -18,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +36,9 @@ class StakeRegProcessorTest {
     @Mock
     private ApplicationEventPublisher publisher;
 
+    @Mock
+    private DepositParamService depositParamService;
+
     @InjectMocks
     private StakeRegProcessor stakeRegProcessor;
 
@@ -43,6 +50,7 @@ class StakeRegProcessorTest {
 
     @Test
     void processStakeRegistration_WhenCertTypeIsStakeRegistration() {
+        when(depositParamService.getKeyDeposit(anyInt())).thenReturn(BigInteger.valueOf(2_000_000));
         StakeRegistration stakeRegistrationCert = StakeRegistration
                 .builder()
                 .stakeCredential(StakeCredential.builder()
@@ -76,10 +84,11 @@ class StakeRegProcessorTest {
         assertThat(stakeRegDeSaved.getType()).isEqualTo(CertificateType.STAKE_REGISTRATION);
         assertThat(stakeRegDeSaved.getTxHash()).isEqualTo("08a5678d15d1a9196524a35e580b98b4e8b8dc2d57d544a6c8f9520f885d1fdb");
         assertThat(stakeRegDeSaved.getCredential()).isEqualTo(stakeRegistrationCert.getStakeCredential().getHash());
+        assertThat(stakeRegDeSaved.getDeposit()).isEqualTo(BigInteger.valueOf(2_000_000));
     }
 
     @Test
-    void processStakeRegistration_WhenCertTypeIsStakeDeRegistration() {
+    void processStakeRegistration_WhenLegacyDeregistration_SavesNullDeposit() {
         StakeDeregistration stakeDeregistrationCert = StakeDeregistration
                 .builder()
                 .stakeCredential(StakeCredential.builder()
@@ -114,6 +123,40 @@ class StakeRegProcessorTest {
         assertThat(stakeRegDeSaved.getCertIndex()).isEqualTo(0);
         assertThat(stakeRegDeSaved.getTxHash()).isEqualTo("08a5678d15d1a9196524a35e580b98b4e8b8dc2d57d544a6c8f9520f885d1fdb");
         assertThat(stakeRegDeSaved.getCredential()).isEqualTo(stakeDeregistrationCert.getStakeCredential().getHash());
+        assertThat(stakeRegDeSaved.getDeposit()).isNull();
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
+    void processStakeRegistration_WhenRegistrationAndDeregistrationShareEvent_SavesCertificateDeposits() {
+        BigInteger registrationDeposit = BigInteger.valueOf(5_000_000);
+        when(depositParamService.getKeyDeposit(anyInt())).thenReturn(registrationDeposit);
+        StakeRegistration registration = StakeRegistration.builder()
+                .stakeCredential(addrKeyCredential())
+                .build();
+        StakeDeregistration deregistration = StakeDeregistration.builder()
+                .stakeCredential(addrKeyCredential())
+                .build();
+        CertificateEvent certificateEvent = new CertificateEvent(eventMetadata(), List.of(
+                TxCertificates.builder()
+                        .txHash("08a5678d15d1a9196524a35e580b98b4e8b8dc2d57d544a6c8f9520f885d1fdb")
+                        .txIndex(0)
+                        .certificates(List.of(registration))
+                        .build(),
+                TxCertificates.builder()
+                        .txHash("18a5678d15d1a9196524a35e580b98b4e8b8dc2d57d544a6c8f9520f885d1fda")
+                        .txIndex(1)
+                        .certificates(List.of(deregistration))
+                        .build()));
+
+        stakeRegProcessor.processStakeRegistration(certificateEvent);
+
+        verify(stakingStorage).saveRegistrations(stakeRegDetailCaptor.capture());
+        assertThat(stakeRegDetailCaptor.getValue())
+                .extracting(StakeRegistrationDetail::getType, StakeRegistrationDetail::getDeposit)
+                .containsExactly(
+                        Tuple.tuple(CertificateType.STAKE_REGISTRATION, registrationDeposit),
+                        Tuple.tuple(CertificateType.STAKE_DEREGISTRATION, null));
     }
 
     @Test
@@ -155,6 +198,70 @@ class StakeRegProcessorTest {
     }
 
     @Test
+    void processStakeRegistration_WhenCertTypeIsRegCert_storesCertificateCoin() {
+        BigInteger coin = BigInteger.valueOf(5_000_000);
+        Certificate certificate = RegCert.builder()
+                .stakeCredential(addrKeyCredential())
+                .coin(coin)
+                .build();
+
+        processAndAssertStoredDeposit(certificate, CertificateType.STAKE_REGISTRATION, coin);
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
+    void processStakeRegistration_WhenCertTypeIsUnregCert_storesCertificateCoin() {
+        BigInteger coin = BigInteger.valueOf(5_000_000);
+        Certificate certificate = UnregCert.builder()
+                .stakeCredential(addrKeyCredential())
+                .coin(coin)
+                .build();
+
+        processAndAssertStoredDeposit(certificate, CertificateType.STAKE_DEREGISTRATION, coin);
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
+    void processStakeRegistration_WhenCertTypeIsStakeRegDelegCert_storesCertificateCoin() {
+        BigInteger coin = BigInteger.valueOf(5_000_000);
+        Certificate certificate = StakeRegDelegCert.builder()
+                .stakeCredential(addrKeyCredential())
+                .poolKeyHash("62d3773887d1c644d4b28a5743f111597e0ad5654b71d613f40f5d03")
+                .coin(coin)
+                .build();
+
+        processAndAssertStoredDeposit(certificate, CertificateType.STAKE_REGISTRATION, coin);
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
+    void processStakeRegistration_WhenCertTypeIsVoteRegDelegCert_storesCertificateCoin() {
+        BigInteger coin = BigInteger.valueOf(5_000_000);
+        Certificate certificate = VoteRegDelegCert.builder()
+                .stakeCredential(addrKeyCredential())
+                .drep(Drep.addrKeyHash("d1e89233461ca210819328b840ec79ec825b93d9b0501749dea1ecb8"))
+                .coin(coin)
+                .build();
+
+        processAndAssertStoredDeposit(certificate, CertificateType.STAKE_REGISTRATION, coin);
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
+    void processStakeRegistration_WhenCertTypeIsStakeVoteRegDelegCert_storesCertificateCoin() {
+        BigInteger coin = BigInteger.valueOf(5_000_000);
+        Certificate certificate = StakeVoteRegDelegCert.builder()
+                .stakeCredential(addrKeyCredential())
+                .poolKeyHash("62d3773887d1c644d4b28a5743f111597e0ad5654b71d613f40f5d03")
+                .drep(Drep.addrKeyHash("d1e89233461ca210819328b840ec79ec825b93d9b0501749dea1ecb8"))
+                .coin(coin)
+                .build();
+
+        processAndAssertStoredDeposit(certificate, CertificateType.STAKE_REGISTRATION, coin);
+        verify(depositParamService, never()).getKeyDeposit(anyInt());
+    }
+
+    @Test
     void handleRollbackEvent() {
         RollbackEvent rollbackEvent = RollbackEvent.builder()
                 .currentPoint(new Point(78650212, "07de1aad598dd499d44be8bd8c28d5cadf4f47fbfb6b2144ccfb376c996ffcec"))
@@ -167,7 +274,34 @@ class StakeRegProcessorTest {
         verify(stakingStorage, times(1)).deleteDelegationsBySlotGreaterThan(rollbackEvent.getRollbackTo().getSlot());
     }
 
+    private void processAndAssertStoredDeposit(Certificate certificate, CertificateType expectedType, BigInteger expectedDeposit) {
+        CertificateEvent certificateEvent =
+                new CertificateEvent(eventMetadata(),
+                        List.of(TxCertificates.builder()
+                                .txHash("08a5678d15d1a9196524a35e580b98b4e8b8dc2d57d544a6c8f9520f885d1fdb")
+                                .certificates(List.of(certificate))
+                                .build()));
+
+        stakeRegProcessor.processStakeRegistration(certificateEvent);
+
+        verify(stakingStorage, times(1)).saveRegistrations(stakeRegDetailCaptor.capture());
+        StakeRegistrationDetail saved = stakeRegDetailCaptor.getValue().get(0);
+        assertThat(saved.getType()).isEqualTo(expectedType);
+        assertThat(saved.getDeposit()).isEqualTo(expectedDeposit);
+    }
+
+    private StakeCredential addrKeyCredential() {
+        return StakeCredential.builder()
+                .type(StakeCredType.ADDR_KEYHASH)
+                .hash("42343525e6ff07e4de2a1328936c96406e432ff0aaeb7a5c5a5a6cc9")
+                .build();
+    }
+
     private EventMetadata eventMetadata() {
+        return eventMetadata(31742048);
+    }
+
+    private EventMetadata eventMetadata(long slot) {
         return EventMetadata.builder()
                 .mainnet(false)
                 .epochNumber(77)
@@ -176,7 +310,7 @@ class StakeRegProcessorTest {
                 .blockHash("5f834500d2e4dde1bc07feb8e00cd320c53f26fa41749f2e2b2bd0a81fa833f7")
                 .blockTime(1687425248L)
                 .prevBlockHash("3cc1a49034fdcc2463d3a0a4d56b052429988335d6856d8f7485fbd2f2d71383")
-                .slot(31742048)
+                .slot(slot)
                 .epochSlot(119648)
                 .noOfTxs(5)
                 .syncMode(false)

--- a/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/service/DepositParamServiceTest.java
+++ b/stores/staking/src/test/java/com/bloxbean/cardano/yaci/store/staking/service/DepositParamServiceTest.java
@@ -1,0 +1,95 @@
+package com.bloxbean.cardano.yaci.store.staking.service;
+
+import com.bloxbean.cardano.yaci.store.common.domain.ProtocolParams;
+import com.bloxbean.cardano.yaci.store.core.configuration.GenesisConfig;
+import com.bloxbean.cardano.yaci.store.epoch.service.ProtocolParamService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DepositParamServiceTest {
+
+    @Mock
+    private ProtocolParamService protocolParamService;
+
+    @Mock
+    private GenesisConfig genesisConfig;
+
+    @Test
+    void getKeyDeposit_returnsEpochParamWhenPresent() {
+        when(protocolParamService.getProtocolParam(100))
+                .thenReturn(Optional.of(ProtocolParams.builder()
+                        .keyDeposit(BigInteger.valueOf(3_000_000))
+                        .build()));
+
+        DepositParamService service = new DepositParamService(protocolParamService, genesisConfig);
+
+        assertThat(service.getKeyDeposit(100)).isEqualTo(BigInteger.valueOf(3_000_000));
+    }
+
+    @Test
+    void getKeyDeposit_fallsBackToShelleyGenesisWhenEpochParamsMissing() {
+        when(protocolParamService.getProtocolParam(100)).thenReturn(Optional.empty());
+        when(genesisConfig.getShelleyGenesisProtocolParams())
+                .thenReturn(ProtocolParams.builder()
+                        .keyDeposit(BigInteger.valueOf(2_000_000))
+                        .build());
+
+        DepositParamService service = new DepositParamService(protocolParamService, genesisConfig);
+
+        assertThat(service.getKeyDeposit(100)).isEqualTo(BigInteger.valueOf(2_000_000));
+    }
+
+    @Test
+    void getKeyDeposit_fallsBackToTwoAdaWhenGenesisMissing() {
+        when(genesisConfig.getShelleyGenesisProtocolParams()).thenReturn(null);
+
+        DepositParamService service = new DepositParamService(null, genesisConfig);
+
+        assertThat(service.getKeyDeposit(0)).isEqualTo(adaToLovelace(2));
+    }
+
+    @Test
+    void getPoolDeposit_returnsEpochParamWhenPresent() {
+        when(protocolParamService.getProtocolParam(100))
+                .thenReturn(Optional.of(ProtocolParams.builder()
+                        .poolDeposit(BigInteger.valueOf(600_000_000))
+                        .build()));
+
+        DepositParamService service = new DepositParamService(protocolParamService, genesisConfig);
+
+        assertThat(service.getPoolDeposit(100)).isEqualTo(BigInteger.valueOf(600_000_000));
+    }
+
+    @Test
+    void getPoolDeposit_fallsBackToShelleyGenesisWhenEpochParamsMissing() {
+        when(protocolParamService.getProtocolParam(100)).thenReturn(Optional.empty());
+        when(genesisConfig.getShelleyGenesisProtocolParams())
+                .thenReturn(ProtocolParams.builder()
+                        .poolDeposit(BigInteger.valueOf(500_000_000))
+                        .build());
+
+        DepositParamService service = new DepositParamService(protocolParamService, genesisConfig);
+
+        assertThat(service.getPoolDeposit(100)).isEqualTo(BigInteger.valueOf(500_000_000));
+    }
+
+    @Test
+    void getPoolDeposit_fallsBackToFiveHundredAdaWhenGenesisMissing() {
+        when(genesisConfig.getShelleyGenesisProtocolParams()).thenReturn(null);
+
+        DepositParamService service = new DepositParamService(null, genesisConfig);
+
+        assertThat(service.getPoolDeposit(0)).isEqualTo(adaToLovelace(500));
+    }
+
+}


### PR DESCRIPTION
 ## Summary

  Backport #1111 to `release/2.0.x`.

  This persists stake-key deposits on `stake_registration` rows so deposit accounting no longer assumes a constant 2 ADA. Registrations store the certificate coin when available, otherwise resolve the applicable epoch/
  genesis `keyDeposit`; legacy deregistration rows remain nullable and AdaPot resolves refunds from the preceding active registration lifecycle row.

  ## Changes

  - Add nullable `deposit` column to `stake_registration` for H2, MySQL, and PostgreSQL through `V0_800_3__stake_registration_deposit.sql`.
  - Backfill historical `STAKE_REGISTRATION` rows with the existing 2 ADA behavior while keeping historical `STAKE_DEREGISTRATION` rows `NULL`.
  - Persist registration deposit values in the staking ingest path.
  - Update AdaPot deposit snapshots to use stored stake registration deposits and resolve legacy deregistration refunds from lifecycle history.
  - Add Shelley genesis protocol-parameter fallback for key/pool deposits.
  - Add `DATA_MISSING_ERROR` to support observable fallback behavior when a legacy deregistration refund cannot be resolved.

  ## Backport notes

  The original PR also touched `extensions/blockfrost/account` and `aggregates/analytics-store`, but those modules are not present on `release/2.0.x`, so those parts were intentionally excluded from this backport.

  `DATA_MISSING_ERROR` originally came from #1107, which introduced it for transaction full-CBOR missing-data reporting. This backport currently includes only the enum value required by #1111's AdaPot fallback path, not
  the rest of #1107.

  ## Open question

  Should we also backport #1107 to `release/2.0.x` in another PR?


  ## Verification

  - `JAVA_HOME=/home/huy/.jdks/openjdk-21 ./gradlew :components:core:test :stores:staking:test :aggregates:adapot:test`

  Result: `BUILD SUCCESSFUL`.
