### PR TITLE
fix(governance): select latest spo and committee votes

### DIFF
--- a/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
+++ b/aggregates/governance-aggr/src/main/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrService.java
@@ -57,39 +57,49 @@ public class VotingAggrService {
                 .map(id -> row(id.getTransactionId(), id.getGov_action_index()))
                 .collect(Collectors.toList());
 
-        var cteQuery = select(
+        var rankedVoteQuery = select(
+                VOTING_PROCEDURE.TX_HASH.as("tx_hash"),
                 VOTING_PROCEDURE.VOTER_HASH.as("voter_hash"),
                 VOTING_PROCEDURE.VOTER_TYPE.as("voter_type"),
                 VOTING_PROCEDURE.GOV_ACTION_TX_HASH.as("gov_action_tx_hash"),
                 VOTING_PROCEDURE.GOV_ACTION_INDEX.as("gov_action_index"),
-                max(VOTING_PROCEDURE.SLOT).as("max_slot")
+                rowNumber()
+                        .over(partitionBy(
+                                VOTING_PROCEDURE.VOTER_HASH,
+                                VOTING_PROCEDURE.VOTER_TYPE,
+                                VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
+                                VOTING_PROCEDURE.GOV_ACTION_INDEX
+                        ).orderBy(
+                                VOTING_PROCEDURE.SLOT.desc(),
+                                VOTING_PROCEDURE.TX_INDEX.desc(),
+                                VOTING_PROCEDURE.IDX.desc()
+                        ))
+                        .as("vote_rank")
         )
                 .from(VOTING_PROCEDURE)
                 .where(VOTING_PROCEDURE.EPOCH.le(epoch))
                 .and(row(VOTING_PROCEDURE.GOV_ACTION_TX_HASH, VOTING_PROCEDURE.GOV_ACTION_INDEX).in(govActionPairs))
-                .and(VOTING_PROCEDURE.VOTER_TYPE.eq("STAKING_POOL_KEY_HASH"))
-                .groupBy(
-                        VOTING_PROCEDURE.VOTER_HASH,
-                        VOTING_PROCEDURE.VOTER_TYPE,
-                        VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
-                        VOTING_PROCEDURE.GOV_ACTION_INDEX
-                );
+                .and(VOTING_PROCEDURE.VOTER_TYPE.eq("STAKING_POOL_KEY_HASH"));
 
-        var voteWithMaxSlot = table(name("vote_with_max_slot"));
+        var rankedVote = table(name("ranked_vote"));
 
-        var vVoterHash = field(name("vote_with_max_slot", "voter_hash"), String.class);
-        var vGovActionTxHash = field(name("vote_with_max_slot", "gov_action_tx_hash"), String.class);
-        var vGovActionIndex = field(name("vote_with_max_slot", "gov_action_index"), Integer.class);
-        var vMaxSlot = field(name("vote_with_max_slot", "max_slot"), Long.class);
+        var vTxHash = field(name("ranked_vote", "tx_hash"), String.class);
+        var vVoterHash = field(name("ranked_vote", "voter_hash"), String.class);
+        var vVoterType = field(name("ranked_vote", "voter_type"), String.class);
+        var vGovActionTxHash = field(name("ranked_vote", "gov_action_tx_hash"), String.class);
+        var vGovActionIndex = field(name("ranked_vote", "gov_action_index"), Integer.class);
+        var vVoteRank = field(name("ranked_vote", "vote_rank"), Integer.class);
 
-        Result<Record> result = dsl.with("vote_with_max_slot").as(cteQuery)
+        Result<Record> result = dsl.with("ranked_vote").as(rankedVoteQuery)
                 .select(VOTING_PROCEDURE.fields())
                 .from(VOTING_PROCEDURE)
-                .join(voteWithMaxSlot)
-                .on(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash)
+                .join(rankedVote)
+                .on(VOTING_PROCEDURE.TX_HASH.eq(vTxHash)
+                        .and(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash))
+                        .and(VOTING_PROCEDURE.VOTER_TYPE.eq(vVoterType))
                         .and(VOTING_PROCEDURE.GOV_ACTION_TX_HASH.eq(vGovActionTxHash))
                         .and(VOTING_PROCEDURE.GOV_ACTION_INDEX.eq(vGovActionIndex))
-                        .and(VOTING_PROCEDURE.SLOT.eq(vMaxSlot)))
+                        .and(vVoteRank.eq(1)))
                 .andExists(
                         selectOne()
                                 .from(EPOCH_STAKE)
@@ -120,12 +130,24 @@ public class VotingAggrService {
                 .map(id -> row(id.getTransactionId(), id.getGov_action_index()))
                 .collect(Collectors.toList());
 
-        var cteQuery = select(
+        var rankedVoteQuery = select(
+                VOTING_PROCEDURE.TX_HASH.as("tx_hash"),
                 VOTING_PROCEDURE.VOTER_HASH.as("voter_hash"),
                 VOTING_PROCEDURE.VOTER_TYPE.as("voter_type"),
                 VOTING_PROCEDURE.GOV_ACTION_TX_HASH.as("gov_action_tx_hash"),
                 VOTING_PROCEDURE.GOV_ACTION_INDEX.as("gov_action_index"),
-                max(VOTING_PROCEDURE.SLOT).as("max_slot")
+                rowNumber()
+                        .over(partitionBy(
+                                VOTING_PROCEDURE.VOTER_HASH,
+                                VOTING_PROCEDURE.VOTER_TYPE,
+                                VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
+                                VOTING_PROCEDURE.GOV_ACTION_INDEX
+                        ).orderBy(
+                                VOTING_PROCEDURE.SLOT.desc(),
+                                VOTING_PROCEDURE.TX_INDEX.desc(),
+                                VOTING_PROCEDURE.IDX.desc()
+                        ))
+                        .as("vote_rank")
         )
                 .from(VOTING_PROCEDURE)
                 .where(VOTING_PROCEDURE.EPOCH.le(epoch))
@@ -134,31 +156,27 @@ public class VotingAggrService {
                         "CONSTITUTIONAL_COMMITTEE_HOT_SCRIPT_HASH",
                         "CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH"
                 ))
-                .and(VOTING_PROCEDURE.VOTER_HASH.in(committeeHotKeys))
-                .groupBy(
-                        VOTING_PROCEDURE.VOTER_HASH,
-                        VOTING_PROCEDURE.VOTER_TYPE,
-                        VOTING_PROCEDURE.GOV_ACTION_TX_HASH,
-                        VOTING_PROCEDURE.GOV_ACTION_INDEX
-                );
+                .and(VOTING_PROCEDURE.VOTER_HASH.in(committeeHotKeys));
 
-        var voteWithMaxSlot = table(name("vote_with_max_slot"));
+        var rankedVote = table(name("ranked_vote"));
 
-        var vVoterHash = field(name("vote_with_max_slot", "voter_hash"), String.class);
-        var vGovActionTxHash = field(name("vote_with_max_slot", "gov_action_tx_hash"), String.class);
-        var vGovActionIndex = field(name("vote_with_max_slot", "gov_action_index"), Integer.class);
-        var vMaxSlot = field(name("vote_with_max_slot", "max_slot"), Long.class);
+        var vTxHash = field(name("ranked_vote", "tx_hash"), String.class);
+        var vVoterHash = field(name("ranked_vote", "voter_hash"), String.class);
+        var vVoterType = field(name("ranked_vote", "voter_type"), String.class);
+        var vGovActionTxHash = field(name("ranked_vote", "gov_action_tx_hash"), String.class);
+        var vGovActionIndex = field(name("ranked_vote", "gov_action_index"), Integer.class);
+        var vVoteRank = field(name("ranked_vote", "vote_rank"), Integer.class);
 
-        Result<org.jooq.Record> result = dsl.with("vote_with_max_slot").as(
-                        cteQuery
-                )
+        Result<Record> result = dsl.with("ranked_vote").as(rankedVoteQuery)
                 .select(VOTING_PROCEDURE.fields())
                 .from(VOTING_PROCEDURE)
-                .join(voteWithMaxSlot)
-                .on(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash)
+                .join(rankedVote)
+                .on(VOTING_PROCEDURE.TX_HASH.eq(vTxHash)
+                        .and(VOTING_PROCEDURE.VOTER_HASH.eq(vVoterHash))
+                        .and(VOTING_PROCEDURE.VOTER_TYPE.eq(vVoterType))
                         .and(VOTING_PROCEDURE.GOV_ACTION_TX_HASH.eq(vGovActionTxHash))
                         .and(VOTING_PROCEDURE.GOV_ACTION_INDEX.eq(vGovActionIndex))
-                        .and(VOTING_PROCEDURE.SLOT.eq(vMaxSlot)))
+                        .and(vVoteRank.eq(1)))
                 .fetch();
 
         return mapToVotingProcedures(result);

--- a/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
+++ b/aggregates/governance-aggr/src/test/java/com/bloxbean/cardano/yaci/store/governanceaggr/service/VotingAggrServiceTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.UUID;
 
+import static com.bloxbean.cardano.yaci.store.adapot.jooq.Tables.EPOCH_STAKE;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.DREP_REGISTRATION;
 import static com.bloxbean.cardano.yaci.store.governance.jooq.Tables.VOTING_PROCEDURE;
 import static com.bloxbean.cardano.yaci.store.governance_aggr.jooq.Tables.DREP_DIST;
@@ -25,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class VotingAggrServiceTest {
     private static final int SNAPSHOT_EPOCH = 10;
     private static final String DREP_HASH = "11111111111111111111111111111111111111111111111111111111";
+    private static final String SPO_HASH = "22222222222222222222222222222222222222222222222222222222";
+    private static final String COMMITTEE_HASH = "33333333333333333333333333333333333333333333333333333333";
     private static final String GOV_ACTION_TX_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     private DSLContext dsl;
@@ -40,6 +44,65 @@ class VotingAggrServiceTest {
         votingAggrService = new VotingAggrService(dsl, null, null);
         createSchema();
         insertDRepDistribution(SNAPSHOT_EPOCH + 1);
+        insertEpochStake();
+    }
+
+    @Test
+    void getVotesBySPO_returnsVoteWithHighestTxIndexAtLatestSlot() {
+        insertVote("earlier-spo-vote", Vote.NO, VoterType.STAKING_POOL_KEY_HASH, SPO_HASH, SNAPSHOT_EPOCH, 100, 1, 0);
+        insertVote("latest-spo-vote", Vote.YES, VoterType.STAKING_POOL_KEY_HASH, SPO_HASH, SNAPSHOT_EPOCH, 100, 2, 0);
+
+        assertThat(votingAggrService.getVotesBySPO(SNAPSHOT_EPOCH, List.of(govActionId())))
+                .singleElement()
+                .satisfies(vote -> {
+                    assertThat(vote.getTxHash()).isEqualTo("latest-spo-vote");
+                    assertThat(vote.getVote()).isEqualTo(Vote.YES);
+                });
+    }
+
+    @Test
+    void getVotesBySPO_usesVoteIndexAsFinalTieBreaker() {
+        insertVote("earlier-spo-vote", Vote.NO, VoterType.STAKING_POOL_KEY_HASH, SPO_HASH, SNAPSHOT_EPOCH, 100, 1, 0);
+        insertVote("latest-spo-vote", Vote.YES, VoterType.STAKING_POOL_KEY_HASH, SPO_HASH, SNAPSHOT_EPOCH, 100, 1, 1);
+
+        assertThat(votingAggrService.getVotesBySPO(SNAPSHOT_EPOCH, List.of(govActionId())))
+                .singleElement()
+                .satisfies(vote -> {
+                    assertThat(vote.getTxHash()).isEqualTo("latest-spo-vote");
+                    assertThat(vote.getVote()).isEqualTo(Vote.YES);
+                });
+    }
+
+    @Test
+    void getVotesByCommittee_returnsVoteWithHighestTxIndexAtLatestSlot() {
+        insertVote("earlier-committee-vote", Vote.NO, VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH,
+                COMMITTEE_HASH, SNAPSHOT_EPOCH, 100, 1, 0);
+        insertVote("latest-committee-vote", Vote.YES, VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH,
+                COMMITTEE_HASH, SNAPSHOT_EPOCH, 100, 2, 0);
+
+        assertThat(votingAggrService.getVotesByCommittee(
+                SNAPSHOT_EPOCH, List.of(govActionId()), List.of(COMMITTEE_HASH)))
+                .singleElement()
+                .satisfies(vote -> {
+                    assertThat(vote.getTxHash()).isEqualTo("latest-committee-vote");
+                    assertThat(vote.getVote()).isEqualTo(Vote.YES);
+                });
+    }
+
+    @Test
+    void getVotesByCommittee_usesVoteIndexAsFinalTieBreaker() {
+        insertVote("earlier-committee-vote", Vote.NO, VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH,
+                COMMITTEE_HASH, SNAPSHOT_EPOCH, 100, 1, 0);
+        insertVote("latest-committee-vote", Vote.YES, VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH,
+                COMMITTEE_HASH, SNAPSHOT_EPOCH, 100, 1, 1);
+
+        assertThat(votingAggrService.getVotesByCommittee(
+                SNAPSHOT_EPOCH, List.of(govActionId()), List.of(COMMITTEE_HASH)))
+                .singleElement()
+                .satisfies(vote -> {
+                    assertThat(vote.getTxHash()).isEqualTo("latest-committee-vote");
+                    assertThat(vote.getVote()).isEqualTo(Vote.YES);
+                });
     }
 
     @Test
@@ -93,26 +156,43 @@ class VotingAggrServiceTest {
     }
 
     private List<com.bloxbean.cardano.yaci.store.governance.domain.VotingProcedure> getVotes() {
-        var govActionId = GovActionId.builder()
+        return votingAggrService.getVotesByDRep(SNAPSHOT_EPOCH, List.of(govActionId()));
+    }
+
+    private GovActionId govActionId() {
+        return GovActionId.builder()
                 .transactionId(GOV_ACTION_TX_HASH)
                 .gov_action_index(0)
                 .build();
-        return votingAggrService.getVotesByDRep(SNAPSHOT_EPOCH, List.of(govActionId));
     }
 
     private void insertVote(String txHash, Vote vote, int epoch, long slot, int txIndex, int index) {
+        insertVote(txHash, vote, VoterType.DREP_KEY_HASH, DREP_HASH, epoch, slot, txIndex, index);
+    }
+
+    private void insertVote(String txHash, Vote vote, VoterType voterType, String voterHash,
+                            int epoch, long slot, int txIndex, int index) {
         dsl.insertInto(VOTING_PROCEDURE)
                 .set(VOTING_PROCEDURE.ID, UUID.randomUUID())
                 .set(VOTING_PROCEDURE.TX_HASH, txHash)
                 .set(VOTING_PROCEDURE.IDX, index)
                 .set(VOTING_PROCEDURE.TX_INDEX, txIndex)
-                .set(VOTING_PROCEDURE.VOTER_TYPE, VoterType.DREP_KEY_HASH.name())
-                .set(VOTING_PROCEDURE.VOTER_HASH, DREP_HASH)
+                .set(VOTING_PROCEDURE.VOTER_TYPE, voterType.name())
+                .set(VOTING_PROCEDURE.VOTER_HASH, voterHash)
                 .set(VOTING_PROCEDURE.GOV_ACTION_TX_HASH, GOV_ACTION_TX_HASH)
                 .set(VOTING_PROCEDURE.GOV_ACTION_INDEX, 0)
                 .set(VOTING_PROCEDURE.VOTE, vote.name())
                 .set(VOTING_PROCEDURE.EPOCH, epoch)
                 .set(VOTING_PROCEDURE.SLOT, slot)
+                .execute();
+    }
+
+    private void insertEpochStake() {
+        dsl.insertInto(EPOCH_STAKE)
+                .set(EPOCH_STAKE.EPOCH, SNAPSHOT_EPOCH)
+                .set(EPOCH_STAKE.ADDRESS, "stake-address")
+                .set(EPOCH_STAKE.AMOUNT, BigInteger.valueOf(1_000L))
+                .set(EPOCH_STAKE.POOL_ID, SPO_HASH)
                 .execute();
     }
 
@@ -191,6 +271,18 @@ class VotingAggrServiceTest {
                     expiry int,
                     update_datetime timestamp,
                     primary key (drep_hash, drep_type, epoch)
+                )
+                """);
+        dsl.execute("""
+                CREATE TABLE epoch_stake (
+                    epoch int,
+                    address varchar(255),
+                    amount numeric(38),
+                    pool_id varchar(56),
+                    delegation_epoch int,
+                    active_epoch int,
+                    create_datetime timestamp,
+                    primary key (epoch, address)
                 )
                 """);
     }


### PR DESCRIPTION
## Summary

- Ensure SPO and Constitutional Committee vote aggregation returns only the latest vote for each voter and governance action.
- Resolve same-slot votes deterministically using transaction and vote ordering.
- Add regression coverage for both voter groups.

Fixes #1069

## Root cause

`VotingAggrService.getVotesBySPO` and `getVotesByCommittee` selected the maximum vote slot and joined it back to `voting_procedure`. A slot does not uniquely identify a vote, so multiple votes from the same voter for the same governance action could survive when they were submitted in the same block.

This could double-count SPO stake across voting buckets and made Committee vote selection depend on database result order.

## Changes

- Replace the `max(slot)` self-joins in the SPO and Committee queries with ranked vote CTEs.
- Partition votes by voter hash, voter type, governance action transaction hash, and governance action index.
- Rank votes by `slot DESC`, `tx_index DESC`, and `idx DESC`, and return only `vote_rank = 1`.
- Preserve the existing SPO epoch-stake eligibility check and Committee hot-key filter.
- Add tests covering `tx_index` and `idx` tie-breaking for SPO and Committee votes.

## Verification

- `JAVA_HOME=/home/huy/.jdks/openjdk-21 ./gradlew :aggregates:governance-aggr:test --tests com.bloxbean.cardano.yaci.store.governanceaggr.service.VotingAggrServiceTest`
- `JAVA_HOME=/home/huy/.jdks/openjdk-21 ./gradlew :aggregates:governance-aggr:test`
- `git diff --check`

All checks passed.

## Deployment validation

- [ ] Deploy and test the change on Preview. (in progress)
- [x] Deploy and test the change on Preprod.

## Notes

- No database schema changes are required.
- The DRep-specific unregistration filtering remains unchanged and is not applied to SPO or Committee votes.
