### PR TITLE
chore(config): switch default mainnet relay to Cardano Foundation backbone (backport #1125)

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -17,6 +17,9 @@ store.cardano.protocol-magic=1
 #store.cardano.port=3001
 #store.cardano.protocol-magic=764824073
 
+#For an alternate public mainnet relay, use IOG's backbone instead of the host above
+#store.cardano.host=backbone.cardano.iog.io
+
 #Sanchonet
 #store.cardano.host=sanchonet-node.play.dev.cardano.org
 #store.cardano.port=3001

--- a/config/application.properties
+++ b/config/application.properties
@@ -13,7 +13,7 @@ store.cardano.protocol-magic=1
 #store.cardano.protocol-magic=2
 
 #Ucomment below for mainnet
-#store.cardano.host=backbone.cardano.iog.io
+#store.cardano.host=backbone.mainnet.cardanofoundation.org
 #store.cardano.port=3001
 #store.cardano.protocol-magic=764824073
 

--- a/docker/config/application.properties
+++ b/docker/config/application.properties
@@ -17,6 +17,9 @@ store.cardano.protocol-magic=1
 #store.cardano.port=3001
 #store.cardano.protocol-magic=764824073
 
+#For an alternate public mainnet relay, use IOG's backbone instead of the host above
+#store.cardano.host=backbone.cardano.iog.io
+
 #Sanchonet
 #store.cardano.host=sanchonet-node.play.dev.cardano.org
 #store.cardano.port=3001

--- a/docker/config/application.properties
+++ b/docker/config/application.properties
@@ -13,7 +13,7 @@ store.cardano.protocol-magic=1
 #store.cardano.protocol-magic=2
 
 #Ucomment below for mainnet
-#store.cardano.host=backbone.cardano.iog.io
+#store.cardano.host=backbone.mainnet.cardanofoundation.org
 #store.cardano.port=3001
 #store.cardano.protocol-magic=764824073
 


### PR DESCRIPTION
Backport of #1125 to `release/2.0.x`.

## Summary

Makes `backbone.mainnet.cardanofoundation.org` the default mainnet relay in the sample configuration. The previous default, `backbone.cardano.iog.io`, was noticeably slower during our mainnet sync testing.

The IOG relay is kept in the file as a commented alternate, so users can switch by uncommenting it:

```properties
#Ucomment below for mainnet
#store.cardano.host=backbone.mainnet.cardanofoundation.org
#store.cardano.port=3001
#store.cardano.protocol-magic=764824073

#For an alternate public mainnet relay, use IOG's backbone instead of the host above
#store.cardano.host=backbone.cardano.iog.io
```

Applied to both:
- `config/application.properties`
- `docker/config/application.properties`

Port (`3001`) and protocol magic (`764824073`) are unchanged.

Cherry-picked cleanly from #1125 — no conflicts, resulting diff is identical to the main PR.

## Test plan

Comment-only defaults in sample config files; no code paths affected. Verified by syncing mainnet against the new relay during testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
