### PR TITLE
[merge to 2.0.x] feat(admin-cli): add generic index apply command

### DIFF
--- a/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
+++ b/applications/admin-cli/src/main/java/com/bloxbean/cardano/yaci/store/admin/cli/db/DBCommands.java
@@ -18,6 +18,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.command.annotation.Option;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,18 +70,30 @@ public class DBCommands {
     @Command(description = "Apply the default indexes required for read operations.")
     public void applyIndexes(@Option(longNames = "skip-extra-indexes", defaultValue = "false", description = "Skip additional optional indexes.") boolean skipExtraIndexes) {
         writeLn(info("Start to apply index ..."));
-        applyIndexes(INDEX_FILE);
+        applyIndexesFromFiles(INDEX_FILE);
 
         if (!skipExtraIndexes) {
             writeLn(info("Start to apply extra index ..."));
-            applyIndexes(EXTRA_INDEX_FILE);
+            applyIndexesFromFiles(EXTRA_INDEX_FILE);
         }
     }
 
     @Command(description = "Apply only additional optional read indexes")
     public void applyExtraIndexes() {
         writeLn(info("Start to apply extra index ..."));
-        applyIndexes(EXTRA_INDEX_FILE);
+        applyIndexesFromFiles(EXTRA_INDEX_FILE);
+    }
+
+    @Command(description = "Apply one or more optional index definitions")
+    public void applyOptionalIndexes(
+            @Option(longNames = "indexes", label = "indexes",
+                    description = "Comma-separated optional index names (e.g., 'asset-ext-index')")
+            String indexes,
+            @Option(longNames = "index-files", label = "index-files",
+                    description = "Comma-separated index definition file paths (e.g., 'file:///path/to/index.yml')")
+            String indexFiles) {
+        writeLn(info("Start to apply optional indexes ..."));
+        applyIndexesFromFiles(getIndexFiles(indexes, indexFiles));
     }
 
     @Command(description = "Rollback data to a previous epoch")
@@ -129,12 +142,12 @@ public class DBCommands {
         }
     }
 
-    private void applyIndexes(String indexFile) {
+    private void applyIndexesFromFiles(String... indexFiles) {
         IndexLoader indexLoader = new IndexLoader();
-        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexes(indexFile);
+        List<IndexDefinition> indexDefinitionList = indexLoader.loadIndexesFromMultipleFiles(indexFiles);
         if (indexDefinitionList == null || indexDefinitionList.isEmpty()) {
             log.warn("No optional index found to apply");
-            writeLn(warn("No optional index found to apply : {}", indexFile));
+            writeLn(warn("No optional index found to apply from files: %s", String.join(", ", indexFiles)));
             return;
         }
 
@@ -182,6 +195,45 @@ public class DBCommands {
         }
 
         return new String[]{this.rollbackFiles};
+    }
+
+    private String[] getIndexFiles(String indexes, String indexFiles) {
+        List<String> files = new ArrayList<>();
+
+        if (indexes != null && !indexes.trim().isEmpty()) {
+            List<String> internalIndexes = parseCommaSeparatedFiles(indexes);
+            internalIndexes.stream()
+                    .filter(this::isResourcePath)
+                    .findFirst()
+                    .ifPresent(resourcePath -> {
+                        throw new IllegalArgumentException("External index file paths should be provided with --index-files: " + resourcePath);
+                    });
+            files.addAll(internalIndexes);
+        }
+
+        if (indexFiles != null && !indexFiles.trim().isEmpty()) {
+            files.addAll(parseCommaSeparatedFiles(indexFiles));
+        }
+
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException("Index names or --index-files must be provided");
+        }
+
+        return files.toArray(String[]::new);
+    }
+
+    private List<String> parseCommaSeparatedFiles(String files) {
+        return Arrays.stream(files.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private boolean isResourcePath(String filePath) {
+        return filePath.startsWith("classpath:") ||
+                filePath.startsWith("file:") ||
+                filePath.startsWith("http:") ||
+                filePath.startsWith("https:");
     }
 
     private void applyRollback(String[] rollbackFiles, RollbackContext rollbackContext) {

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexDefinition.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexDefinition.java
@@ -21,5 +21,6 @@ public class IndexDefinition {
         private List<String> columns;
         private String type;
         private List<String> excludes;
+        private String where;
     }
 }

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/IndexService.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/service/IndexService.java
@@ -69,7 +69,10 @@ public class IndexService {
                     return null;
 
                 String using = index.getType() != null? "USING " + index.getType().trim() : "";
-                return String.format("CREATE INDEX IF NOT EXISTS %s ON %s %s (%s);", indexName, tableName, using, columns);
+                String where = index.getWhere() != null && !index.getWhere().trim().isEmpty()
+                        ? " WHERE " + index.getWhere().trim()
+                        : "";
+                return String.format("CREATE INDEX IF NOT EXISTS %s ON %s %s (%s) %s;", indexName, tableName, using, columns, where);
             case h2:
                 if (index.getExcludes() != null && index.getExcludes().contains(DatabaseUtils.DbType.h2.toString()))
                     return null;

--- a/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
+++ b/components/dbutils/src/main/java/com/bloxbean/cardano/yaci/store/dbutils/index/util/IndexLoader.java
@@ -1,14 +1,28 @@
 package com.bloxbean.cardano.yaci.store.dbutils.index.util;
 
 import com.bloxbean.cardano.yaci.store.dbutils.index.model.IndexDefinition;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class IndexLoader {
+
+    private ResourceLoader resourceLoader;
+
+    public IndexLoader() {
+        this.resourceLoader = new DefaultResourceLoader();
+    }
+
+    public IndexLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
 
     public List<IndexDefinition> loadIndexes(String yamlFilePath) {
         Yaml yaml = new Yaml();
@@ -18,6 +32,89 @@ public class IndexLoader {
         }
 
         List<Map<String, Object>> data = yaml.load(inputStream);
+        return parseIndexDefinitions(data);
+    }
+
+    public List<IndexDefinition> loadIndexesFromMultipleFiles(String... filePaths) {
+        List<IndexDefinition> allIndexDefinitions = new ArrayList<>();
+
+        for (String filePath : filePaths) {
+            String normalizedFilePath = normalizeFilePath(filePath);
+            List<IndexDefinition> indexDefinitions;
+
+            if (isResourcePath(normalizedFilePath)) {
+                if (resourceLoader == null) {
+                    throw new IllegalStateException("ResourceLoader not configured for resource path: " + normalizedFilePath);
+                }
+                indexDefinitions = loadIndexesFromResourcePath(normalizedFilePath);
+            } else {
+                indexDefinitions = loadIndexes(normalizedFilePath);
+            }
+
+            if (indexDefinitions != null) {
+                allIndexDefinitions.addAll(indexDefinitions);
+            }
+        }
+
+        return allIndexDefinitions;
+    }
+
+    private boolean isResourcePath(String filePath) {
+        return filePath.startsWith("classpath:") ||
+                filePath.startsWith("file:") ||
+                filePath.startsWith("http:") ||
+                filePath.startsWith("https:");
+    }
+
+    private List<IndexDefinition> loadIndexesFromResourcePath(String resourcePath) {
+        try {
+            Resource resource = resourceLoader.getResource(resourcePath);
+            if (!resource.exists()) {
+                throw new IllegalArgumentException("Resource not found: " + resourcePath);
+            }
+
+            Yaml yaml = new Yaml();
+            try (InputStream inputStream = resource.getInputStream()) {
+                List<Map<String, Object>> data = yaml.load(inputStream);
+                return parseIndexDefinitions(data);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error loading resource: " + resourcePath, e);
+        }
+    }
+
+    private String normalizeFilePath(String filePath) {
+        if (filePath == null) {
+            throw new IllegalArgumentException("Index file path cannot be null");
+        }
+
+        String normalizedFilePath = filePath.trim();
+        if (normalizedFilePath.isEmpty()) {
+            throw new IllegalArgumentException("Index file path cannot be empty");
+        }
+
+        if (isResourcePath(normalizedFilePath)) {
+            return normalizedFilePath;
+        }
+
+        String fileName = normalizedFilePath;
+        int lastSeparator = Math.max(normalizedFilePath.lastIndexOf('/'), normalizedFilePath.lastIndexOf('\\'));
+        if (lastSeparator >= 0) {
+            fileName = normalizedFilePath.substring(lastSeparator + 1);
+        }
+
+        if (!fileName.contains(".")) {
+            return normalizedFilePath + ".yml";
+        }
+
+        return normalizedFilePath;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<IndexDefinition> parseIndexDefinitions(List<Map<String, Object>> data) {
+        if (data == null) {
+            return new ArrayList<>();
+        }
 
         List<IndexDefinition> indexDefinitions = new ArrayList<>();
         for (Map<String, Object> item : data) {
@@ -30,7 +127,8 @@ public class IndexLoader {
                 List<String> columns = (List<String>) indexMap.get("columns");
                 String type = (String) indexMap.get("type");
                 List<String> excludes = (List<String>) indexMap.get("excludes");
-                IndexDefinition.Index index = new IndexDefinition.Index(name, columns, type, excludes);
+                String where = (String) indexMap.get("where");
+                IndexDefinition.Index index = new IndexDefinition.Index(name, columns, type, excludes, where);
                 indexes.add(index);
             }
 

--- a/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
+++ b/components/dbutils/src/test/java/com/bloxbean/cardano/yaci/store/dbutils/index/model/IndexLoaderTest.java
@@ -3,9 +3,11 @@ package com.bloxbean.cardano.yaci.store.dbutils.index.model;
 import com.bloxbean.cardano.yaci.store.dbutils.index.util.IndexLoader;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class IndexLoaderTest {
 
@@ -25,5 +27,44 @@ class IndexLoaderTest {
         assertThat(indexDefinitions.get(0).getIndexes().get(0).getName()).isNotBlank();
         assertThat(indexDefinitions.get(0).getIndexes().get(0).getType()).isEqualTo("gin");
         assertThat(indexDefinitions.get(0).getIndexes().get(0).getExcludes()).hasSizeGreaterThan(0);
+    }
+
+    @Test
+    void loadIndexesFromMultipleFiles() {
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles("test-index-1.yml", "test-index-2.yml");
+
+        assertThat(indexDefinitions).hasSize(2);
+        assertThat(indexDefinitions)
+                .extracting(IndexDefinition::getTable)
+                .containsExactly("test_table_1", "test_table_2");
+    }
+
+    @Test
+    void loadIndexesFromFileResourcePath() throws Exception {
+        var resource = getClass().getClassLoader().getResource("test-index-1.yml");
+        assertThat(resource).isNotNull();
+
+        String filePath = Path.of(resource.toURI()).toUri().toString();
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles(filePath);
+
+        assertThat(indexDefinitions).hasSize(1);
+        assertThat(indexDefinitions.get(0).getTable()).isEqualTo("test_table_1");
+    }
+
+    @Test
+    void loadIndexesFromMultipleFilesShouldAppendYmlSuffix() {
+        List<IndexDefinition> indexDefinitions = new IndexLoader()
+                .loadIndexesFromMultipleFiles("test-index-1");
+
+        assertThat(indexDefinitions).hasSize(1);
+        assertThat(indexDefinitions.get(0).getTable()).isEqualTo("test_table_1");
+    }
+
+    @Test
+    void loadIndexesFromMultipleFilesShouldThrowForMissingFile() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IndexLoader().loadIndexesFromMultipleFiles("missing-index"));
     }
 }

--- a/components/dbutils/src/test/resources/test-index-1.yml
+++ b/components/dbutils/src/test/resources/test-index-1.yml
@@ -1,0 +1,5 @@
+- table: test_table_1
+  indexes:
+    - name: idx_test_table_1_slot
+      columns:
+        - slot

--- a/components/dbutils/src/test/resources/test-index-2.yml
+++ b/components/dbutils/src/test/resources/test-index-2.yml
@@ -1,0 +1,5 @@
+- table: test_table_2
+  indexes:
+    - name: idx_test_table_2_hash
+      columns:
+        - hash


### PR DESCRIPTION
Original PR: #962

Backported without the blockfrost parts, since `release/2.0.x` has no blockfrost extension:

- `blockfrost-index.yml` — not included
- its `resource-config.json` entry — not included
- `IndexLoaderTest.loadBlockfrostIndexes` — not included
- the `--indexes` example in `DBCommands` now reads `'asset-ext-index'` instead of `'blockfrost-index,asset-ext-index'`

Everything else carries over unchanged: the `apply-optional-indexes` command, multi-file loading in `IndexLoader`, named definitions resolved from the classpath, external `file:` /`classpath:` / `http:` / `https:` resources, and the `.yml` shorthand.

Needed on this branch so #1134 can be backported next — that PR moves the assets-ext optional indexes into `asset-ext-index.yml`, which this command applies.
