### PR TITLE
fix(admin-cli): add cip68 rollback table

### DIFF
--- a/components/dbutils/src/main/resources/rollback.yml
+++ b/components/dbutils/src/main/resources/rollback.yml
@@ -6,6 +6,13 @@ rollback:
         type: "slot"
         column: "slot"
         operator: ">"
+
+    - name: "cip68_metadata"
+      operation: "DELETE"
+      condition:
+        type: "slot"
+        column: "slot"
+        operator: ">"
         
     - name: "block"
       operation: "DELETE"

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/RollbackServiceTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/RollbackServiceTest.java
@@ -68,6 +68,7 @@ class RollbackServiceTest {
         assertTrue(result.getSecond());
 
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM assets WHERE slot > :slot"), any(SqlParameterSource.class));
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM cip68_metadata WHERE slot > :slot"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM block WHERE slot > :slot"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM block_cbor WHERE slot > :slot"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM transaction_cbor WHERE slot > :slot"), any(SqlParameterSource.class));
@@ -111,6 +112,7 @@ class RollbackServiceTest {
         assertTrue(result.getSecond());
 
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM assets WHERE slot > :slot"), any(SqlParameterSource.class));
+        verify(jdbcTemplate, times(1)).update(eq("DELETE FROM cip68_metadata WHERE slot > :slot"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM epoch_stake WHERE epoch >= (:epoch + -1)"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM tx_input WHERE spent_at_slot > :slot"), any(SqlParameterSource.class));
         verify(jdbcTemplate, times(1)).update(eq("DELETE FROM adapot_jobs WHERE slot > :slot"), any(SqlParameterSource.class));

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/RollbackLoaderTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/RollbackLoaderTest.java
@@ -59,6 +59,16 @@ class RollbackLoaderTest {
         assertEquals("slot", assetTable.getCondition().getColumn());
         assertEquals(">", assetTable.getCondition().getOperator());
         assertNull(assetTable.getCondition().getOffset());
+
+        RollbackConfig.TableRollbackDefinition cip68Table = findTableByName(config.getTables(), "cip68_metadata");
+        assertNotNull(cip68Table);
+        assertEquals("DELETE", cip68Table.getOperation());
+        assertEquals("slot", cip68Table.getCondition().getType());
+        assertEquals("slot", cip68Table.getCondition().getColumn());
+        assertEquals(">", cip68Table.getCondition().getOperator());
+        assertNull(cip68Table.getCondition().getOffset());
+
+        assertNull(findTableByName(config.getTables(), "cip113_registry_node"));
     }
 
     @Test
@@ -73,6 +83,8 @@ class RollbackLoaderTest {
         assertTrue(tableNames.contains("adapot_jobs"));
         assertTrue(tableNames.contains("tx_input"));
         assertTrue(tableNames.contains("assets"));
+        assertTrue(tableNames.contains("cip68_metadata"));
+        assertFalse(tableNames.contains("cip113_registry_node"));
     }
 
     @Test

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/RollbackLoaderTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/RollbackLoaderTest.java
@@ -67,8 +67,6 @@ class RollbackLoaderTest {
         assertEquals("slot", cip68Table.getCondition().getColumn());
         assertEquals(">", cip68Table.getCondition().getOperator());
         assertNull(cip68Table.getCondition().getOffset());
-
-        assertNull(findTableByName(config.getTables(), "cip113_registry_node"));
     }
 
     @Test
@@ -84,7 +82,6 @@ class RollbackLoaderTest {
         assertTrue(tableNames.contains("tx_input"));
         assertTrue(tableNames.contains("assets"));
         assertTrue(tableNames.contains("cip68_metadata"));
-        assertFalse(tableNames.contains("cip113_registry_node"));
     }
 
     @Test


### PR DESCRIPTION
 ## Summary

  - Add `cip68_metadata` to the default admin-cli rollback configuration.
  - Verify rollback config loading includes CIP-68 on-chain metadata rollback.
  - Verify rollback SQL generation deletes CIP-68 rows by `slot > :slot`.

  ## Details

  The asset-ext CIP-68 metadata table stores on-chain reference NFT metadata and already uses slot-based rollback in the runtime rollback processor. The admin-cli rollback path loads table operations from
  `rollback.yml`, so `cip68_metadata` must be listed there for manual rollback operations to clean rows after the rollback point.

  CIP-113 rollback is intentionally not added because the CIP-113 implementation is expected to be removed from asset-ext.

#1132 