### PR TITLE
fix(common): use byron genesis slotDuration for byron slot length (backport #1135)

### DIFF
--- a/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ByronGenesis.java
+++ b/components/common/src/main/java/com/bloxbean/cardano/yaci/store/common/genesis/ByronGenesis.java
@@ -36,7 +36,7 @@ public class ByronGenesis extends GenesisFile {
     private List<GenesisBalance> avvmGenesisBalances;
     private List<GenesisBalance> nonAvvmGenesisBalances;
     private long startTime;
-    private long byronSlotLength;
+    private long byronSlotLength; //in second
     private long protocolMagic;
     private long k;
 
@@ -50,13 +50,6 @@ public class ByronGenesis extends GenesisFile {
 
     public ByronGenesis(long protocolMagic) {
         super(protocolMagic);
-    }
-
-    public long getByronSlotLength() {
-        if (byronSlotLength == 0)
-            return 0;
-        else
-            return byronSlotLength / 1000;
     }
 
     public long getEpochLength() {

--- a/components/common/src/test/java/com/bloxbean/carano/yaci/store/common/genesis/ByronGenesisTest.java
+++ b/components/common/src/test/java/com/bloxbean/carano/yaci/store/common/genesis/ByronGenesisTest.java
@@ -23,6 +23,7 @@ class ByronGenesisTest {
 
     public static final String GENESIS_MAINNET_BYRON_GENESIS_JSON = "/genesis/mainnet-byron-genesis.json";
     public static final String GENESIS_PREPROD_BYRON_GENESIS_JSON = "/genesis/preprod-byron-genesis.json";
+    public static final String GENESIS_CUSTOM_BYRON_GENESIS_JSON = "/genesis/custom-byron-genesis.json";
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -77,6 +78,24 @@ class ByronGenesisTest {
         List<GenesisBalance> avvmGenesisBalances = byronGenesis.getAvvmGenesisBalances();
         List<GenesisBalance> nonAvvmGenesisBalances = byronGenesis.getNonAvvmGenesisBalances();
         System.out.println(avvmGenesisBalances);
+    }
+
+    @Test
+    void getByronSlotLength_mainnet() {
+        InputStream is = this.getClass().getResourceAsStream(GENESIS_MAINNET_BYRON_GENESIS_JSON);
+        ByronGenesis byronGenesis = new ByronGenesis(is);
+
+        //slotDuration in mainnet byron genesis is 20000 ms
+        assertThat(byronGenesis.getByronSlotLength()).isEqualTo(20);
+    }
+
+    @Test
+    void getByronSlotLength_custom() {
+        InputStream is = this.getClass().getResourceAsStream(GENESIS_CUSTOM_BYRON_GENESIS_JSON);
+        ByronGenesis byronGenesis = new ByronGenesis(is);
+
+        //slotDuration in this custom byron genesis is 1000 ms
+        assertThat(byronGenesis.getByronSlotLength()).isEqualTo(1);
     }
 
     private Map<String, BigInteger> loadMap(String file) {

--- a/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfigTest.java
+++ b/components/core/src/test/java/com/bloxbean/cardano/yaci/store/core/configuration/GenesisConfigTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yaci.store.core.configuration;
 
+import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yaci.store.common.config.StoreProperties;
 import com.bloxbean.cardano.yaci.store.common.domain.NetworkType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,5 +22,17 @@ class GenesisConfigTest {
 
         assertThat(genesisConfig.getShelleyGenesisProtocolParams().getKeyDeposit())
                 .isEqualTo(BigInteger.valueOf(2_000_000));
+    }
+
+    @Test
+    void slotDuration_byron_ReturnsValueFromGenesis() {
+        StoreProperties storeProperties = new StoreProperties();
+        storeProperties.setProtocolMagic(NetworkType.MAINNET.getProtocolMagic());
+        GenesisConfig genesisConfig = new GenesisConfig(
+                storeProperties, new ObjectMapper(), new DefaultResourceLoader());
+
+        //slotDuration in mainnet byron genesis is 20000 ms
+        assertThat(genesisConfig.getByronSlotLength()).isEqualTo(20);
+        assertThat(genesisConfig.slotDuration(Era.Byron)).isEqualTo(20.0);
     }
 }


### PR DESCRIPTION
Backport of #1135 to `release/2.0.x`. Relates to #1053, which was reported against 2.0.2.1.

Clean cherry-pick of c87eb6388 — the three touched files were byte-identical between `main` and `release/2.0.x`, so no adaptation was needed.

## Problem

`ByronGenesis.readGenesisData()` already converts `blockVersionData.slotDuration` from milliseconds to seconds, but `getByronSlotLength()` divided by 1000 a **second** time:

```java
byronSlotLength = ...get(ATTR_SLOT_DURATION).asLong() / 1000; //in second   -> 20

public long getByronSlotLength() {
    if (byronSlotLength == 0)
        return 0;
    else
        return byronSlotLength / 1000;   // 20 / 1000 == 0  (integer division)
}
```

The getter returns a non-zero value only when the field exceeds 1000, i.e. when the genesis `slotDuration` is at least 1,000,000 ms. No real chain declares that, so in practice the method always returned `0`, and `GenesisConfig.slotDuration(Era.Byron)` fell through to its hardcoded 20s fallback — which is why the startup banner printed `ByronEra Slot Duration : 20.0` even though the genesis file had been parsed correctly.

Credit to @edridudi for the root-cause analysis in #1053.

## Impact

Mainnet, preprod and preview all declare `slotDuration: 20000`, whose Byron slots genuinely are 20s — they computed `20000 → 20 → 0 → 20` and landed on the right answer by accident. **No behaviour change for those networks.**

A chain whose Byron era did not run at 20s had its Byron block times computed at 20s/slot. The error accrued at `(20 − actualSeconds)` per Byron slot and then froze once Byron closed, so every post-Byron block inherited it as a constant offset of `byronSlotCount × (20 − actualSeconds)` seconds. In the reported case (`slotDuration: 1000`, 43200 Byron slots) that is `43200 × 19 = 820800`s — timestamps ~9.5 days in the future.

## Fix

Drop the explicit getter so Lombok's `@Data` getter returns the already-converted field. The `long` signature is unchanged, so this is source- and binary-compatible for 2.0.x consumers.

The 20s fallback in `GenesisConfig.slotDuration(Era.Byron)` is deliberately kept for genesis files that fail to supply the field — it just stops being reached for well-formed genesis.

## Note for affected chains

`block_time` is computed at index time and stored, so **this patch does not repair already-indexed data**. A chain with a non-20s Byron slot keeps the offset on every existing row; only newly indexed blocks come out right. Those deployments need a resync from genesis (or a rollback to before the Byron/Shelley boundary). Mainnet/preprod/preview deployments need nothing.

## Tests

Run on this branch against JDK 21 — all pass:

- `ByronGenesisTest.getByronSlotLength_mainnet` → 20 and `getByronSlotLength_custom` → 1, the latter using the already-present-but-unused `custom-byron-genesis.json` (`slotDuration: 1000`) as the regression vector.
- `GenesisConfigTest.slotDuration_byron_ReturnsValueFromGenesis` guards the integration path — asserts the value now comes from the genesis rather than the fallback.

Both fail against the old code (`20 / 1000 == 0`).

## Other genesis subclasses

Checked — no other instance of this shape. `ShelleyGenesis` reads `slotLength` with `asDouble()` and no division; Alonzo and Conway have no slot fields.

## Known limitation left as-is

`readGenesisData()` still truncates ms→s with integer division, so a sub-second Byron `slotDuration` would floor to `0` and hit the fallback. That predates this bug and no known chain uses one; fixing it would mean changing the public getter's return type to `double`, which is not appropriate on a patch branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

