### PR TITLE
fix(analytics): keep stake_registration Parquet export backward compatible

### DIFF
--- a/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/StakeRegistrationExporter.java
+++ b/aggregates/analytics-store/src/main/java/com/bloxbean/cardano/yaci/store/analytics/exporter/StakeRegistrationExporter.java
@@ -52,7 +52,6 @@ public class StakeRegistrationExporter extends AbstractTableExporter {
                     sr.credential,
                     sr.cred_type,
                     sr.type,
-                    sr.deposit,
                     sr.address,
                     sr.epoch,
                     sr.slot,


### PR DESCRIPTION
## Summary

Removes `sr.deposit` from `StakeRegistrationExporter`'s SELECT so the Parquet export schema stays backward compatible with data written by earlier releases.

The `deposit` column was added to `stake_registration` by migration `V0_800_3`, and the exporter was updated to select it. Exporting it changes the Parquet schema, which existing deployments cannot absorb.

## Why this breaks existing deployments

`DuckLakeWriterService` creates each table once with `CREATE TABLE ... AS <query> LIMIT 0` and then appends **positionally**:

```java
String insertSql = String.format("INSERT INTO %s %s;", tableName, query);
```

On a deployment whose `stake_registration` table already has 13 columns, a 14-column SELECT fails on every partition:

```
table stake_registration has 13 columns but 14 values were supplied
```

Recovery means resetting the export state and re-exporting the whole table by hand.

The read path is affected too. `ParquetReadConnectionProvider` reads committed files with `read_parquet([...])`, and the file list comes from `ducklake_list_files()` with **no `ORDER BY`**. With files of differing schemas that ordering decides the outcome — verified against a real DuckLake catalog:

| query | old file first | new file first |
|---|---|---|
| `count(*)` | ok | ok |
| explicit columns present in both | ok | ok |
| `SELECT *` | ok, but **silently omits `deposit`** | **fails**: `schema mismatch in glob` |

Since MCP's `analytics-execute-sql` runs model-generated SQL, `SELECT *` is common.

## What is not affected

`deposit` remains in PostgreSQL and every consumer reads it from there:

- `DepositSnapshotService` (adapot deposit snapshot)
- `BFAccountStorageReaderImpl` (Blockfrost account API)
- `StakeRegistrationEntity` / `StakeRegistrationDetail`

Migration `V0_800_3` and its backfill are unchanged. The only thing deferred is querying `deposit` through the analytics/MCP layer.

## Follow-up

Exporting this column (or any new one) needs both halves, and shipping only one is worse than shipping neither — the writer's positional-insert failure is what currently prevents drift from reaching disk:

1. **Writer** — reconcile the table schema before appending: `ALTER TABLE ... ADD COLUMN` plus `INSERT ... BY NAME`.
2. **Reader** — `union_by_name=true` on `read_parquet()`, otherwise mixed-schema files drop the column or error depending on file order.

## Test plan

- [x] `:aggregates:analytics-store:test` passes
- [x] Exporter SELECT is back to 12 columns, matching the schema of previously exported data
- [x] Verified `sr.deposit` was the only exported column added since the last release, so this restores full export-schema compatibility
- [x] Failure and read-path behaviour reproduced against a real DuckLake catalog before making the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
