### PR TITLE
Disable auto-recovery by default for analytics profile

### DIFF
--- a/docker/config/application-analytics.properties
+++ b/docker/config/application-analytics.properties
@@ -23,10 +23,6 @@ yaci.store.analytics.continuous-sync.buffer-days=1
 # Enable admin API for monitoring
 yaci.store.analytics.admin.enabled=true
 
-# Auto recovery: restart sync if health check fails (connection lost, errors, or no blocks received)
-store.admin.auto-recovery-enabled=true
-store.admin.health-check-interval=120
-
 ####################
 # DuckDB configuration
 ####################


### PR DESCRIPTION
## Summary

- Remove automatic enablement of sync auto-recovery from the Docker analytics profile.
- Remove the analytics-specific 120-second health-check interval override, which is no longer needed when auto-recovery is disabled.
- Keep auto-recovery available as an explicit operator opt-in through the existing base configuration documentation.

## Rationale

During long-running block post-processing, auto-recovery can classify sync as unhealthy and start a replacement sync before callbacks from the previous session have terminated. This can produce overlapping sync generations and corrupt shared derived state.

The immediate safe mitigation is to stop enabling auto-recovery merely by selecting the analytics profile while the restart/quiescence behavior is investigated.

Related to #1129. This PR mitigates the default configuration risk but does not close the underlying concurrency issue.

## Profile audit

Searched all application properties, YAML, and YML profile files. The analytics Docker profile was the only profile with an active auto-recovery-enabled setting. The remaining occurrences are commented examples in the base application configurations.

## Validation

- git diff --check
- Verified no application profile actively sets auto-recovery-enabled
