### PR TITLE
chore(docker): add missing assets extension section to docker config (backport #1127)

### DIFF
--- a/docker/config/application.properties
+++ b/docker/config/application.properties
@@ -336,6 +336,21 @@ logging.level.com.bloxbean.cardano.yaci.store.core.service=INFO
 
 server.forward-headers-strategy=framework
 
+#######################################################################################
+# Assets Extension (CIP-26 + CIP-68 + CIP-113 Token Metadata)
+# Disabled by default. Uncomment the master flag to enable; CIP-26 and CIP-68 are then
+# enabled by default, so the master flag alone gives the default behaviour.
+# CIP-26 git registry auto-detected from store.cardano.protocol-magic.
+# CIP-68 is on-chain and needs no config.
+# CIP-113 registry NFT policy IDs auto-detected from protocol-magic.
+#######################################################################################
+#store.assets.ext.enabled=true
+# CIP-26 and CIP-68 are enabled by default when the master flag is on. To disable one:
+#store.assets.ext.cip26.enabled=false
+#store.assets.ext.cip68.enabled=false
+# CIP-113 is off by default (not yet live on mainnet). To enable:
+#store.assets.ext.cip113.enabled=true
+
 spring.threads.virtual.enabled=true
 
 #######################################################################################


### PR DESCRIPTION
Backport of #1127 to `release/2.0.x`.

## Summary

`config/application.properties` documents the Assets Extension (CIP-26 / CIP-68 / CIP-113) flags, but `docker/config/application.properties` was missing that section entirely — so Docker users had no discoverable way to enable the extension. The same gap exists on `release/2.0.x`.

Copied the section verbatim from `config/application.properties` into `docker/config/application.properties`, in the same position (between `server.forward-headers-strategy` and `spring.threads.virtual.enabled`).

```properties
#store.assets.ext.enabled=true
#store.assets.ext.cip26.enabled=false
#store.assets.ext.cip68.enabled=false
#store.assets.ext.cip113.enabled=true
```

The `applications/all` distribution used by the Docker image on this branch already depends on `starters:assets-ext-spring-boot-starter`, so these are functional knobs — they were just undocumented on the Docker side.

Cherry-picked cleanly from #1127 — no conflicts. The source section in `config/application.properties` is identical on `main` and `release/2.0.x`, and the resulting diff matches the main PR exactly.

## Behaviour

None. Every added line is a comment; defaults are unchanged.

## Other drift, not addressed here

Same as in #1127 — two properties still present only in `config/application.properties`, left alone to keep this scoped to the assets extension:

- `#store.cardano.mempool-monitoring-enabled=true`
- `#store.block-receive-delay-seconds=120`

## Test plan

Comment-only addition to a sample config file; no code paths affected. Verified the copied block is byte-identical to the source section on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
